### PR TITLE
[layout] add Polish layout

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ThumbKeyPLv1.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ThumbKeyPLv1.kt
@@ -1,0 +1,505 @@
+package com.dessalines.thumbkey.keyboards
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowDropDown
+import androidx.compose.material.icons.outlined.ArrowDropUp
+import androidx.compose.material.icons.outlined.Copyright
+import androidx.compose.material.icons.outlined.KeyboardCapslock
+import com.dessalines.thumbkey.utils.ColorVariant
+import com.dessalines.thumbkey.utils.FontSizeVariant
+import com.dessalines.thumbkey.utils.KeyAction
+import com.dessalines.thumbkey.utils.KeyC
+import com.dessalines.thumbkey.utils.KeyDisplay
+import com.dessalines.thumbkey.utils.KeyItemC
+import com.dessalines.thumbkey.utils.KeyboardC
+import com.dessalines.thumbkey.utils.KeyboardMode
+import com.dessalines.thumbkey.utils.SwipeDirection
+
+val THUMBKEY_PL_V1_MAIN = KeyboardC(
+    arrayOf(
+        arrayOf(
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("s"),
+                    action = KeyAction.CommitText("s"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY
+                ),
+                swipes = mapOf(
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("w"),
+                        action = KeyAction.CommitText("w")
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("ś"),
+                        action = KeyAction.CommitText("ś")
+                    )
+
+                )
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("r"),
+                    action = KeyAction.CommitText("r"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY
+                ),
+                swipes = mapOf(
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("g"),
+                        action = KeyAction.CommitText("g")
+                    ),
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("ź"),
+                        action = KeyAction.CommitText("ź")
+                    ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("ż"),
+                        action = KeyAction.CommitText("ż")
+                    )
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("o"),
+                    action = KeyAction.CommitText("o"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY
+                ),
+                swipes = mapOf(
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("u"),
+                        action = KeyAction.CommitText("u")
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("ó"),
+                        action = KeyAction.CommitText("ó")
+                    )
+
+                )
+            ),
+            SETTINGS_KEY_ITEM
+        ),
+        arrayOf(
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("n"),
+                    action = KeyAction.CommitText("n"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY
+                ),
+                swipes = mapOf(
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("m"),
+                        action = KeyAction.CommitText("m")
+                    ),
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("ń"),
+                        action = KeyAction.CommitText("ń")
+                    )
+
+                )
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("h"),
+                    action = KeyAction.CommitText("h"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY
+                ),
+                swipes = mapOf(
+                    SwipeDirection.TOP_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("j"),
+                        action = KeyAction.CommitText("j")
+                    ),
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("q"),
+                        action = KeyAction.CommitText("q")
+                    ),
+                    SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("b"),
+                        action = KeyAction.CommitText("b")
+                    ),
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("p"),
+                        action = KeyAction.CommitText("p")
+                    ),
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("y"),
+                        action = KeyAction.CommitText("y")
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("x"),
+                        action = KeyAction.CommitText("x")
+                    ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("v"),
+                        action = KeyAction.CommitText("v")
+                    ),
+                    SwipeDirection.LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("k"),
+                        action = KeyAction.CommitText("k")
+                    )
+                )
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("a"),
+                    action = KeyAction.CommitText("a"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY
+                ),
+                swipes = mapOf(
+                    SwipeDirection.LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("l"),
+                        action = KeyAction.CommitText("l")
+                    ),
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
+                        action = KeyAction.ToggleShiftMode(true),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("ą"),
+                        action = KeyAction.CommitText("ą")
+                    ),
+
+                )
+            ),
+            NUMERIC_KEY_ITEM
+        ),
+        arrayOf(
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("t"),
+                    action = KeyAction.CommitText("t"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY
+                ),
+                swipes = mapOf(
+                    SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("c"),
+                        action = KeyAction.CommitText("c")
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("ć"),
+                        action = KeyAction.CommitText("ć")
+                    )
+
+                )
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("i"),
+                    action = KeyAction.CommitText("i"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY
+                ),
+                swipes = mapOf(
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("f"),
+                        action = KeyAction.CommitText("f")
+                    ),
+                    SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("'"),
+                        action = KeyAction.CommitText("'"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("z"),
+                        action = KeyAction.CommitText("z")
+                    ),
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("-"),
+                        action = KeyAction.CommitText("-"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("."),
+                        action = KeyAction.CommitText("."),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("*"),
+                        action = KeyAction.CommitText("*"),
+                        color = ColorVariant.MUTED
+                    )
+                )
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("e"),
+                    action = KeyAction.CommitText("e"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY
+                ),
+                swipes = mapOf(
+                    SwipeDirection.TOP_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("d"),
+                        action = KeyAction.CommitText("d")
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("ę"),
+                        action = KeyAction.CommitText("ę")
+                    )
+
+                )
+            ),
+            BACKSPACE_KEY_ITEM
+        ),
+        arrayOf(
+            SPACEBAR_KEY_ITEM,
+            RETURN_KEY_ITEM
+        )
+    )
+)
+
+val THUMBKEY_PL_V1_SHIFTED = KeyboardC(
+    arrayOf(
+        arrayOf(
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("S"),
+                    action = KeyAction.CommitText("S"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY
+                ),
+                swipes = mapOf(
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("W"),
+                        action = KeyAction.CommitText("W")
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("Ś"),
+                        action = KeyAction.CommitText("Ś")
+                    )
+                )
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("R"),
+                    action = KeyAction.CommitText("R"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY
+                ),
+                swipes = mapOf(
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("G"),
+                        action = KeyAction.CommitText("G")
+                    ),
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("Ź"),
+                        action = KeyAction.CommitText("Ź")
+                    ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("Ż"),
+                        action = KeyAction.CommitText("Ż")
+                    )
+
+                )
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("O"),
+                    action = KeyAction.CommitText("O"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY
+                ),
+                swipes = mapOf(
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("U"),
+                        action = KeyAction.CommitText("U")
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("Ó"),
+                        action = KeyAction.CommitText("Ó")
+                    )
+
+                )
+            ),
+            SETTINGS_KEY_ITEM
+        ),
+        arrayOf(
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("N"),
+                    action = KeyAction.CommitText("N"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY
+                ),
+                swipes = mapOf(
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("M"),
+                        action = KeyAction.CommitText("M")
+                    ),
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("Ń"),
+                        action = KeyAction.CommitText("Ń")
+                    )
+
+                )
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("H"),
+                    action = KeyAction.CommitText("H"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY
+                ),
+                swipes = mapOf(
+                    SwipeDirection.TOP_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("J"),
+                        action = KeyAction.CommitText("J")
+                    ),
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("Q"),
+                        action = KeyAction.CommitText("Q")
+                    ),
+                    SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("B"),
+                        action = KeyAction.CommitText("B")
+                    ),
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("P"),
+                        action = KeyAction.CommitText("P")
+                    ),
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("Y"),
+                        action = KeyAction.CommitText("Y")
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("X"),
+                        action = KeyAction.CommitText("X")
+                    ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("V"),
+                        action = KeyAction.CommitText("V")
+                    ),
+                    SwipeDirection.LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("K"),
+                        action = KeyAction.CommitText("K")
+                    )
+                )
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("A"),
+                    action = KeyAction.CommitText("A"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY
+                ),
+                swipes = mapOf(
+                    SwipeDirection.LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("L"),
+                        action = KeyAction.CommitText("L")
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
+                        action = KeyAction.ToggleShiftMode(false),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.IconDisplay(Icons.Outlined.KeyboardCapslock),
+                        capsModeDisplay = KeyDisplay.IconDisplay(Icons.Outlined.Copyright),
+                        action = KeyAction.ToggleCapsLock,
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("Ą"),
+                        action = KeyAction.CommitText("Ą")
+                    ),
+
+                )
+            ),
+            NUMERIC_KEY_ITEM
+        ),
+        arrayOf(
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("T"),
+                    action = KeyAction.CommitText("T"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY
+                ),
+                swipes = mapOf(
+                    SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("C"),
+                        action = KeyAction.CommitText("C")
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("Ć"),
+                        action = KeyAction.CommitText("Ć")
+                    )
+
+                )
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("I"),
+                    action = KeyAction.CommitText("I"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY
+                ),
+                swipes = mapOf(
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("F"),
+                        action = KeyAction.CommitText("F")
+                    ),
+                    SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("'"),
+                        action = KeyAction.CommitText("'"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("Z"),
+                        action = KeyAction.CommitText("Z")
+                    ),
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("-"),
+                        action = KeyAction.CommitText("-"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("."),
+                        action = KeyAction.CommitText("."),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("*"),
+                        action = KeyAction.CommitText("*"),
+                        color = ColorVariant.MUTED
+                    )
+                )
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("E"),
+                    action = KeyAction.CommitText("E"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY
+                ),
+                swipes = mapOf(
+                    SwipeDirection.TOP_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("D"),
+                        action = KeyAction.CommitText("D")
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("Ę"),
+                        action = KeyAction.CommitText("Ę")
+                    )
+
+                )
+            ),
+            BACKSPACE_KEY_ITEM
+        ),
+        arrayOf(
+            SPACEBAR_KEY_ITEM,
+            RETURN_KEY_ITEM
+        )
+    )
+)
+
+val THUMBKEY_PL_V1_KEYBOARD_MODES: Map<KeyboardMode, KeyboardC> = mapOf(
+    KeyboardMode.MAIN to THUMBKEY_PL_V1_MAIN,
+    KeyboardMode.SHIFTED to THUMBKEY_PL_V1_SHIFTED,
+    KeyboardMode.NUMERIC to NUMERIC_KEYBOARD
+)


### PR DESCRIPTION
This is a pull request related to https://github.com/dessalines/thumb-key/issues/118.

I kept the original English keyboard, just adding diactirics on bottom swipe, where applicable: only lower 'ć' and 'ż', 'ź' are in a bit different place. I think 'ż' and 'ź' would be the most problematic. One other place they could be put is left and bottom-left swipe of 'e': this would group all 'z'-related letters close together, what do you think?

As for uppercase letters, since down swipe in 'A' is bound to lowercase, I kept that and added 'Ą' as a bottom-right swipe.