### PR TITLE
programmer keyboard layout

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,21 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+** Thumb-Key Version **
+Type the version from the settings here.
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,19 +2,13 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: ''
+labels: enhancement
 assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+- [ ] Did you check to see if this issue already exists?
+- [ ] Is this only a single feature request? Do not put multiple feature requests in one issue.
+- [ ] Is this a question or discussion? Don't use this, use https://lemmy.ml/c/thumbkey
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
-
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
-
-**Additional context**
-Add any other context or screenshots about the feature request here.
+** Describe the feature request below **

--- a/.github/ISSUE_TEMPLATE/question---discussions.md
+++ b/.github/ISSUE_TEMPLATE/question---discussions.md
@@ -1,0 +1,12 @@
+---
+name: Question / Discussions
+about: A question / discussion about thumb-key
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+Don't use this for questions / discussions. Use the official community at:
+
+https://lemmy.ml/c/thumbkey

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/CommonKeys.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/CommonKeys.kt
@@ -82,6 +82,38 @@ val BACKSPACE_KEY_ITEM =
             SwipeDirection.BOTTOM_LEFT to KeyC(
                 action = KeyAction.DeleteLastWord,
                 display = null
+            ),
+            SwipeDirection.RIGHT to KeyC(
+                action = KeyAction.SendEvent(
+                    KeyEvent(
+                        KeyEvent.ACTION_DOWN,
+                        KeyEvent
+                            .KEYCODE_FORWARD_DEL
+                    )
+                ),
+                display = KeyDisplay.TextDisplay("DEL"),
+                color = ColorVariant.MUTED,
+                size = FontSizeVariant.SMALLEST
+            ),
+            SwipeDirection.TOP_RIGHT to KeyC(
+                action = KeyAction.SendEvent(
+                    KeyEvent(
+                        KeyEvent.ACTION_DOWN,
+                        KeyEvent
+                            .KEYCODE_FORWARD_DEL
+                    )
+                ),
+                display = null
+            ),
+            SwipeDirection.BOTTOM_RIGHT to KeyC(
+                action = KeyAction.SendEvent(
+                    KeyEvent(
+                        KeyEvent.ACTION_DOWN,
+                        KeyEvent
+                            .KEYCODE_FORWARD_DEL
+                    )
+                ),
+                display = null
             )
         ),
         backgroundColor = ColorVariant.SURFACE_VARIANT
@@ -108,6 +140,24 @@ val SPACEBAR_KEY_ITEM =
                     KeyEvent(
                         KeyEvent.ACTION_DOWN,
                         KeyEvent.KEYCODE_DPAD_RIGHT
+                    )
+                ),
+                display = null
+            ),
+            SwipeDirection.TOP to KeyC(
+                action = KeyAction.SendEvent(
+                    KeyEvent(
+                        KeyEvent.ACTION_DOWN,
+                        KeyEvent.KEYCODE_DPAD_UP
+                    )
+                ),
+                display = null
+            ),
+            SwipeDirection.BOTTOM to KeyC(
+                action = KeyAction.SendEvent(
+                    KeyEvent(
+                        KeyEvent.ACTION_DOWN,
+                        KeyEvent.KEYCODE_DPAD_DOWN
                     )
                 ),
                 display = null

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ThumbKeyENv4Programmer.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ThumbKeyENv4Programmer.kt
@@ -1,0 +1,683 @@
+package com.dessalines.thumbkey.keyboards
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowDropDown
+import androidx.compose.material.icons.outlined.ArrowDropUp
+import androidx.compose.material.icons.outlined.Copyright
+import androidx.compose.material.icons.outlined.KeyboardCapslock
+import androidx.compose.material.icons.outlined.KeyboardTab
+import com.dessalines.thumbkey.utils.ColorVariant
+import com.dessalines.thumbkey.utils.FontSizeVariant
+import com.dessalines.thumbkey.utils.KeyAction
+import com.dessalines.thumbkey.utils.KeyC
+import com.dessalines.thumbkey.utils.KeyDisplay
+import com.dessalines.thumbkey.utils.KeyItemC
+import com.dessalines.thumbkey.utils.KeyboardC
+import com.dessalines.thumbkey.utils.KeyboardMode
+import com.dessalines.thumbkey.utils.SwipeDirection
+
+// Adds more punctuation options to the main screen to reduce switches to the numeric keyboard
+val THUMBKEY_EN_V4_PROGRAMMER = KeyboardC(
+    arrayOf(
+        arrayOf(
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("s"),
+                    action = KeyAction.CommitText("s"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY
+                ),
+                swipes = mapOf(
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("w"),
+                        action = KeyAction.CommitText("w")
+                    ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("("),
+                        action = KeyAction.CommitText("("),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.TOP_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("`"),
+                        action = KeyAction.CommitText("`"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("\\"),
+                        action = KeyAction.CommitText("\\"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("/"),
+                        action = KeyAction.CommitText("/"),
+                        color = ColorVariant.MUTED
+                    )
+                )
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("r"),
+                    action = KeyAction.CommitText("r"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY
+                ),
+                swipes = mapOf(
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("g"),
+                        action = KeyAction.CommitText("g")
+                    ),
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("^"),
+                        action = KeyAction.CommitText("^"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("<"),
+                        action = KeyAction.CommitText("<"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay(">"),
+                        action = KeyAction.CommitText(">"),
+                        color = ColorVariant.MUTED
+                    )
+                )
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("o"),
+                    action = KeyAction.CommitText("o"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY
+                ),
+                swipes = mapOf(
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("u"),
+                        action = KeyAction.CommitText("u")
+                    ),
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay(")"),
+                        action = KeyAction.CommitText(")"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.TOP_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("="),
+                        action = KeyAction.CommitText("="),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("+"),
+                        action = KeyAction.CommitText("+"),
+                        color = ColorVariant.MUTED
+                    )
+                )
+            ),
+            SETTINGS_KEY_ITEM
+        ),
+        arrayOf(
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("n"),
+                    action = KeyAction.CommitText("n"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY
+                ),
+                swipes = mapOf(
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("m"),
+                        action = KeyAction.CommitText("m")
+                    ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("@"),
+                        action = KeyAction.CommitText("@"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("\""),
+                        action = KeyAction.CommitText("\""),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.TOP_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("'"),
+                        action = KeyAction.CommitText("'"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("$"),
+                        action = KeyAction.CommitText("$"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("&"),
+                        action = KeyAction.CommitText("&"),
+                        color = ColorVariant.MUTED
+                    )
+                )
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("h"),
+                    action = KeyAction.CommitText("h"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY
+                ),
+                swipes = mapOf(
+                    SwipeDirection.TOP_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("j"),
+                        action = KeyAction.CommitText("j")
+                    ),
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("q"),
+                        action = KeyAction.CommitText("q")
+                    ),
+                    SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("b"),
+                        action = KeyAction.CommitText("b")
+                    ),
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("p"),
+                        action = KeyAction.CommitText("p")
+                    ),
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("y"),
+                        action = KeyAction.CommitText("y")
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("x"),
+                        action = KeyAction.CommitText("x")
+                    ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("v"),
+                        action = KeyAction.CommitText("v")
+                    ),
+                    SwipeDirection.LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("k"),
+                        action = KeyAction.CommitText("k")
+                    )
+                )
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("a"),
+                    action = KeyAction.CommitText("a"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY
+                ),
+                swipes = mapOf(
+                    SwipeDirection.LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("l"),
+                        action = KeyAction.CommitText("l")
+                    ),
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
+                        action = KeyAction.ToggleShiftMode(true),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
+                        action = KeyAction.ToggleShiftMode(false),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.IconDisplay(Icons.Outlined.KeyboardTab),
+                        action = KeyAction.CommitText("\t"),
+                        color = ColorVariant.MUTED
+                    )
+                )
+            ),
+            NUMERIC_KEY_ITEM
+        ),
+        arrayOf(
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("t"),
+                    action = KeyAction.CommitText("t"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY
+                ),
+                swipes = mapOf(
+                    SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("c"),
+                        action = KeyAction.CommitText("c")
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay(","),
+                        action = KeyAction.CommitText(","),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.TOP_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("["),
+                        action = KeyAction.CommitText("["),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("{"),
+                        action = KeyAction.CommitText("{"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("!"),
+                        action = KeyAction.CommitText("!"),
+                        color = ColorVariant.MUTED
+                    )
+                )
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("i"),
+                    action = KeyAction.CommitText("i"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY
+                ),
+                swipes = mapOf(
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("f"),
+                        action = KeyAction.CommitText("f")
+                    ),
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("z"),
+                        action = KeyAction.CommitText("z")
+                    ),
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("-"),
+                        action = KeyAction.CommitText("-"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("."),
+                        action = KeyAction.CommitText("."),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("*"),
+                        action = KeyAction.CommitText("*"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("?"),
+                        action = KeyAction.CommitText("?"),
+                        color = ColorVariant.MUTED
+                    )
+                )
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("e"),
+                    action = KeyAction.CommitText("e"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY
+                ),
+                swipes = mapOf(
+                    SwipeDirection.TOP_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("d"),
+                        action = KeyAction.CommitText("d")
+                    ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay(";"),
+                        action = KeyAction.CommitText(";"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay(":"),
+                        action = KeyAction.CommitText(":"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("}"),
+                        action = KeyAction.CommitText("}"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("]"),
+                        action = KeyAction.CommitText("]"),
+                        color = ColorVariant.MUTED
+                    )
+                )
+            ),
+            BACKSPACE_KEY_ITEM
+        ),
+        arrayOf(
+            SPACEBAR_KEY_ITEM,
+            RETURN_KEY_ITEM
+        )
+    )
+)
+
+val THUMBKEY_EN_V4_PROGRAMMER_SHIFTED = KeyboardC(
+    arrayOf(
+        arrayOf(
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("S"),
+                    action = KeyAction.CommitText("S"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY
+                ),
+                swipes = mapOf(
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("W"),
+                        action = KeyAction.CommitText("W")
+                    ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("("),
+                        action = KeyAction.CommitText("("),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.TOP_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("~"),
+                        action = KeyAction.CommitText("~")
+                    ),
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("\\"),
+                        action = KeyAction.CommitText("\\"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("%"),
+                        action = KeyAction.CommitText("%"),
+                    )
+                )
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("R"),
+                    action = KeyAction.CommitText("R"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY
+                ),
+                swipes = mapOf(
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("G"),
+                        action = KeyAction.CommitText("G")
+                    ),
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("^"),
+                        action = KeyAction.CommitText("^"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("<"),
+                        action = KeyAction.CommitText("<"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay(">"),
+                        action = KeyAction.CommitText(">"),
+                        color = ColorVariant.MUTED
+                    )
+                )
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("O"),
+                    action = KeyAction.CommitText("O"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY
+                ),
+                swipes = mapOf(
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("U"),
+                        action = KeyAction.CommitText("U")
+                    ),
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay(")"),
+                        action = KeyAction.CommitText(")"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.TOP_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("="),
+                        action = KeyAction.CommitText("="),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("+"),
+                        action = KeyAction.CommitText("+"),
+                        color = ColorVariant.MUTED
+                    )
+                )
+            ),
+            SETTINGS_KEY_ITEM
+        ),
+        arrayOf(
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("N"),
+                    action = KeyAction.CommitText("N"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY
+                ),
+                swipes = mapOf(
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("M"),
+                        action = KeyAction.CommitText("M")
+                    ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("#"),
+                        action = KeyAction.CommitText("#"),
+                    ),
+                    SwipeDirection.LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("\""),
+                        action = KeyAction.CommitText("\""),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.TOP_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("'"),
+                        action = KeyAction.CommitText("'"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("€"),
+                        action = KeyAction.CommitText("€")
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("|"),
+                        action = KeyAction.CommitText("|")
+                    )
+                )
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("H"),
+                    action = KeyAction.CommitText("H"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY
+                ),
+                swipes = mapOf(
+                    SwipeDirection.TOP_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("J"),
+                        action = KeyAction.CommitText("J")
+                    ),
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("Q"),
+                        action = KeyAction.CommitText("Q")
+                    ),
+                    SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("B"),
+                        action = KeyAction.CommitText("B")
+                    ),
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("P"),
+                        action = KeyAction.CommitText("P")
+                    ),
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("Y"),
+                        action = KeyAction.CommitText("Y")
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("X"),
+                        action = KeyAction.CommitText("X")
+                    ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("V"),
+                        action = KeyAction.CommitText("V")
+                    ),
+                    SwipeDirection.LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("K"),
+                        action = KeyAction.CommitText("K")
+                    )
+                )
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("A"),
+                    action = KeyAction.CommitText("A"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY
+                ),
+                swipes = mapOf(
+                    SwipeDirection.LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("L"),
+                        action = KeyAction.CommitText("L")
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
+                        action = KeyAction.ToggleShiftMode(false),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.IconDisplay(Icons.Outlined.KeyboardCapslock),
+                        capsModeDisplay = KeyDisplay.IconDisplay(Icons.Outlined.Copyright),
+                        action = KeyAction.ToggleCapsLock,
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.IconDisplay(Icons.Outlined.KeyboardTab),
+                        action = KeyAction.CommitText("\t"),
+                        color = ColorVariant.MUTED
+                    )
+                )
+            ),
+            NUMERIC_KEY_ITEM
+        ),
+        arrayOf(
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("T"),
+                    action = KeyAction.CommitText("T"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY
+                ),
+                swipes = mapOf(
+                    SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("C"),
+                        action = KeyAction.CommitText("C")
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay(","),
+                        action = KeyAction.CommitText(","),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.TOP_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("["),
+                        action = KeyAction.CommitText("["),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("https://"),
+                        action = KeyAction.CommitText("https://"),
+                        color = ColorVariant.MUTED,
+                        size = FontSizeVariant.SMALLEST
+                    ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("{"),
+                        action = KeyAction.CommitText("{"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("!"),
+                        action = KeyAction.CommitText("!"),
+                        color = ColorVariant.MUTED
+                    )
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("I"),
+                    action = KeyAction.CommitText("I"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY
+                ),
+                swipes = mapOf(
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("F"),
+                        action = KeyAction.CommitText("F")
+                    ),
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("Z"),
+                        action = KeyAction.CommitText("Z")
+                    ),
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("_"),
+                        action = KeyAction.CommitText("_"),
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("."),
+                        action = KeyAction.CommitText("."),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("*"),
+                        action = KeyAction.CommitText("*"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("?"),
+                        action = KeyAction.CommitText("?"),
+                        color = ColorVariant.MUTED
+                    )
+                )
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("E"),
+                    action = KeyAction.CommitText("E"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY
+                ),
+                swipes = mapOf(
+                    SwipeDirection.TOP_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("D"),
+                        action = KeyAction.CommitText("D")
+                    ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay(";"),
+                        action = KeyAction.CommitText(";"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay(":"),
+                        action = KeyAction.CommitText(":"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("}"),
+                        action = KeyAction.CommitText("}"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("]"),
+                        action = KeyAction.CommitText("]"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay(".com/"),
+                        action = KeyAction.CommitText(".com/"),
+                        color = ColorVariant.MUTED,
+                        size = FontSizeVariant.SMALLEST
+                    )
+                )
+            ),
+            BACKSPACE_KEY_ITEM
+        ),
+        arrayOf(
+            SPACEBAR_KEY_ITEM,
+            RETURN_KEY_ITEM
+        )
+    )
+)
+
+val THUMBKEY_EN_V4_PROGRAMMER_KEYBOARD_MODES: Map<KeyboardMode, KeyboardC> = mapOf(
+    KeyboardMode.MAIN to THUMBKEY_EN_V4_PROGRAMMER,
+    KeyboardMode.SHIFTED to THUMBKEY_EN_V4_PROGRAMMER_SHIFTED,
+    KeyboardMode.NUMERIC to NUMERIC_KEYBOARD
+)

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ThumbKeyENv4Programmer.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ThumbKeyENv4Programmer.kt
@@ -246,13 +246,13 @@ val THUMBKEY_EN_V4_PROGRAMMER = KeyboardC(
                         color = ColorVariant.MUTED
                     ),
                     SwipeDirection.TOP_LEFT to KeyC(
-                        display = KeyDisplay.TextDisplay("["),
-                        action = KeyAction.CommitText("["),
+                        display = KeyDisplay.TextDisplay("{"),
+                        action = KeyAction.CommitText("{"),
                         color = ColorVariant.MUTED
                     ),
                     SwipeDirection.BOTTOM_LEFT to KeyC(
-                        display = KeyDisplay.TextDisplay("{"),
-                        action = KeyAction.CommitText("{"),
+                        display = KeyDisplay.TextDisplay("["),
+                        action = KeyAction.CommitText("["),
                         color = ColorVariant.MUTED
                     ),
                     SwipeDirection.BOTTOM_RIGHT to KeyC(
@@ -568,8 +568,8 @@ val THUMBKEY_EN_V4_PROGRAMMER_SHIFTED = KeyboardC(
                         color = ColorVariant.MUTED
                     ),
                     SwipeDirection.TOP_LEFT to KeyC(
-                        display = KeyDisplay.TextDisplay("["),
-                        action = KeyAction.CommitText("["),
+                        display = KeyDisplay.TextDisplay("{"),
+                        action = KeyAction.CommitText("{"),
                         color = ColorVariant.MUTED
                     ),
                     SwipeDirection.LEFT to KeyC(
@@ -579,8 +579,8 @@ val THUMBKEY_EN_V4_PROGRAMMER_SHIFTED = KeyboardC(
                         size = FontSizeVariant.SMALLEST
                     ),
                     SwipeDirection.BOTTOM_LEFT to KeyC(
-                        display = KeyDisplay.TextDisplay("{"),
-                        action = KeyAction.CommitText("{"),
+                        display = KeyDisplay.TextDisplay("["),
+                        action = KeyAction.CommitText("["),
                         color = ColorVariant.MUTED
                     ),
                     SwipeDirection.BOTTOM_RIGHT to KeyC(
@@ -660,8 +660,8 @@ val THUMBKEY_EN_V4_PROGRAMMER_SHIFTED = KeyboardC(
                         color = ColorVariant.MUTED
                     ),
                     SwipeDirection.RIGHT to KeyC(
-                        display = KeyDisplay.TextDisplay(".com/"),
-                        action = KeyAction.CommitText(".com/"),
+                        display = KeyDisplay.TextDisplay(".com"),
+                        action = KeyAction.CommitText(".com"),
                         color = ColorVariant.MUTED,
                         size = FontSizeVariant.SMALLEST
                     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ThumbKeyENv4Programmer.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ThumbKeyENv4Programmer.kt
@@ -71,6 +71,16 @@ val THUMBKEY_EN_V4_PROGRAMMER = KeyboardC(
                         action = KeyAction.CommitText("^"),
                         color = ColorVariant.MUTED
                     ),
+                    SwipeDirection.TOP_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("\""),
+                        action = KeyAction.CommitText("\""),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("'"),
+                        action = KeyAction.CommitText("'"),
+                        color = ColorVariant.MUTED
+                    ),
                     SwipeDirection.LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("<"),
                         action = KeyAction.CommitText("<"),
@@ -127,19 +137,9 @@ val THUMBKEY_EN_V4_PROGRAMMER = KeyboardC(
                         display = KeyDisplay.TextDisplay("m"),
                         action = KeyAction.CommitText("m")
                     ),
-                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                    SwipeDirection.LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("@"),
                         action = KeyAction.CommitText("@"),
-                        color = ColorVariant.MUTED
-                    ),
-                    SwipeDirection.LEFT to KeyC(
-                        display = KeyDisplay.TextDisplay("\""),
-                        action = KeyAction.CommitText("\""),
-                        color = ColorVariant.MUTED
-                    ),
-                    SwipeDirection.TOP_LEFT to KeyC(
-                        display = KeyDisplay.TextDisplay("'"),
-                        action = KeyAction.CommitText("'"),
                         color = ColorVariant.MUTED
                     ),
                     SwipeDirection.TOP to KeyC(
@@ -150,6 +150,11 @@ val THUMBKEY_EN_V4_PROGRAMMER = KeyboardC(
                     SwipeDirection.BOTTOM to KeyC(
                         display = KeyDisplay.TextDisplay("&"),
                         action = KeyAction.CommitText("&"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("|"),
+                        action = KeyAction.CommitText("|"),
                         color = ColorVariant.MUTED
                     )
                 )
@@ -395,6 +400,16 @@ val THUMBKEY_EN_V4_PROGRAMMER_SHIFTED = KeyboardC(
                         action = KeyAction.CommitText("^"),
                         color = ColorVariant.MUTED
                     ),
+                    SwipeDirection.TOP_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("\""),
+                        action = KeyAction.CommitText("\""),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("'"),
+                        action = KeyAction.CommitText("'"),
+                        color = ColorVariant.MUTED
+                    ),
                     SwipeDirection.LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("<"),
                         action = KeyAction.CommitText("<"),
@@ -451,27 +466,23 @@ val THUMBKEY_EN_V4_PROGRAMMER_SHIFTED = KeyboardC(
                         display = KeyDisplay.TextDisplay("M"),
                         action = KeyAction.CommitText("M")
                     ),
-                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                    SwipeDirection.LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("#"),
                         action = KeyAction.CommitText("#"),
-                    ),
-                    SwipeDirection.LEFT to KeyC(
-                        display = KeyDisplay.TextDisplay("\""),
-                        action = KeyAction.CommitText("\""),
-                        color = ColorVariant.MUTED
-                    ),
-                    SwipeDirection.TOP_LEFT to KeyC(
-                        display = KeyDisplay.TextDisplay("'"),
-                        action = KeyAction.CommitText("'"),
-                        color = ColorVariant.MUTED
                     ),
                     SwipeDirection.TOP to KeyC(
                         display = KeyDisplay.TextDisplay("€"),
                         action = KeyAction.CommitText("€")
                     ),
                     SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("&"),
+                        action = KeyAction.CommitText("&"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("|"),
-                        action = KeyAction.CommitText("|")
+                        action = KeyAction.CommitText("|"),
+                        color = ColorVariant.MUTED
                     )
                 )
             ),

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
@@ -60,7 +60,7 @@ enum class ColorVariant {
 }
 
 enum class FontSizeVariant {
-    LARGE, SMALL
+    LARGE, SMALL, SMALLEST
 }
 
 enum class ThemeMode(private val stringId: Int) {
@@ -87,6 +87,7 @@ enum class ThemeColor(private val stringId: Int) {
 
 enum class KeyboardLayout(val title: String) {
     ThumbKeyENv4("Thumb-Key English v4"),
+    ThumbKeyENv4Programmer("Thumb-Key English v4 (Programmer)"),
     ThumbKeyDEv2("Thumb-Key Deutsch v2"),
     ThumbKeyDKv1("Thumb-Key dansk v1"),
     ThumbKeyEUv1("Thumb-Key euskara v1"),

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -37,6 +37,7 @@ import com.dessalines.thumbkey.keyboards.MESSAGEEASE_HE_KEYBOARD_MODES
 import com.dessalines.thumbkey.keyboards.THUMBKEY_DE_V2_KEYBOARD_MODES
 import com.dessalines.thumbkey.keyboards.THUMBKEY_DK_V1_KEYBOARD_MODES
 import com.dessalines.thumbkey.keyboards.THUMBKEY_EN_V4_KEYBOARD_MODES
+import com.dessalines.thumbkey.keyboards.THUMBKEY_EN_V4_PROGRAMMER_KEYBOARD_MODES
 import com.dessalines.thumbkey.keyboards.THUMBKEY_EU_V1_KEYBOARD_MODES
 import com.dessalines.thumbkey.keyboards.THUMBKEY_FA_V1_KEYBOARD_MODES
 import com.dessalines.thumbkey.keyboards.THUMBKEY_FI_V1_KEYBOARD_MODES
@@ -71,6 +72,8 @@ fun fontSizeVariantToFontSize(fontSizeVariant: FontSizeVariant, keySize: Dp): Te
     val divFactor = when (fontSizeVariant) {
         FontSizeVariant.LARGE -> 2.5f
         FontSizeVariant.SMALL -> 5f
+        FontSizeVariant.SMALLEST -> 8f
+
     }
     return TextUnit(keySize.value / divFactor, TextUnitType.Sp)
 }
@@ -78,6 +81,7 @@ fun fontSizeVariantToFontSize(fontSizeVariant: FontSizeVariant, keySize: Dp): Te
 fun keyboardLayoutToModes(layout: KeyboardLayout): Map<KeyboardMode, KeyboardC> {
     return when (layout) {
         KeyboardLayout.ThumbKeyENv4 -> THUMBKEY_EN_V4_KEYBOARD_MODES
+        KeyboardLayout.ThumbKeyENv4Programmer -> THUMBKEY_EN_V4_PROGRAMMER_KEYBOARD_MODES
         KeyboardLayout.ThumbKeyDEv2 -> THUMBKEY_DE_V2_KEYBOARD_MODES
         KeyboardLayout.ThumbKeyDKv1 -> THUMBKEY_DK_V1_KEYBOARD_MODES
         KeyboardLayout.ThumbKeyEUv1 -> THUMBKEY_EU_V1_KEYBOARD_MODES


### PR DESCRIPTION
the layout just adds symbols to the ENv4 style, making as few changes to the default punctuation layout as possible. The intention is to reduce having to switch with the # key and just have everything under your finger-tips. The only changes made to the default were to make sure that every letter has spacing between it and punctuation to reduce typing errors. It also tries to keep similar spaces between bracket types

I also added a "smaller" option for fonts to fit things like "DEL", "https://", and ".com"

I also added up/down arrow functionality and delete key functionality by default - i understand if you'd want to not include those changes and I can just incorporate them into the layout separately if needed. just seems like unnecessary copy and paste. you might not want the "DEL" text though

edit: turns out this addresses a lot from #147. I think this can be home to a separate "system keys" keyboard (As opposed to the typical "symbol" key since that would just be redundant) and i've begun work on that, but feel stuck as i worry about key up/down actions though with system keys and im not sure how that would work