### PR TITLE
suggestion to add sterling symbol to numeric key 3 bottom left swipe

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/Numeric.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/Numeric.kt
@@ -86,6 +86,10 @@ val NUMERIC_KEYBOARD = KeyboardC(
                         display = KeyDisplay.TextDisplay("€"),
                         action = KeyAction.CommitText("€")
                     ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("£"),
+                        action = KeyAction.CommitText("£")
+                    ),
                     SwipeDirection.BOTTOM to KeyC(
                         display = KeyDisplay.TextDisplay("="),
                         action = KeyAction.CommitText("=")


### PR DESCRIPTION
added £ symbol to bottom left swipe position of numeric key 3 for en-gb users.