### PR TITLE
Fix Capital V in MessageEaseENSymbols.kt

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/MessageEaseENSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/MessageEaseENSymbols.kt
@@ -352,8 +352,8 @@ val MESSAGEEASE_EN_SYMBOLS_SHIFTED = KeyboardC(
                 ),
                 swipes = mapOf(
                     SwipeDirection.BOTTOM_RIGHT to KeyC(
-                        display = KeyDisplay.TextDisplay("v"),
-                        action = KeyAction.CommitText("v")
+                        display = KeyDisplay.TextDisplay("V"),
+                        action = KeyAction.CommitText("V")
                     ),
                     SwipeDirection.RIGHT to KeyC(
                         display = KeyDisplay.TextDisplay("-"),


### PR DESCRIPTION
The MessageEaseENSymbols keyboard had a lower case 'v' in the upper case layer, making it impossible to type an upper case 'V'. This pull request fixes that.