### PR TITLE
Comprehensive delimiter for deleting last word.

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -348,7 +348,7 @@ fun deleteLastWord(ime: IMEService) {
 
     val trimmedLength = lastWords?.length?.minus(lastWords.trimmedLength()) ?: 0
     val trimmed = lastWords?.trim()
-    val lastWordLength = trimmed?.split(" ")?.lastOrNull()?.length ?: 1
+    val lastWordLength = trimmed?.split("\\s".toRegex())?.lastOrNull()?.length ?: 1
     val minDelete = if (lastWordLength > 0) {
         lastWordLength + trimmedLength
     } else {


### PR DESCRIPTION
Using the "s" regex metacharacter to better match whitespace characters. Line feeds and carriage returns are currently not being considered, so deleteLastWord() can delete multiple words on multiple lines. E.g. on the first word of a subsequent paragraph.