### PR TITLE
KeyAction.CommitText to better handle Shifted mode.

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -191,6 +191,8 @@ fun performKeyAction(
                     ime = ime,
                     onAutoCapitalize = onAutoCapitalize
                 )
+            } else {// To return to MAIN mode after a shifted key action.
+                onAutoCapitalize(false)
             }
         }
         is KeyAction.SendEvent -> {


### PR DESCRIPTION
When autoCapitalize is disabled and a shifted key is pressed, onAutoCapitalize(false) will set the keyboard back to MAIN mode if capsLocks is off.

It's not very tidy, but it resolves #187.