### PR TITLE
Smoother animation, notification on layout change and a bug fix

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/ComposeKeyboardView.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ComposeKeyboardView.kt
@@ -2,6 +2,7 @@ package com.dessalines.thumbkey
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.widget.Toast
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.platform.AbstractComposeView
@@ -9,6 +10,7 @@ import androidx.lifecycle.lifecycleScope
 import com.dessalines.thumbkey.db.AppSettingsRepository
 import com.dessalines.thumbkey.ui.components.keyboard.KeyboardScreen
 import com.dessalines.thumbkey.ui.theme.ThumbkeyTheme
+import com.dessalines.thumbkey.utils.KeyboardLayout
 import com.dessalines.thumbkey.utils.keyboardLayoutsSetFromString
 import kotlinx.coroutines.launch
 
@@ -43,6 +45,9 @@ class ComposeKeyboardView(
                         nextLayout?.let { layout ->
                             val s2 = s.copy(keyboardLayout = layout)
                             settingsRepo.update(s2)
+                            // Display the new layout's name on the screen
+                            val layoutName = KeyboardLayout.values().find { it.index == nextLayout }?.title
+                            Toast.makeText(context, "$layoutName", Toast.LENGTH_SHORT).show()
                         }
                     }
                 },

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
@@ -2,8 +2,10 @@ package com.dessalines.thumbkey.ui.components.keyboard
 import android.content.Context
 import android.media.AudioManager
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -29,6 +31,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
@@ -291,14 +294,31 @@ fun KeyboardKey(
                 KeyText(it, keySizeDp, hideLetters, capsLock)
             }
         }
-        // The popup overlay
+
+        // The animated box that fades out.
         AnimatedVisibility(
             modifier = Modifier
                 .fillMaxSize()
-                .background(color = MaterialTheme.colorScheme.tertiaryContainer),
+                .background(color = Color(0, 0, 0, 0)),
             visible = releasedKey.value != null,
-            enter = slideInVertically(tween(animationSpeed)),
-            exit = ExitTransition.None
+            enter = EnterTransition.None,
+            exit = fadeOut( tween(animationSpeed) )
+        ) {
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier.fillMaxSize()
+                    .background(color = MaterialTheme.colorScheme.tertiaryContainer)
+            ) {}
+        }
+
+        // The animated key letter that falls downwards and then fades out.
+        AnimatedVisibility(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(color = Color(0, 0, 0, 0)),
+            visible = releasedKey.value != null,
+            enter = slideInVertically( tween(animationSpeed) ),
+            exit = fadeOut( tween(animationSpeed) )
         ) {
             Box(
                 contentAlignment = Alignment.Center,

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -185,7 +185,7 @@ fun performKeyAction(
             Log.d(TAG, "committing key text: $text")
             ime.currentInputConnection.commitText(
                 text,
-                text.length
+                1
             )
 
             if (autoCapitalize) {


### PR DESCRIPTION
**Smoother Animation**
Hi, I have made the animation look smoother by fading it out. Before the animation would draw a box over the key and after it was finished, the box would instantly disappear. I've made both the box and the falling letter fade out at the end of the animation, which makes it look a lot less sharp. To test how smooth it looks, set both animation speeds to 500.
_see KeyboardKey.kt for these changes_

**Layout change notification**
I've added a Toast notification for every time the user changes the layout, so it will tell them which layout they are now on.
_see ComposeKeyboardView.kt for these change._

**Bug fix**
The cursor was moving to the wrong place when we had a key that entered a string of text with more than one character.
Fixes issue 216.
_see Utils.kt for the bug fix_