### PR TITLE
Update ThumbKeyDEv2MultiLingual.kt

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ThumbKeyDEv2MultiLingual.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ThumbKeyDEv2MultiLingual.kt
@@ -24,18 +24,12 @@ val THUMBKEY_DE_V2_MULTILINGUAL_MAIN = KeyboardC(
                     action = KeyAction.CommitText("t"),
                     size = FontSizeVariant.LARGE,
                     color = ColorVariant.PRIMARY,
-                ),
-                swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
+                ),                
                 swipes = mapOf(
                     SwipeDirection.TOP_LEFT to KeyC(
-                        display = KeyDisplay.TextDisplay("https://"),
-                        action = KeyAction.CommitText("https://"),
-                        color = ColorVariant.MUTED,
-                    ),
-                    SwipeDirection.LEFT to KeyC(
-                        display = KeyDisplay.TextDisplay("|"),
-                        action = KeyAction.CommitText("|"),
-                        color = ColorVariant.MUTED,
+                        display = KeyDisplay.TextDisplay("@"),
+                        action = KeyAction.CommitText("@"),
+                        color = ColorVariant.MUTED,                   
                     ),
                     SwipeDirection.TOP_RIGHT to KeyC(
                         display = KeyDisplay.TextDisplay("#"),
@@ -45,6 +39,7 @@ val THUMBKEY_DE_V2_MULTILINGUAL_MAIN = KeyboardC(
                     SwipeDirection.RIGHT to KeyC(
                         display = KeyDisplay.TextDisplay("ç"),
                         action = KeyAction.CommitText("ç"),
+                        color = ColorVariant.MUTED,
                     ),
                     SwipeDirection.BOTTOM_RIGHT to KeyC(
                         display = KeyDisplay.TextDisplay("c"),
@@ -58,27 +53,15 @@ val THUMBKEY_DE_V2_MULTILINGUAL_MAIN = KeyboardC(
                     action = KeyAction.CommitText("d"),
                     size = FontSizeVariant.LARGE,
                     color = ColorVariant.PRIMARY,
-                ),
-                swipeType = SwipeNWay.TWO_WAY_VERTICAL,
-                swipes = mapOf(
-                    SwipeDirection.TOP_LEFT to KeyC(
-                        display = KeyDisplay.TextDisplay(".com"),
-                        action = KeyAction.CommitText(".com"),
-                        color = ColorVariant.MUTED,
-                    ),
-                    SwipeDirection.TOP to KeyC(
-                        display = KeyDisplay.TextDisplay("&"),
-                        action = KeyAction.CommitText("&"),
-                        color = ColorVariant.MUTED,
-                    ),
-                    SwipeDirection.TOP_RIGHT to KeyC(
-                        display = KeyDisplay.TextDisplay(".de"),
-                        action = KeyAction.CommitText(".de"),
-                        color = ColorVariant.MUTED,
-                    ),
+                ),                
+                swipes = mapOf(                    
                     SwipeDirection.BOTTOM to KeyC(
                         display = KeyDisplay.TextDisplay("f"),
                         action = KeyAction.CommitText("f"),
+                    ),
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("l"),
+                        action = KeyAction.CommitText("l"),                  
                     ),
                 ),
             ),
@@ -89,34 +72,35 @@ val THUMBKEY_DE_V2_MULTILINGUAL_MAIN = KeyboardC(
                     size = FontSizeVariant.LARGE,
                     color = ColorVariant.PRIMARY,
                 ),
-                swipes = mapOf(
+                swipes = mapOf(                    
                     SwipeDirection.BOTTOM_LEFT to KeyC(
-                        display = KeyDisplay.TextDisplay("l"),
-                        action = KeyAction.CommitText("l"),
-                    ),
-                    SwipeDirection.RIGHT to KeyC(
                         display = KeyDisplay.TextDisplay("ä"),
                         action = KeyAction.CommitText("ä"),
                     ),
                     SwipeDirection.BOTTOM_RIGHT to KeyC(
                         display = KeyDisplay.TextDisplay("â"),
                         action = KeyAction.CommitText("â"),
+                        color = ColorVariant.MUTED,
                     ),
                     SwipeDirection.BOTTOM to KeyC(
                         display = KeyDisplay.TextDisplay("à"),
                         action = KeyAction.CommitText("à"),
+                        color = ColorVariant.MUTED,
                     ),
                     SwipeDirection.TOP_LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("€"),
                         action = KeyAction.CommitText("€"),
+                        color = ColorVariant.MUTED,
                     ),
                     SwipeDirection.TOP to KeyC(
-                        display = KeyDisplay.TextDisplay("<"),
-                        action = KeyAction.CommitText("<"),
+                        display = KeyDisplay.TextDisplay("|"),
+                        action = KeyAction.CommitText("|"),
+                        color = ColorVariant.MUTED,
                     ),
                     SwipeDirection.TOP_RIGHT to KeyC(
-                        display = KeyDisplay.TextDisplay("3"),
-                        action = KeyAction.CommitText("3"),
+                        display = KeyDisplay.TextDisplay("&"),
+                        action = KeyAction.CommitText("&"),
+                        color = ColorVariant.MUTED,
                     ),
                 ),
             ),
@@ -129,8 +113,7 @@ val THUMBKEY_DE_V2_MULTILINGUAL_MAIN = KeyboardC(
                     action = KeyAction.CommitText("r"),
                     size = FontSizeVariant.LARGE,
                     color = ColorVariant.PRIMARY,
-                ),
-                swipeType = SwipeNWay.TWO_WAY_HORIZONTAL,
+                ),                
                 swipes = mapOf(
                     SwipeDirection.RIGHT to KeyC(
                         display = KeyDisplay.TextDisplay("m"),
@@ -139,10 +122,12 @@ val THUMBKEY_DE_V2_MULTILINGUAL_MAIN = KeyboardC(
                     SwipeDirection.BOTTOM_LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("ó"),
                         action = KeyAction.CommitText("ó"),
+                        ´
                     ),
                     SwipeDirection.LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("ò"),
                         action = KeyAction.CommitText("ò"),
+                        color = ColorVariant.MUTED,
                     ),
                     SwipeDirection.TOP_LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("ö"),
@@ -151,6 +136,7 @@ val THUMBKEY_DE_V2_MULTILINGUAL_MAIN = KeyboardC(
                     SwipeDirection.TOP to KeyC(
                         display = KeyDisplay.TextDisplay("ô"),
                         action = KeyAction.CommitText("ô"),
+                        color = ColorVariant.MUTED,
                     ),
                     SwipeDirection.TOP_RIGHT to KeyC(
                         display = KeyDisplay.TextDisplay("o"),
@@ -206,20 +192,22 @@ val THUMBKEY_DE_V2_MULTILINGUAL_MAIN = KeyboardC(
                     action = KeyAction.CommitText("i"),
                     size = FontSizeVariant.LARGE,
                     color = ColorVariant.PRIMARY,
-                ),
-                swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                ),                
                 swipes = mapOf(
-                    SwipeDirection.TOP_LEFT to KeyC(
+                    SwipeDirection.BOTTOM to KeyC(
                         display = KeyDisplay.TextDisplay("ï"),
                         action = KeyAction.CommitText("ï"),
+                        color = ColorVariant.MUTED,
                     ),
-                    SwipeDirection.TOP_RIGHT to KeyC(
+                    SwipeDirection.RIGHT to KeyC(
                         display = KeyDisplay.TextDisplay("ì"),
                         action = KeyAction.CommitText("ì"),
+                        color = ColorVariant.MUTED,
                     ),
-                    SwipeDirection.LEFT to KeyC(
+                    SwipeDirection.BOTTOM.RIGHT to KeyC(
                         display = KeyDisplay.TextDisplay("î"),
                         action = KeyAction.CommitText("î"),
+                        color = ColorVariant.MUTED,
                     ),
                     SwipeDirection.TOP to KeyC(
                         display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
@@ -237,8 +225,7 @@ val THUMBKEY_DE_V2_MULTILINGUAL_MAIN = KeyboardC(
                     action = KeyAction.CommitText("n"),
                     size = FontSizeVariant.LARGE,
                     color = ColorVariant.PRIMARY,
-                ),
-                swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
+                ),                
                 swipes = mapOf(
                     SwipeDirection.RIGHT to KeyC(
                         display = KeyDisplay.TextDisplay("g"),
@@ -251,6 +238,7 @@ val THUMBKEY_DE_V2_MULTILINGUAL_MAIN = KeyboardC(
                     SwipeDirection.TOP to KeyC(
                         display = KeyDisplay.TextDisplay("û"),
                         action = KeyAction.CommitText("û"),
+                        color = ColorVariant.MUTED,
                     ),
                     SwipeDirection.TOP_LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("ü"),
@@ -259,6 +247,7 @@ val THUMBKEY_DE_V2_MULTILINGUAL_MAIN = KeyboardC(
                     SwipeDirection.LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("ù"),
                         action = KeyAction.CommitText("ù"),
+                        color = ColorVariant.MUTED,
                     ),
                     SwipeDirection.BOTTOM_LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("("),
@@ -325,28 +314,32 @@ val THUMBKEY_DE_V2_MULTILINGUAL_MAIN = KeyboardC(
                     action = KeyAction.CommitText("e"),
                     size = FontSizeVariant.LARGE,
                     color = ColorVariant.PRIMARY,
-                ),
-                swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
+                ),                
                 swipes = mapOf(
                     SwipeDirection.LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("œ"),
                         action = KeyAction.CommitText("œ"),
+                        color = ColorVariant.MUTED,
                     ),
                     SwipeDirection.TOP_LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("ë"),
                         action = KeyAction.CommitText("ë"),
+                        color = ColorVariant.MUTED,
                     ),
                     SwipeDirection.TOP to KeyC(
                         display = KeyDisplay.TextDisplay("ê"),
                         action = KeyAction.CommitText("ê"),
+                        color = ColorVariant.MUTED,
                     ),
                     SwipeDirection.TOP_RIGHT to KeyC(
                         display = KeyDisplay.TextDisplay("è"),
                         action = KeyAction.CommitText("è"),
+                        color = ColorVariant.MUTED,
                     ),
                     SwipeDirection.RIGHT to KeyC(
                         display = KeyDisplay.TextDisplay("é"),
                         action = KeyAction.CommitText("é"),
+                        color = ColorVariant.MUTED,
                     ),
                     SwipeDirection.BOTTOM_RIGHT to KeyC(
                         display = KeyDisplay.TextDisplay(")"),
@@ -383,27 +376,22 @@ val THUMBKEY_DE_V2_MULTILINGUAL_SHIFTED = KeyboardC(
                     action = KeyAction.CommitText("T"),
                     size = FontSizeVariant.LARGE,
                     color = ColorVariant.PRIMARY,
-                ),
-                swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
+                ),               
                 swipes = mapOf(
                     SwipeDirection.TOP_LEFT to KeyC(
-                        display = KeyDisplay.TextDisplay("https://"),
-                        action = KeyAction.CommitText("https://"),
-                        color = ColorVariant.MUTED,
-                    ),
-                    SwipeDirection.LEFT to KeyC(
-                        display = KeyDisplay.TextDisplay("|"),
-                        action = KeyAction.CommitText("|"),
-                        color = ColorVariant.MUTED,
+                        display = KeyDisplay.TextDisplay("@"),
+                        action = KeyAction.CommitText("@"),
+                        color = ColorVariant.MUTED,                   
                     ),
                     SwipeDirection.TOP_RIGHT to KeyC(
                         display = KeyDisplay.TextDisplay("#"),
                         action = KeyAction.CommitText("#"),
-                        color = ColorVariant.MUTED,
+                        color = ColorVariant.MUTED,                   
                     ),
                     SwipeDirection.RIGHT to KeyC(
                         display = KeyDisplay.TextDisplay("Ç"),
                         action = KeyAction.CommitText("Ç"),
+                         color = ColorVariant.MUTED,
                     ),
                     SwipeDirection.BOTTOM_RIGHT to KeyC(
                         display = KeyDisplay.TextDisplay("C"),
@@ -417,27 +405,15 @@ val THUMBKEY_DE_V2_MULTILINGUAL_SHIFTED = KeyboardC(
                     action = KeyAction.CommitText("D"),
                     size = FontSizeVariant.LARGE,
                     color = ColorVariant.PRIMARY,
-                ),
-                swipeType = SwipeNWay.TWO_WAY_VERTICAL,
+                ),                
                 swipes = mapOf(
-                    SwipeDirection.TOP_LEFT to KeyC(
-                        display = KeyDisplay.TextDisplay(".com"),
-                        action = KeyAction.CommitText(".com"),
-                        color = ColorVariant.MUTED,
-                    ),
-                    SwipeDirection.TOP to KeyC(
-                        display = KeyDisplay.TextDisplay("&"),
-                        action = KeyAction.CommitText("&"),
-                        color = ColorVariant.MUTED,
-                    ),
-                    SwipeDirection.TOP_RIGHT to KeyC(
-                        display = KeyDisplay.TextDisplay(".de"),
-                        action = KeyAction.CommitText(".de"),
-                        color = ColorVariant.MUTED,
-                    ),
                     SwipeDirection.BOTTOM to KeyC(
                         display = KeyDisplay.TextDisplay("F"),
                         action = KeyAction.CommitText("F"),
+                    ),
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("L"),
+                        action = KeyAction.CommitText("L"), 
                     ),
                 ),
             ),
@@ -448,34 +424,35 @@ val THUMBKEY_DE_V2_MULTILINGUAL_SHIFTED = KeyboardC(
                     size = FontSizeVariant.LARGE,
                     color = ColorVariant.PRIMARY,
                 ),
-                swipes = mapOf(
-                    SwipeDirection.BOTTOM_LEFT to KeyC(
-                        display = KeyDisplay.TextDisplay("L"),
-                        action = KeyAction.CommitText("L"),
-                    ),
-                    SwipeDirection.RIGHT to KeyC(
+                  swipes = mapOf(                    
+                    SwipeDirection.BOTTOM_LEFT to KeyC(                       
                         display = KeyDisplay.TextDisplay("Ä"),
                         action = KeyAction.CommitText("Ä"),
                     ),
                     SwipeDirection.BOTTOM_RIGHT to KeyC(
                         display = KeyDisplay.TextDisplay("Â"),
                         action = KeyAction.CommitText("Â"),
+                        color = ColorVariant.MUTED,
                     ),
                     SwipeDirection.BOTTOM to KeyC(
                         display = KeyDisplay.TextDisplay("À"),
                         action = KeyAction.CommitText("À"),
+                        color = ColorVariant.MUTED,
                     ),
                     SwipeDirection.TOP_LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("€"),
                         action = KeyAction.CommitText("€"),
+                        color = ColorVariant.MUTED,
                     ),
                     SwipeDirection.TOP to KeyC(
-                        display = KeyDisplay.TextDisplay("<"),
-                        action = KeyAction.CommitText("<"),
+                        display = KeyDisplay.TextDisplay("|"),
+                        action = KeyAction.CommitText("|"),
+                        color = ColorVariant.MUTED,
                     ),
                     SwipeDirection.TOP_RIGHT to KeyC(
-                        display = KeyDisplay.TextDisplay("3"),
-                        action = KeyAction.CommitText("3"),
+                        display = KeyDisplay.TextDisplay("&"),
+                        action = KeyAction.CommitText("&"),
+                        color = ColorVariant.MUTED,                    
                     ),
                 ),
             ),
@@ -488,8 +465,7 @@ val THUMBKEY_DE_V2_MULTILINGUAL_SHIFTED = KeyboardC(
                     action = KeyAction.CommitText("R"),
                     size = FontSizeVariant.LARGE,
                     color = ColorVariant.PRIMARY,
-                ),
-                swipeType = SwipeNWay.TWO_WAY_HORIZONTAL,
+                ),                
                 swipes = mapOf(
                     SwipeDirection.RIGHT to KeyC(
                         display = KeyDisplay.TextDisplay("M"),
@@ -498,10 +474,12 @@ val THUMBKEY_DE_V2_MULTILINGUAL_SHIFTED = KeyboardC(
                     SwipeDirection.BOTTOM_LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("Ó"),
                         action = KeyAction.CommitText("Ó"),
+                        color = ColorVariant.MUTED,
                     ),
                     SwipeDirection.LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("Ò"),
                         action = KeyAction.CommitText("Ò"),
+                        color = ColorVariant.MUTED,
                     ),
                     SwipeDirection.TOP_LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("Ö"),
@@ -510,6 +488,7 @@ val THUMBKEY_DE_V2_MULTILINGUAL_SHIFTED = KeyboardC(
                     SwipeDirection.TOP to KeyC(
                         display = KeyDisplay.TextDisplay("Ô"),
                         action = KeyAction.CommitText("Ô"),
+                        color = ColorVariant.MUTED,
                     ),
                     SwipeDirection.TOP_RIGHT to KeyC(
                         display = KeyDisplay.TextDisplay("O"),
@@ -565,20 +544,22 @@ val THUMBKEY_DE_V2_MULTILINGUAL_SHIFTED = KeyboardC(
                     action = KeyAction.CommitText("I"),
                     size = FontSizeVariant.LARGE,
                     color = ColorVariant.PRIMARY,
-                ),
-                swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                ),                
                 swipes = mapOf(
-                    SwipeDirection.TOP_LEFT to KeyC(
+                    SwipeDirection.BOTTOM to KeyC(
                         display = KeyDisplay.TextDisplay("Ï"),
                         action = KeyAction.CommitText("Ï"),
+                        color = ColorVariant.MUTED,
                     ),
-                    SwipeDirection.TOP_RIGHT to KeyC(
+                    SwipeDirection.RIGHT to KeyC(
                         display = KeyDisplay.TextDisplay("Ì"),
                         action = KeyAction.CommitText("Ì"),
+                        color = ColorVariant.MUTED,
                     ),
-                    SwipeDirection.LEFT to KeyC(
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
                         display = KeyDisplay.TextDisplay("Î"),
                         action = KeyAction.CommitText("Î"),
+                        color = ColorVariant.MUTED,                     
                     ),
                     SwipeDirection.BOTTOM to KeyC(
                         display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
@@ -601,8 +582,7 @@ val THUMBKEY_DE_V2_MULTILINGUAL_SHIFTED = KeyboardC(
                     action = KeyAction.CommitText("N"),
                     size = FontSizeVariant.LARGE,
                     color = ColorVariant.PRIMARY,
-                ),
-                swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
+                ),                
                 swipes = mapOf(
                     SwipeDirection.RIGHT to KeyC(
                         display = KeyDisplay.TextDisplay("G"),
@@ -615,6 +595,7 @@ val THUMBKEY_DE_V2_MULTILINGUAL_SHIFTED = KeyboardC(
                     SwipeDirection.TOP to KeyC(
                         display = KeyDisplay.TextDisplay("Û"),
                         action = KeyAction.CommitText("Û"),
+                        color = ColorVariant.MUTED,
                     ),
                     SwipeDirection.TOP_LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("Ü"),
@@ -623,6 +604,7 @@ val THUMBKEY_DE_V2_MULTILINGUAL_SHIFTED = KeyboardC(
                     SwipeDirection.LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("Ù"),
                         action = KeyAction.CommitText("Ù"),
+                        color = ColorVariant.MUTED,
                     ),
                     SwipeDirection.BOTTOM_LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("("),
@@ -689,28 +671,32 @@ val THUMBKEY_DE_V2_MULTILINGUAL_SHIFTED = KeyboardC(
                     action = KeyAction.CommitText("E"),
                     size = FontSizeVariant.LARGE,
                     color = ColorVariant.PRIMARY,
-                ),
-                swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
+                ),                
                 swipes = mapOf(
                     SwipeDirection.LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("Œ"),
                         action = KeyAction.CommitText("Œ"),
+                        color = ColorVariant.MUTED,
                     ),
                     SwipeDirection.TOP_LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("Ë"),
                         action = KeyAction.CommitText("Ë"),
+                        color = ColorVariant.MUTED,
                     ),
                     SwipeDirection.TOP to KeyC(
                         display = KeyDisplay.TextDisplay("Ê"),
                         action = KeyAction.CommitText("Ê"),
+                        color = ColorVariant.MUTED,
                     ),
                     SwipeDirection.TOP_RIGHT to KeyC(
                         display = KeyDisplay.TextDisplay("È"),
                         action = KeyAction.CommitText("È"),
+                        color = ColorVariant.MUTED,
                     ),
                     SwipeDirection.RIGHT to KeyC(
                         display = KeyDisplay.TextDisplay("É"),
                         action = KeyAction.CommitText("É"),
+                        color = ColorVariant.MUTED,
                     ),
                     SwipeDirection.BOTTOM_RIGHT to KeyC(
                         display = KeyDisplay.TextDisplay(")"),


### PR DESCRIPTION
Bug fixes: I did not take into account predefined swipe types "wipeType = SwipeNWay.FOUR_WAY_DIAGONAL,". In this version I removed those lines and switched the symbols around so that they won't overlap - did not take that in either. Thanks for incorporating!