### PR TITLE
Fix the MessageEaseRUSymbols layout by removing FOUR_WAY_DIAGONAL

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/MessageEaseRUSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/MessageEaseRUSymbols.kt
@@ -270,7 +270,6 @@ val MESSAGEEASE_RU_SYMBOLS_MAIN = KeyboardC(
                     size = FontSizeVariant.LARGE,
                     color = ColorVariant.PRIMARY,
                 ),
-                swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
                 swipes = mapOf(
                     SwipeDirection.TOP to KeyC(
                         display = KeyDisplay.TextDisplay("ё"),
@@ -656,7 +655,6 @@ val MESSAGEEASE_RU_SYMBOLS_SHIFTED = KeyboardC(
                     size = FontSizeVariant.LARGE,
                     color = ColorVariant.PRIMARY,
                 ),
-                swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
                 swipes = mapOf(
                     SwipeDirection.TOP to KeyC(
                         display = KeyDisplay.TextDisplay("Ё"),


### PR DESCRIPTION
There are top, bottom, and right swipe characters on the bottom left tile that otherwise get ignored.

![image](https://github.com/dessalines/thumb-key/assets/290707/566c0a50-ded3-4729-b219-46cd08e8b7bc)
