### PR TITLE
New layout: "Four columns" (English).

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FourColumnsENv1.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FourColumnsENv1.kt
@@ -1,0 +1,816 @@
+package com.dessalines.thumbkey.keyboards
+
+import android.view.KeyEvent
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowDropDown
+import androidx.compose.material.icons.outlined.ArrowDropUp
+import androidx.compose.material.icons.outlined.Copyright
+import androidx.compose.material.icons.outlined.KeyboardBackspace
+import androidx.compose.material.icons.outlined.KeyboardCapslock
+import androidx.compose.material.icons.outlined.Settings
+import com.dessalines.thumbkey.utils.ColorVariant
+import com.dessalines.thumbkey.utils.FontSizeVariant
+import com.dessalines.thumbkey.utils.KeyAction
+import com.dessalines.thumbkey.utils.KeyC
+import com.dessalines.thumbkey.utils.KeyDisplay
+import com.dessalines.thumbkey.utils.KeyItemC
+import com.dessalines.thumbkey.utils.KeyboardC
+import com.dessalines.thumbkey.utils.KeyboardMode
+import com.dessalines.thumbkey.utils.SwipeDirection
+import com.dessalines.thumbkey.utils.SwipeNWay
+
+val FOUR_COLUMNS_EN_V1 = KeyboardC(
+    listOf(
+        listOf(
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("e"),
+                    action = KeyAction.CommitText("e"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                swipes = mapOf(
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("q"),
+                        action = KeyAction.CommitText("q"),
+                    ),
+                    SwipeDirection.LEFT to KeyC(
+                        display = null,
+                        action = KeyAction.CommitText("q"),
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("w"),
+                        action = KeyAction.CommitText("w"),
+                    ),
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("t"),
+                    action = KeyAction.CommitText("t"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.TWO_WAY_VERTICAL,
+                swipes = mapOf(
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("r"),
+                        action = KeyAction.CommitText("r"),
+                    ),
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay(" "),
+                    action = KeyAction.CommitText(" "),
+                ),
+                swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                swipes = mapOf(
+                    SwipeDirection.LEFT to KeyC(
+                        action = KeyAction.SendEvent(
+                            KeyEvent(
+                                KeyEvent.ACTION_DOWN,
+                                KeyEvent.KEYCODE_DPAD_LEFT,
+                            ),
+                        ),
+                        display = null,
+                    ),
+                    SwipeDirection.RIGHT to KeyC(
+                        action = KeyAction.SendEvent(
+                            KeyEvent(
+                                KeyEvent.ACTION_DOWN,
+                                KeyEvent.KEYCODE_DPAD_RIGHT,
+                            ),
+                        ),
+                        display = null,
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("*"),
+                        action = KeyAction.CommitText("*"),
+                        color = ColorVariant.MUTED,
+                    ),
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.IconDisplay(Icons.Outlined.Settings),
+                        action = KeyAction.GotoSettings,
+                        color = ColorVariant.SECONDARY,
+                    ),
+                ),
+                nextTapActions = listOf(
+                    KeyAction.ReplaceLastText(", ", trimCount = 1),
+                    KeyAction.ReplaceLastText(". "),
+                    KeyAction.ReplaceLastText("? "),
+                    KeyAction.ReplaceLastText("! "),
+                    KeyAction.ReplaceLastText(": "),
+                    KeyAction.ReplaceLastText("; "),
+                ),
+                backgroundColor = ColorVariant.SURFACE_VARIANT,
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("i"),
+                    action = KeyAction.CommitText("i"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                swipes = mapOf(
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("y"),
+                        action = KeyAction.CommitText("y"),
+                    ),
+                    SwipeDirection.LEFT to KeyC(
+                        display = null,
+                        action = KeyAction.CommitText("y"),
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("u"),
+                        action = KeyAction.CommitText("u"),
+                    ),
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("o"),
+                    action = KeyAction.CommitText("o"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.TWO_WAY_VERTICAL,
+                swipes = mapOf(
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("p"),
+                        action = KeyAction.CommitText("p"),
+                    ),
+                ),
+            ),
+        ),
+        listOf(
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("a"),
+                    action = KeyAction.CommitText("a"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("s"),
+                    action = KeyAction.CommitText("s"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                swipes = mapOf(
+                    SwipeDirection.RIGHT to KeyC(
+                        display = null,
+                        action = KeyAction.CommitText("f"),
+                    ),
+                    SwipeDirection.LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("f"),
+                        action = KeyAction.CommitText("f"),
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("d"),
+                        action = KeyAction.CommitText("d"),
+                    ),
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay(" "),
+                    action = KeyAction.CommitText(" "),
+                ),
+                swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                swipes = mapOf(
+                    SwipeDirection.LEFT to KeyC(
+                        action = KeyAction.SendEvent(
+                            KeyEvent(
+                                KeyEvent.ACTION_DOWN,
+                                KeyEvent.KEYCODE_DPAD_LEFT,
+                            ),
+                        ),
+                        display = null,
+                    ),
+                    SwipeDirection.RIGHT to KeyC(
+                        action = KeyAction.SendEvent(
+                            KeyEvent(
+                                KeyEvent.ACTION_DOWN,
+                                KeyEvent.KEYCODE_DPAD_RIGHT,
+                            ),
+                        ),
+                        display = null,
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay(","),
+                        action = KeyAction.CommitText(","),
+                        color = ColorVariant.MUTED,
+                    ),
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("'"),
+                        action = KeyAction.CommitText("'"),
+                        color = ColorVariant.MUTED,
+                    ),
+                ),
+                nextTapActions = listOf(
+                    KeyAction.ReplaceLastText(", ", trimCount = 1),
+                    KeyAction.ReplaceLastText(". "),
+                    KeyAction.ReplaceLastText("? "),
+                    KeyAction.ReplaceLastText("! "),
+                    KeyAction.ReplaceLastText(": "),
+                    KeyAction.ReplaceLastText("; "),
+                ),
+                backgroundColor = ColorVariant.SURFACE_VARIANT,
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("h"),
+                    action = KeyAction.CommitText("h"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.TWO_WAY_VERTICAL,
+                swipes = mapOf(
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("g"),
+                        action = KeyAction.CommitText("g"),
+                    ),
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("l"),
+                    action = KeyAction.CommitText("l"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                swipes = mapOf(
+                    SwipeDirection.RIGHT to KeyC(
+                        display = null,
+                        action = KeyAction.CommitText("j"),
+                    ),
+                    SwipeDirection.LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("j"),
+                        action = KeyAction.CommitText("j"),
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("k"),
+                        action = KeyAction.CommitText("k"),
+                    ),
+                ),
+            ),
+        ),
+        listOf(
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("c"),
+                    action = KeyAction.CommitText("c"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                swipes = mapOf(
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("z"),
+                        action = KeyAction.CommitText("z"),
+                    ),
+                    SwipeDirection.LEFT to KeyC(
+                        display = null,
+                        action = KeyAction.CommitText("z"),
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("x"),
+                        action = KeyAction.CommitText("x"),
+                    ),
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("b"),
+                    action = KeyAction.CommitText("b"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.TWO_WAY_VERTICAL,
+                swipes = mapOf(
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("v"),
+                        action = KeyAction.CommitText("v"),
+                    ),
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay(" "),
+                    action = KeyAction.CommitText(" "),
+                ),
+                swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                swipes = mapOf(
+                    SwipeDirection.LEFT to KeyC(
+                        action = KeyAction.SendEvent(
+                            KeyEvent(
+                                KeyEvent.ACTION_DOWN,
+                                KeyEvent.KEYCODE_DPAD_LEFT,
+                            ),
+                        ),
+                        display = null,
+                    ),
+                    SwipeDirection.RIGHT to KeyC(
+                        action = KeyAction.SendEvent(
+                            KeyEvent(
+                                KeyEvent.ACTION_DOWN,
+                                KeyEvent.KEYCODE_DPAD_RIGHT,
+                            ),
+                        ),
+                        display = null,
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("."),
+                        action = KeyAction.CommitText("."),
+                        color = ColorVariant.MUTED,
+                    ),
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("-"),
+                        action = KeyAction.CommitText("-"),
+                        color = ColorVariant.MUTED,
+                    ),
+                ),
+                nextTapActions = listOf(
+                    KeyAction.ReplaceLastText(", ", trimCount = 1),
+                    KeyAction.ReplaceLastText(". "),
+                    KeyAction.ReplaceLastText("? "),
+                    KeyAction.ReplaceLastText("! "),
+                    KeyAction.ReplaceLastText(": "),
+                    KeyAction.ReplaceLastText("; "),
+                ),
+                backgroundColor = ColorVariant.SURFACE_VARIANT,
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("n"),
+                    action = KeyAction.CommitText("n"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("m"),
+                    action = KeyAction.CommitText("m"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+            ),
+        ),
+        listOf(
+            NUMERIC_KEY_ITEM,
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.IconDisplay(Icons.Outlined.KeyboardBackspace),
+                    action = KeyAction.SendEvent(
+                        KeyEvent(
+                            KeyEvent.ACTION_DOWN,
+                            KeyEvent
+                                .KEYCODE_DEL,
+                        ),
+                    ),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.SECONDARY,
+                ),
+                swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                swipes = mapOf(
+                    SwipeDirection.LEFT to KeyC(
+                        action = KeyAction.DeleteLastWord,
+                        display = null,
+                    ),
+                    SwipeDirection.RIGHT to KeyC(
+                        action = KeyAction.SendEvent(
+                            KeyEvent(
+                                KeyEvent.ACTION_DOWN,
+                                KeyEvent
+                                    .KEYCODE_FORWARD_DEL,
+                            ),
+                        ),
+                        display = null,
+                        color = ColorVariant.MUTED,
+                        size = FontSizeVariant.SMALLEST,
+                    ),
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
+                        action = KeyAction.ToggleShiftMode(true),
+                        color = ColorVariant.SECONDARY,
+                    ),
+                ),
+                widthMultiplier = 3,
+                backgroundColor = ColorVariant.SURFACE_VARIANT,
+            ),
+            RETURN_KEY_ITEM,
+        ),
+    ),
+)
+
+val FOUR_COLUMNS_EN_V1_SHIFTED = KeyboardC(
+    listOf(
+        listOf(
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("E"),
+                    action = KeyAction.CommitText("E"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                swipes = mapOf(
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("Q"),
+                        action = KeyAction.CommitText("Q"),
+                    ),
+                    SwipeDirection.LEFT to KeyC(
+                        display = null,
+                        action = KeyAction.CommitText("Q"),
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("W"),
+                        action = KeyAction.CommitText("W"),
+                    ),
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("T"),
+                    action = KeyAction.CommitText("T"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.TWO_WAY_VERTICAL,
+                swipes = mapOf(
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("R"),
+                        action = KeyAction.CommitText("R"),
+                    ),
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay(" "),
+                    action = KeyAction.CommitText(" "),
+                ),
+                swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                swipes = mapOf(
+                    SwipeDirection.LEFT to KeyC(
+                        action = KeyAction.SendEvent(
+                            KeyEvent(
+                                KeyEvent.ACTION_DOWN,
+                                KeyEvent.KEYCODE_DPAD_LEFT,
+                            ),
+                        ),
+                        display = null,
+                    ),
+                    SwipeDirection.RIGHT to KeyC(
+                        action = KeyAction.SendEvent(
+                            KeyEvent(
+                                KeyEvent.ACTION_DOWN,
+                                KeyEvent.KEYCODE_DPAD_RIGHT,
+                            ),
+                        ),
+                        display = null,
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("*"),
+                        action = KeyAction.CommitText("*"),
+                        color = ColorVariant.MUTED,
+                    ),
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.IconDisplay(Icons.Outlined.Settings),
+                        action = KeyAction.GotoSettings,
+                        color = ColorVariant.SECONDARY,
+                    ),
+                ),
+                nextTapActions = listOf(
+                    KeyAction.ReplaceLastText(", ", trimCount = 1),
+                    KeyAction.ReplaceLastText(". "),
+                    KeyAction.ReplaceLastText("? "),
+                    KeyAction.ReplaceLastText("! "),
+                    KeyAction.ReplaceLastText(": "),
+                    KeyAction.ReplaceLastText("; "),
+                ),
+                backgroundColor = ColorVariant.SURFACE_VARIANT,
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("I"),
+                    action = KeyAction.CommitText("I"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                swipes = mapOf(
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("Y"),
+                        action = KeyAction.CommitText("Y"),
+                    ),
+                    SwipeDirection.LEFT to KeyC(
+                        display = null,
+                        action = KeyAction.CommitText("Y"),
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("U"),
+                        action = KeyAction.CommitText("U"),
+                    ),
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("O"),
+                    action = KeyAction.CommitText("O"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.TWO_WAY_VERTICAL,
+                swipes = mapOf(
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("P"),
+                        action = KeyAction.CommitText("P"),
+                    ),
+                ),
+            ),
+        ),
+        listOf(
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("A"),
+                    action = KeyAction.CommitText("A"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("S"),
+                    action = KeyAction.CommitText("S"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                swipes = mapOf(
+                    SwipeDirection.RIGHT to KeyC(
+                        display = null,
+                        action = KeyAction.CommitText("F"),
+                    ),
+                    SwipeDirection.LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("F"),
+                        action = KeyAction.CommitText("F"),
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("D"),
+                        action = KeyAction.CommitText("D"),
+                    ),
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay(" "),
+                    action = KeyAction.CommitText(" "),
+                ),
+                swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                swipes = mapOf(
+                    SwipeDirection.LEFT to KeyC(
+                        action = KeyAction.SendEvent(
+                            KeyEvent(
+                                KeyEvent.ACTION_DOWN,
+                                KeyEvent.KEYCODE_DPAD_LEFT,
+                            ),
+                        ),
+                        display = null,
+                    ),
+                    SwipeDirection.RIGHT to KeyC(
+                        action = KeyAction.SendEvent(
+                            KeyEvent(
+                                KeyEvent.ACTION_DOWN,
+                                KeyEvent.KEYCODE_DPAD_RIGHT,
+                            ),
+                        ),
+                        display = null,
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay(","),
+                        action = KeyAction.CommitText(","),
+                        color = ColorVariant.MUTED,
+                    ),
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("'"),
+                        action = KeyAction.CommitText("'"),
+                        color = ColorVariant.MUTED,
+                    ),
+                ),
+                nextTapActions = listOf(
+                    KeyAction.ReplaceLastText(", ", trimCount = 1),
+                    KeyAction.ReplaceLastText(". "),
+                    KeyAction.ReplaceLastText("? "),
+                    KeyAction.ReplaceLastText("! "),
+                    KeyAction.ReplaceLastText(": "),
+                    KeyAction.ReplaceLastText("; "),
+                ),
+                backgroundColor = ColorVariant.SURFACE_VARIANT,
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("H"),
+                    action = KeyAction.CommitText("H"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.TWO_WAY_VERTICAL,
+                swipes = mapOf(
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("G"),
+                        action = KeyAction.CommitText("G"),
+                    ),
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("L"),
+                    action = KeyAction.CommitText("L"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                swipes = mapOf(
+                    SwipeDirection.RIGHT to KeyC(
+                        display = null,
+                        action = KeyAction.CommitText("J"),
+                    ),
+                    SwipeDirection.LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("J"),
+                        action = KeyAction.CommitText("J"),
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("K"),
+                        action = KeyAction.CommitText("K"),
+                    ),
+                ),
+            ),
+        ),
+        listOf(
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("C"),
+                    action = KeyAction.CommitText("C"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                swipes = mapOf(
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("Z"),
+                        action = KeyAction.CommitText("Z"),
+                    ),
+                    SwipeDirection.LEFT to KeyC(
+                        display = null,
+                        action = KeyAction.CommitText("Z"),
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("X"),
+                        action = KeyAction.CommitText("X"),
+                    ),
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("B"),
+                    action = KeyAction.CommitText("B"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.TWO_WAY_VERTICAL,
+                swipes = mapOf(
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("V"),
+                        action = KeyAction.CommitText("V"),
+                    ),
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay(" "),
+                    action = KeyAction.CommitText(" "),
+                ),
+                swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                swipes = mapOf(
+                    SwipeDirection.LEFT to KeyC(
+                        action = KeyAction.SendEvent(
+                            KeyEvent(
+                                KeyEvent.ACTION_DOWN,
+                                KeyEvent.KEYCODE_DPAD_LEFT,
+                            ),
+                        ),
+                        display = null,
+                    ),
+                    SwipeDirection.RIGHT to KeyC(
+                        action = KeyAction.SendEvent(
+                            KeyEvent(
+                                KeyEvent.ACTION_DOWN,
+                                KeyEvent.KEYCODE_DPAD_RIGHT,
+                            ),
+                        ),
+                        display = null,
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("."),
+                        action = KeyAction.CommitText("."),
+                        color = ColorVariant.MUTED,
+                    ),
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("-"),
+                        action = KeyAction.CommitText("-"),
+                        color = ColorVariant.MUTED,
+                    ),
+                ),
+                nextTapActions = listOf(
+                    KeyAction.ReplaceLastText(", ", trimCount = 1),
+                    KeyAction.ReplaceLastText(". "),
+                    KeyAction.ReplaceLastText("? "),
+                    KeyAction.ReplaceLastText("! "),
+                    KeyAction.ReplaceLastText(": "),
+                    KeyAction.ReplaceLastText("; "),
+                ),
+                backgroundColor = ColorVariant.SURFACE_VARIANT,
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("N"),
+                    action = KeyAction.CommitText("N"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("M"),
+                    action = KeyAction.CommitText("M"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+            ),
+        ),
+        listOf(
+            NUMERIC_KEY_ITEM,
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.IconDisplay(Icons.Outlined.KeyboardBackspace),
+                    action = KeyAction.SendEvent(
+                        KeyEvent(
+                            KeyEvent.ACTION_DOWN,
+                            KeyEvent
+                                .KEYCODE_DEL,
+                        ),
+                    ),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.SECONDARY,
+                ),
+                swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                swipes = mapOf(
+                    SwipeDirection.LEFT to KeyC(
+                        action = KeyAction.DeleteLastWord,
+                        display = null,
+                    ),
+                    SwipeDirection.RIGHT to KeyC(
+                        action = KeyAction.SendEvent(
+                            KeyEvent(
+                                KeyEvent.ACTION_DOWN,
+                                KeyEvent
+                                    .KEYCODE_FORWARD_DEL,
+                            ),
+                        ),
+                        display = null,
+                        color = ColorVariant.MUTED,
+                        size = FontSizeVariant.SMALLEST,
+                    ),
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.IconDisplay(Icons.Outlined.KeyboardCapslock),
+                        capsModeDisplay = KeyDisplay.IconDisplay(Icons.Outlined.Copyright),
+                        action = KeyAction.ToggleCapsLock,
+                        color = ColorVariant.SECONDARY,
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
+                        action = KeyAction.ToggleShiftMode(false),
+                        color = ColorVariant.SECONDARY,
+                    ),
+                ),
+                widthMultiplier = 3,
+                backgroundColor = ColorVariant.SURFACE_VARIANT,
+            ),
+            RETURN_KEY_ITEM,
+        ),
+    ),
+)
+
+val FOUR_COLUMNS_EN_V1_KEYBOARD_MODES: Map<KeyboardMode, KeyboardC> = mapOf(
+    KeyboardMode.MAIN to FOUR_COLUMNS_EN_V1,
+    KeyboardMode.SHIFTED to FOUR_COLUMNS_EN_V1_SHIFTED,
+    KeyboardMode.NUMERIC to NUMERIC_KEYBOARD,
+)

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
@@ -129,6 +129,7 @@ enum class KeyboardLayout(val title: String, val index: Int) {
     ThumbKeyFRv2("Thumb-Key français v2", 33),
     ThumbKeySVv1("Thumb-Key svenska v1", 34),
     ThumbKeyTRv1("Thumb-Key Türkçe v1", 35),
+    FourColumnsENv1("v. Four Columns english v1", 36),
 }
 
 enum class KeyboardPosition(private val stringId: Int) {

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -31,6 +31,7 @@ import com.dessalines.thumbkey.IMEService
 import com.dessalines.thumbkey.MainActivity
 import com.dessalines.thumbkey.R
 import com.dessalines.thumbkey.db.DEFAULT_KEYBOARD_LAYOUT
+import com.dessalines.thumbkey.keyboards.FOUR_COLUMNS_EN_V1_KEYBOARD_MODES
 import com.dessalines.thumbkey.keyboards.MESSAGEEASE_DE_KEYBOARD_MODES
 import com.dessalines.thumbkey.keyboards.MESSAGEEASE_EN_KEYBOARD_MODES
 import com.dessalines.thumbkey.keyboards.MESSAGEEASE_EN_SYMBOLS_KEYBOARD_MODES
@@ -136,6 +137,7 @@ fun keyboardLayoutToModes(layout: KeyboardLayout): Map<KeyboardMode, KeyboardC> 
         KeyboardLayout.ThumbKeyFRv2 -> THUMBKEY_FR_V2_KEYBOARD_MODES
         KeyboardLayout.ThumbKeySVv1 -> THUMBKEY_SV_V1_KEYBOARD_MODES
         KeyboardLayout.ThumbKeyTRv1 -> THUMBKEY_TR_V1_KEYBOARD_MODES
+        KeyboardLayout.FourColumnsENv1 -> FOUR_COLUMNS_EN_V1_KEYBOARD_MODES
     }
 }
 


### PR DESCRIPTION
<img src="https://github.com/dessalines/thumb-key/assets/8158663/3d5a95de-e199-4075-b889-e513222add2c" width=50%>


This layout introduces a fourth column for letters and switches to a vertical, centered spacebar.

The idea is that each thumb gets assigned to a couple of columns and that they can reach horizontally to alternate pressing the spacebar. It also works well with one handed typing.


#### Design points

The spacebar is the most used key by far. Trying to reduce thumb fatigue by having it through the middle of the keyboard to avoid reaching down to tap it.

Backspace positioned at the usual place of the spacebar and shift/caps-lock are set as vertical swipes there.

Avoids using diagonal swipes.

The key distribution is guided by the QWERTY layout for familiarity, but in a way that the most common letters are center key-taps.

#### Letter distribution logic

For each letter-row of a QWERTY layout, pick the 4 most common letters and assign them as center-keys.

```
qwertyuiop -> e | t | i | o
asdfghjkl -> a | s | h | l
zxcvbnm -> c | b | n | m
```

The remaining keys are set as swipes on their nearest center-key in their letter-row, taking care to balance the overall cumulative frequency for each key.

```
qw[e] | r[t] | y[i]u | [o]p
a | [s]df | g[h] | jk[l]
zx[c] | v[b] | [n] | [m]
```

Downward swipes are assigned for the second most frequent letter, both left and right swipes for the third most frequent letter and upwards swipes for the less frequent one.

Finally, the extra keys usually make it possible for accented letters to be set as swipes on the same key as their base letter.

~

I've sketched layouts for Deutch (qwertz), French (azerty), Italian, Portuguese, Spanish, and they work out to have 8 to 10 of their most common letters as center-keys (French is the exception, with 7 of them). If this layout fits within Thumb-Key, I'll do a pr with the layouts for them.

Spanish layout:
<img src="https://github.com/dessalines/thumb-key/assets/8158663/96bfa738-8d6a-4b83-b77c-1c86f78af8c3" width=50%>

I've been typing with these layouts for a few weeks and can touch-type by now :D.

I Used this study as a reference: "[Letter Frequency Analysis of Languages Using Latin Alphabet](https://core.ac.uk/download/pdf/231084615.pdf)" 

Note: the layout is titled "v. Four Columns english v1" so it goes to the bottom of the list.