### PR TITLE
Fix bug in deleteLastWord

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,19 @@
+# Thumb-Key 1.7.0 (2023-06-18)
+
+## What's Changed
+
+- Update Danish translation and fix minor errors in the Danish keyboard by @Limfjorden in https://github.com/dessalines/thumb-key/pull/286
+- Fix swedish keyboard by @maxhambraeus in https://github.com/dessalines/thumb-key/pull/287
+- Update ThumbKeyIDv1Symbols.kt by @awandepan in https://github.com/dessalines/thumb-key/pull/289
+- New layout: "Four columns" (English). by @mockballed in https://github.com/dessalines/thumb-key/pull/292
+- Add debug mode. by @dessalines in https://github.com/dessalines/thumb-key/pull/294
+
+## New Contributors
+
+- @maxhambraeus made their first contribution in https://github.com/dessalines/thumb-key/pull/287
+
+**Full Changelog**: https://github.com/dessalines/thumb-key/compare/1.6.1...1.7.0
+
 # Thumb-Key 1.6.1 (2023-06-10)
 
 ## What's Changed

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.TextUnitType
-import androidx.core.text.trimmedLength
 import androidx.navigation.NavController
 import com.dessalines.thumbkey.IMEService
 import com.dessalines.thumbkey.MainActivity

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -386,14 +386,10 @@ fun autoCapitalizeCheck(
 fun deleteLastWord(ime: IMEService) {
     val lastWords = ime.currentInputConnection.getTextBeforeCursor(100, 0)
 
-    val trimmedLength = lastWords?.length?.minus(lastWords.trimmedLength()) ?: 0
+    val trailingSpacesLength = lastWords?.length?.minus(lastWords.trimEnd().length) ?: 0
     val trimmed = lastWords?.trim()
     val lastWordLength = trimmed?.split("\\s".toRegex())?.lastOrNull()?.length ?: 1
-    val minDelete = if (lastWordLength > 0) {
-        lastWordLength + trimmedLength
-    } else {
-        1
-    }
+    val minDelete = lastWordLength + trailingSpacesLength
 
     ime.currentInputConnection.deleteSurroundingText(minDelete, 0)
 }


### PR DESCRIPTION
This fixes a bug I found when swiping left on the delete key to delete the last word: Sometimes, it deletes not only the last word, but also the space (in rare cases even more) before it.

This can be easily seen by starting out in an empty text field and typing a space and then a word, like: 

> ` word|`

(vertical bar is cursor)

Here, hitting `deleteLastWord` deletes the last word plus the preceding space.

For a more extreme example, watch what happens when you type five spaces and then some words:

> `     more words|`

Here, hitting `deleteLastWord` deletes the last two words at once, leaving only the leading five spaces.

This unwanted behavior happens whenever the char-sequence `lastWords` in the function `deleteLastWord`, which contains the last 100 characters, begins with a space. Then the spaces up to the first non-whitespace character are added to the number of characters to be deleted.

I found out about this because after typing more than 100 characters into a text field, it happens quite often that the first of the last 100 characters is a space, so the space before the word is deleted along with it.

For example:

> word word word word word word word word word word word word word word word word word word word word one two|

Expected result after hitting `deleteLastWord`:

> word word word word word word word word word word word word word word word word word word word word one |

Unexpected result after hitting `deleteLastWord` again:

> word word word word word word word word word word word word word word word word word word word word|

Apart from removing this inconsistency, I changed the function so that when there is no last word, meaning there are only spaces in a text field, `deleteLastWord` doesn't default to deleting just one character but instead deletes all of the spaces. This is not important and completely unrelated to the bug fix, just something I thought I would want the button to do.