### PR TITLE
Add single quote to MessageEase German

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/MessageEaseDE.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/MessageEaseDE.kt
@@ -260,6 +260,11 @@ val MESSAGEEASE_DE_MAIN = KeyboardC(
                         ),
                         color = ColorVariant.MUTED,
                     ),
+                    SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("'"),
+                        action = KeyAction.CommitText("'"),
+                        color = ColorVariant.MUTED,
+                    ),
                     SwipeDirection.BOTTOM_LEFT to KeyC(
                         display = KeyDisplay.TextDisplay(","),
                         action = KeyAction.CommitText(","),


### PR DESCRIPTION
In MessageEase, the single quote is in the same position in the German layout as in the English layout.
<img src="https://www.exideas.com/ME/keyboardPix/keyboardGermanWElegantFont.png" width="200">
In Thumbkey however, it was missing from the German layout.

I just copied over the relevant part of the keymap from the `MessageEaseEn.kt` file.

I don't have an Android development setup and therefore could not run or test the code, but since it's just some copy-paste I could do that in a simple text editor. But in case of doubts, please test that it works.