### PR TITLE
まみむめも=>ゔ

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ThumbKeyJAv1Hiragana.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ThumbKeyJAv1Hiragana.kt
@@ -302,29 +302,10 @@ val THUMBKEY_JA_V1_HIRAGANA_SHIFTED = KeyboardC(
         listOf(
             KeyItemC(
                 center = KeyC(
-                    display = KeyDisplay.TextDisplay("ま"),
-                    action = KeyAction.CommitText("ま"),
+                    display = KeyDisplay.TextDisplay("ゔ"),
+                    action = KeyAction.CommitText("ゔ"),
                     size = FontSizeVariant.LARGE,
                     color = ColorVariant.PRIMARY,
-                ),
-                swipeType = SwipeNWay.FOUR_WAY_CROSS,
-                swipes = mapOf(
-                    SwipeDirection.BOTTOM to KeyC(
-                        display = KeyDisplay.TextDisplay("み"),
-                        action = KeyAction.CommitText("み"),
-                    ),
-                    SwipeDirection.LEFT to KeyC(
-                        display = KeyDisplay.TextDisplay("む"),
-                        action = KeyAction.CommitText("む"),
-                    ),
-                    SwipeDirection.TOP to KeyC(
-                        display = KeyDisplay.TextDisplay("め"),
-                        action = KeyAction.CommitText("め"),
-                    ),
-                    SwipeDirection.RIGHT to KeyC(
-                        display = KeyDisplay.TextDisplay("も"),
-                        action = KeyAction.CommitText("も"),
-                    ),
                 ),
             ),
             KeyItemC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ThumbKeyJAv1Katakana.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ThumbKeyJAv1Katakana.kt
@@ -302,29 +302,10 @@ val THUMBKEY_JA_V1_KATAKANA_SHIFTED = KeyboardC(
         listOf(
             KeyItemC(
                 center = KeyC(
-                    display = KeyDisplay.TextDisplay("マ"),
-                    action = KeyAction.CommitText("マ"),
+                    display = KeyDisplay.TextDisplay("ヴ"),
+                    action = KeyAction.CommitText("ヴ"),
                     size = FontSizeVariant.LARGE,
                     color = ColorVariant.PRIMARY,
-                ),
-                swipeType = SwipeNWay.FOUR_WAY_CROSS,
-                swipes = mapOf(
-                    SwipeDirection.BOTTOM to KeyC(
-                        display = KeyDisplay.TextDisplay("ミ"),
-                        action = KeyAction.CommitText("ミ"),
-                    ),
-                    SwipeDirection.LEFT to KeyC(
-                        display = KeyDisplay.TextDisplay("ム"),
-                        action = KeyAction.CommitText("ム"),
-                    ),
-                    SwipeDirection.TOP to KeyC(
-                        display = KeyDisplay.TextDisplay("メ"),
-                        action = KeyAction.CommitText("メ"),
-                    ),
-                    SwipeDirection.RIGHT to KeyC(
-                        display = KeyDisplay.TextDisplay("モ"),
-                        action = KeyAction.CommitText("モ"),
-                    ),
                 ),
             ),
             KeyItemC(


### PR DESCRIPTION
"ま","み","む","め","も"/"マ","ミ","ム","メ","モ" are included in THUMBKEY_JA_V1_HIRAGANA/KATAKANA so are not necessary in THUMBKEY_JA_V1_HIRAGANA/KATAKANA_SHIFTED, while "ゔ"/"ヴ" are not included in any keyboard. So I deleted "ま","み","む","め","も"/"マ","ミ","ム","メ","モ" from THUMBKEY_JA_V1_HIRAGANA/KATAKANA_SHIFTED, and added "ゔ"/"ヴ". "ま","み","む","め","も"/"マ","ミ","ム","メ","モ" is still available in THUMBKEY_JA_V1_HIRAGANA/KATAKANA.
Sorry for opening same pull request twice.