### PR TITLE
Add ENv4MultiLayout

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ThumbKeyENv4Multi.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ThumbKeyENv4Multi.kt
@@ -28,7 +28,7 @@ val THUMBKEY_EN_V4_MULTI_MAIN = KeyboardC(
                 ),
                 swipeType = SwipeNWay.EIGHT_WAY,
                 swipes = mapOf(
-					SwipeDirection.TOP to KeyC(
+                    SwipeDirection.TOP to KeyC(
                         display = KeyDisplay.TextDisplay("š"),
                         action = KeyAction.CommitText("š"),
                     ),
@@ -36,7 +36,7 @@ val THUMBKEY_EN_V4_MULTI_MAIN = KeyboardC(
                         display = KeyDisplay.TextDisplay("w"),
                         action = KeyAction.CommitText("w"),
                     ),
-					SwipeDirection.LEFT to KeyC(
+                    SwipeDirection.LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("ô"),
                         action = KeyAction.CommitText("ô"),
                     ),
@@ -51,7 +51,7 @@ val THUMBKEY_EN_V4_MULTI_MAIN = KeyboardC(
                 ),
                 swipeType = SwipeNWay.TWO_WAY_VERTICAL,
                 swipes = mapOf(
-					SwipeDirection.TOP to KeyC(
+                    SwipeDirection.TOP to KeyC(
                         display = KeyDisplay.TextDisplay("ŕ"),
                         action = KeyAction.CommitText("ŕ"),
                     ),
@@ -70,14 +70,14 @@ val THUMBKEY_EN_V4_MULTI_MAIN = KeyboardC(
                 ),
                 swipeType = SwipeNWay.EIGHT_WAY,
                 swipes = mapOf(
-					SwipeDirection.TOP to KeyC(
+                    SwipeDirection.TOP to KeyC(
                         display = KeyDisplay.TextDisplay("ó"),
                         action = KeyAction.CommitText("ó"),
                     ),
-					SwipeDirection.BOTTOM_RIGHT to KeyC(
-						display = KeyDisplay.TextDisplay("ú"),
-						action = KeyAction.CommitText("ú"),
-					),
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("ú"),
+                        action = KeyAction.CommitText("ú"),
+                    ),
                     SwipeDirection.BOTTOM_LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("u"),
                         action = KeyAction.CommitText("u"),
@@ -96,7 +96,7 @@ val THUMBKEY_EN_V4_MULTI_MAIN = KeyboardC(
                 ),
                 swipeType = SwipeNWay.FOUR_WAY_CROSS,
                 swipes = mapOf(
-					SwipeDirection.TOP to KeyC(
+                    SwipeDirection.TOP to KeyC(
                         display = KeyDisplay.TextDisplay("ň"),
                         action = KeyAction.CommitText("ň"),
                     ),
@@ -104,7 +104,7 @@ val THUMBKEY_EN_V4_MULTI_MAIN = KeyboardC(
                         display = KeyDisplay.TextDisplay("m"),
                         action = KeyAction.CommitText("m"),
                     ),
-					SwipeDirection.LEFT to KeyC(
+                    SwipeDirection.LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("ä"),
                         action = KeyAction.CommitText("ä"),
                     ),
@@ -117,7 +117,7 @@ val THUMBKEY_EN_V4_MULTI_MAIN = KeyboardC(
                     size = FontSizeVariant.LARGE,
                     color = ColorVariant.PRIMARY,
                 ),
-				swipeType = SwipeNWay.EIGHT_WAY,
+                swipeType = SwipeNWay.EIGHT_WAY,
                 swipes = mapOf(
                     SwipeDirection.TOP_LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("j"),
@@ -162,24 +162,24 @@ val THUMBKEY_EN_V4_MULTI_MAIN = KeyboardC(
                 ),
                 swipeType = SwipeNWay.EIGHT_WAY,
                 swipes = mapOf(
-					SwipeDirection.TOP_LEFT to KeyC(
+                    SwipeDirection.TOP_LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("ĺ"),
                         action = KeyAction.CommitText("ĺ"),
                     ),
-					SwipeDirection.TOP to KeyC(
-						display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
-						action = KeyAction.ToggleShiftMode(true),
-						color = ColorVariant.MUTED,
-					),
-					SwipeDirection.TOP_RIGHT to KeyC(
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
+                        action = KeyAction.ToggleShiftMode(true),
+                        color = ColorVariant.MUTED,
+                    ),
+                    SwipeDirection.TOP_RIGHT to KeyC(
                         display = KeyDisplay.TextDisplay("á"),
                         action = KeyAction.CommitText("á"),
                     ),
-					SwipeDirection.BOTTOM_RIGHT to KeyC(
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
                         display = KeyDisplay.TextDisplay("ý"),
                         action = KeyAction.CommitText("ý"),
                     ),
-					SwipeDirection.BOTTOM_LEFT to KeyC(
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("ľ"),
                         action = KeyAction.CommitText("ľ"),
                     ),
@@ -201,7 +201,7 @@ val THUMBKEY_EN_V4_MULTI_MAIN = KeyboardC(
                 ),
                 swipeType = SwipeNWay.EIGHT_WAY,
                 swipes = mapOf(
-					SwipeDirection.TOP to KeyC(
+                    SwipeDirection.TOP to KeyC(
                         display = KeyDisplay.TextDisplay("ť"),
                         action = KeyAction.CommitText("ť"),
                     ),
@@ -209,7 +209,7 @@ val THUMBKEY_EN_V4_MULTI_MAIN = KeyboardC(
                         display = KeyDisplay.TextDisplay("c"),
                         action = KeyAction.CommitText("c"),
                     ),
-					SwipeDirection.BOTTOM_RIGHT to KeyC(
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
                         display = KeyDisplay.TextDisplay("č"),
                         action = KeyAction.CommitText("č"),
                     ),
@@ -222,9 +222,9 @@ val THUMBKEY_EN_V4_MULTI_MAIN = KeyboardC(
                     size = FontSizeVariant.LARGE,
                     color = ColorVariant.PRIMARY,
                 ),
-				swipeType = SwipeNWay.EIGHT_WAY,
+                swipeType = SwipeNWay.EIGHT_WAY,
                 swipes = mapOf(
-					SwipeDirection.TOP_LEFT to KeyC(
+                    SwipeDirection.TOP_LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("í"),
                         action = KeyAction.CommitText("í"),
                     ),
@@ -271,15 +271,15 @@ val THUMBKEY_EN_V4_MULTI_MAIN = KeyboardC(
                         display = KeyDisplay.TextDisplay("d"),
                         action = KeyAction.CommitText("d"),
                     ),
-					SwipeDirection.TOP to KeyC(
+                    SwipeDirection.TOP to KeyC(
                         display = KeyDisplay.TextDisplay("é"),
                         action = KeyAction.CommitText("é"),
                     ),
-					SwipeDirection.RIGHT to KeyC(
+                    SwipeDirection.RIGHT to KeyC(
                         display = KeyDisplay.TextDisplay("ž"),
                         action = KeyAction.CommitText("ž"),
                     ),
-					SwipeDirection.BOTTOM_LEFT to KeyC(
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("ď"),
                         action = KeyAction.CommitText("ď"),
                     ),
@@ -306,7 +306,7 @@ val THUMBKEY_EN_V4_MULTI_SHIFTED = KeyboardC(
                 ),
                 swipeType = SwipeNWay.EIGHT_WAY,
                 swipes = mapOf(
-					SwipeDirection.TOP to KeyC(
+                    SwipeDirection.TOP to KeyC(
                         display = KeyDisplay.TextDisplay("Š"),
                         action = KeyAction.CommitText("Š"),
                     ),
@@ -314,7 +314,7 @@ val THUMBKEY_EN_V4_MULTI_SHIFTED = KeyboardC(
                         display = KeyDisplay.TextDisplay("W"),
                         action = KeyAction.CommitText("W"),
                     ),
-					SwipeDirection.LEFT to KeyC(
+                    SwipeDirection.LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("Ô"),
                         action = KeyAction.CommitText("Ô"),
                     ),
@@ -329,7 +329,7 @@ val THUMBKEY_EN_V4_MULTI_SHIFTED = KeyboardC(
                 ),
                 swipeType = SwipeNWay.TWO_WAY_VERTICAL,
                 swipes = mapOf(
-					SwipeDirection.TOP to KeyC(
+                    SwipeDirection.TOP to KeyC(
                         display = KeyDisplay.TextDisplay("Ŕ"),
                         action = KeyAction.CommitText("Ŕ"),
                     ),
@@ -348,11 +348,11 @@ val THUMBKEY_EN_V4_MULTI_SHIFTED = KeyboardC(
                 ),
                 swipeType = SwipeNWay.EIGHT_WAY,
                 swipes = mapOf(
-					SwipeDirection.TOP to KeyC(
+                    SwipeDirection.TOP to KeyC(
                         display = KeyDisplay.TextDisplay("Ó"),
                         action = KeyAction.CommitText("Ó"),
                     ),
-					SwipeDirection.BOTTOM_RIGHT to KeyC(
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
                         display = KeyDisplay.TextDisplay("Ú"),
                         action = KeyAction.CommitText("Ú"),
                     ),
@@ -374,7 +374,7 @@ val THUMBKEY_EN_V4_MULTI_SHIFTED = KeyboardC(
                 ),
                 swipeType = SwipeNWay.FOUR_WAY_CROSS,
                 swipes = mapOf(
-					SwipeDirection.TOP to KeyC(
+                    SwipeDirection.TOP to KeyC(
                         display = KeyDisplay.TextDisplay("Ň"),
                         action = KeyAction.CommitText("Ň"),
                     ),
@@ -382,7 +382,7 @@ val THUMBKEY_EN_V4_MULTI_SHIFTED = KeyboardC(
                         display = KeyDisplay.TextDisplay("M"),
                         action = KeyAction.CommitText("M"),
                     ),
-					SwipeDirection.LEFT to KeyC(
+                    SwipeDirection.LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("Ä"),
                         action = KeyAction.CommitText("Ä"),
                     ),
@@ -395,7 +395,7 @@ val THUMBKEY_EN_V4_MULTI_SHIFTED = KeyboardC(
                     size = FontSizeVariant.LARGE,
                     color = ColorVariant.PRIMARY,
                 ),
-				swipeType = SwipeNWay.EIGHT_WAY,
+                swipeType = SwipeNWay.EIGHT_WAY,
                 swipes = mapOf(
                     SwipeDirection.TOP_LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("J"),
@@ -440,34 +440,34 @@ val THUMBKEY_EN_V4_MULTI_SHIFTED = KeyboardC(
                 ),
                 swipeType = SwipeNWay.EIGHT_WAY,
                 swipes = mapOf(
-					SwipeDirection.TOP_LEFT to KeyC(
+                    SwipeDirection.TOP_LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("Ĺ"),
                         action = KeyAction.CommitText("Ĺ"),
                     ),
-					SwipeDirection.TOP to KeyC(
+                    SwipeDirection.TOP to KeyC(
                         display = KeyDisplay.IconDisplay(Icons.Outlined.KeyboardCapslock),
                         capsModeDisplay = KeyDisplay.IconDisplay(Icons.Outlined.Copyright),
                         action = KeyAction.ToggleCapsLock,
                         color = ColorVariant.MUTED,
                     ),
-					SwipeDirection.TOP_RIGHT to KeyC(
+                    SwipeDirection.TOP_RIGHT to KeyC(
                         display = KeyDisplay.TextDisplay("Á"),
                         action = KeyAction.CommitText("Á"),
                     ),
-					SwipeDirection.BOTTOM_RIGHT to KeyC(
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
                         display = KeyDisplay.TextDisplay("Ý"),
                         action = KeyAction.CommitText("Ý"),
                     ),
-					SwipeDirection.BOTTOM to KeyC(
+                    SwipeDirection.BOTTOM to KeyC(
                         display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
                         action = KeyAction.ToggleShiftMode(false),
                         color = ColorVariant.MUTED,
-					),
-					SwipeDirection.BOTTOM_LEFT to KeyC(
-						display = KeyDisplay.TextDisplay("Ľ"),
-						action = KeyAction.CommitText("Ľ"),
-					),
-					SwipeDirection.LEFT to KeyC(
+                    ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("Ľ"),
+                        action = KeyAction.CommitText("Ľ"),
+                    ),
+                    SwipeDirection.LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("L"),
                         action = KeyAction.CommitText("L"),
                     ),
@@ -485,7 +485,7 @@ val THUMBKEY_EN_V4_MULTI_SHIFTED = KeyboardC(
                 ),
                 swipeType = SwipeNWay.EIGHT_WAY,
                 swipes = mapOf(
-					SwipeDirection.TOP to KeyC(
+                    SwipeDirection.TOP to KeyC(
                         display = KeyDisplay.TextDisplay("Ť"),
                         action = KeyAction.CommitText("Ť"),
                     ),
@@ -493,7 +493,7 @@ val THUMBKEY_EN_V4_MULTI_SHIFTED = KeyboardC(
                         display = KeyDisplay.TextDisplay("C"),
                         action = KeyAction.CommitText("C"),
                     ),
-					SwipeDirection.BOTTOM_RIGHT to KeyC(
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
                         display = KeyDisplay.TextDisplay("Č"),
                         action = KeyAction.CommitText("Č"),
                     ),
@@ -506,9 +506,9 @@ val THUMBKEY_EN_V4_MULTI_SHIFTED = KeyboardC(
                     size = FontSizeVariant.LARGE,
                     color = ColorVariant.PRIMARY,
                 ),
-				swipeType = SwipeNWay.EIGHT_WAY,
+                swipeType = SwipeNWay.EIGHT_WAY,
                 swipes = mapOf(
-					SwipeDirection.TOP_LEFT to KeyC(
+                    SwipeDirection.TOP_LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("Í"),
                         action = KeyAction.CommitText("Í"),
                         color = ColorVariant.MUTED,
@@ -556,15 +556,15 @@ val THUMBKEY_EN_V4_MULTI_SHIFTED = KeyboardC(
                         display = KeyDisplay.TextDisplay("D"),
                         action = KeyAction.CommitText("D"),
                     ),
-					SwipeDirection.TOP to KeyC(
+                    SwipeDirection.TOP to KeyC(
                         display = KeyDisplay.TextDisplay("É"),
                         action = KeyAction.CommitText("É"),
                     ),
-					SwipeDirection.RIGHT to KeyC(
+                    SwipeDirection.RIGHT to KeyC(
                         display = KeyDisplay.TextDisplay("Ž"),
                         action = KeyAction.CommitText("Ž"),
                     ),
-					SwipeDirection.BOTTOM_LEFT to KeyC(
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("Ď"),
                         action = KeyAction.CommitText("Ď"),
                     ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ThumbKeyENv4Multi.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ThumbKeyENv4Multi.kt
@@ -1,0 +1,586 @@
+package com.dessalines.thumbkey.keyboards
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowDropDown
+import androidx.compose.material.icons.outlined.ArrowDropUp
+import androidx.compose.material.icons.outlined.Copyright
+import androidx.compose.material.icons.outlined.KeyboardCapslock
+import com.dessalines.thumbkey.utils.ColorVariant
+import com.dessalines.thumbkey.utils.FontSizeVariant
+import com.dessalines.thumbkey.utils.KeyAction
+import com.dessalines.thumbkey.utils.KeyC
+import com.dessalines.thumbkey.utils.KeyDisplay
+import com.dessalines.thumbkey.utils.KeyItemC
+import com.dessalines.thumbkey.utils.KeyboardC
+import com.dessalines.thumbkey.utils.KeyboardMode
+import com.dessalines.thumbkey.utils.SwipeDirection
+import com.dessalines.thumbkey.utils.SwipeNWay
+
+val THUMBKEY_EN_V4_MULTI_MAIN = KeyboardC(
+    listOf(
+        listOf(
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("s"),
+                    action = KeyAction.CommitText("s"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.EIGHT_WAY,
+                swipes = mapOf(
+					SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("š"),
+                        action = KeyAction.CommitText("š"),
+                    ),
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("w"),
+                        action = KeyAction.CommitText("w"),
+                    ),
+					SwipeDirection.LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("ô"),
+                        action = KeyAction.CommitText("ô"),
+                    ),
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("r"),
+                    action = KeyAction.CommitText("r"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.TWO_WAY_VERTICAL,
+                swipes = mapOf(
+					SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("ŕ"),
+                        action = KeyAction.CommitText("ŕ"),
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("g"),
+                        action = KeyAction.CommitText("g"),
+                    ),
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("o"),
+                    action = KeyAction.CommitText("o"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.EIGHT_WAY,
+                swipes = mapOf(
+					SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("ó"),
+                        action = KeyAction.CommitText("ó"),
+                    ),
+					SwipeDirection.BOTTOM_RIGHT to KeyC(
+						display = KeyDisplay.TextDisplay("ú"),
+						action = KeyAction.CommitText("ú"),
+					),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("u"),
+                        action = KeyAction.CommitText("u"),
+                    ),
+                ),
+            ),
+            SETTINGS_KEY_ITEM,
+        ),
+        listOf(
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("n"),
+                    action = KeyAction.CommitText("n"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                swipes = mapOf(
+					SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("ň"),
+                        action = KeyAction.CommitText("ň"),
+                    ),
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("m"),
+                        action = KeyAction.CommitText("m"),
+                    ),
+					SwipeDirection.LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("ä"),
+                        action = KeyAction.CommitText("ä"),
+                    ),
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("h"),
+                    action = KeyAction.CommitText("h"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+				swipeType = SwipeNWay.EIGHT_WAY,
+                swipes = mapOf(
+                    SwipeDirection.TOP_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("j"),
+                        action = KeyAction.CommitText("j"),
+                    ),
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("q"),
+                        action = KeyAction.CommitText("q"),
+                    ),
+                    SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("b"),
+                        action = KeyAction.CommitText("b"),
+                    ),
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("p"),
+                        action = KeyAction.CommitText("p"),
+                    ),
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("y"),
+                        action = KeyAction.CommitText("y"),
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("x"),
+                        action = KeyAction.CommitText("x"),
+                    ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("v"),
+                        action = KeyAction.CommitText("v"),
+                    ),
+                    SwipeDirection.LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("k"),
+                        action = KeyAction.CommitText("k"),
+                    ),
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("a"),
+                    action = KeyAction.CommitText("a"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.EIGHT_WAY,
+                swipes = mapOf(
+					SwipeDirection.TOP_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("ĺ"),
+                        action = KeyAction.CommitText("ĺ"),
+                    ),
+					SwipeDirection.TOP to KeyC(
+						display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
+						action = KeyAction.ToggleShiftMode(true),
+						color = ColorVariant.MUTED,
+					),
+					SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("á"),
+                        action = KeyAction.CommitText("á"),
+                    ),
+					SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("ý"),
+                        action = KeyAction.CommitText("ý"),
+                    ),
+					SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("ľ"),
+                        action = KeyAction.CommitText("ľ"),
+                    ),
+                    SwipeDirection.LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("l"),
+                        action = KeyAction.CommitText("l"),
+                    ),
+                ),
+            ),
+            NUMERIC_KEY_ITEM,
+        ),
+        listOf(
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("t"),
+                    action = KeyAction.CommitText("t"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.EIGHT_WAY,
+                swipes = mapOf(
+					SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("ť"),
+                        action = KeyAction.CommitText("ť"),
+                    ),
+                    SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("c"),
+                        action = KeyAction.CommitText("c"),
+                    ),
+					SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("č"),
+                        action = KeyAction.CommitText("č"),
+                    ),
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("i"),
+                    action = KeyAction.CommitText("i"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+				swipeType = SwipeNWay.EIGHT_WAY,
+                swipes = mapOf(
+					SwipeDirection.TOP_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("í"),
+                        action = KeyAction.CommitText("í"),
+                    ),
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("f"),
+                        action = KeyAction.CommitText("f"),
+                    ),
+                    SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("'"),
+                        action = KeyAction.CommitText("'"),
+                        color = ColorVariant.MUTED,
+                    ),
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("z"),
+                        action = KeyAction.CommitText("z"),
+                    ),
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("-"),
+                        action = KeyAction.CommitText("-"),
+                        color = ColorVariant.MUTED,
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("."),
+                        action = KeyAction.CommitText("."),
+                        color = ColorVariant.MUTED,
+                    ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("*"),
+                        action = KeyAction.CommitText("*"),
+                        color = ColorVariant.MUTED,
+                    ),
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("e"),
+                    action = KeyAction.CommitText("e"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.EIGHT_WAY,
+                swipes = mapOf(
+                    SwipeDirection.TOP_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("d"),
+                        action = KeyAction.CommitText("d"),
+                    ),
+					SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("é"),
+                        action = KeyAction.CommitText("é"),
+                    ),
+					SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("ž"),
+                        action = KeyAction.CommitText("ž"),
+                    ),
+					SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("ď"),
+                        action = KeyAction.CommitText("ď"),
+                    ),
+                ),
+            ),
+            BACKSPACE_KEY_ITEM,
+        ),
+        listOf(
+            SPACEBAR_KEY_ITEM,
+            RETURN_KEY_ITEM,
+        ),
+    ),
+)
+
+val THUMBKEY_EN_V4_MULTI_SHIFTED = KeyboardC(
+    listOf(
+        listOf(
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("S"),
+                    action = KeyAction.CommitText("S"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.EIGHT_WAY,
+                swipes = mapOf(
+					SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("Š"),
+                        action = KeyAction.CommitText("Š"),
+                    ),
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("W"),
+                        action = KeyAction.CommitText("W"),
+                    ),
+					SwipeDirection.LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("Ô"),
+                        action = KeyAction.CommitText("Ô"),
+                    ),
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("R"),
+                    action = KeyAction.CommitText("R"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.TWO_WAY_VERTICAL,
+                swipes = mapOf(
+					SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("Ŕ"),
+                        action = KeyAction.CommitText("Ŕ"),
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("G"),
+                        action = KeyAction.CommitText("G"),
+                    ),
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("O"),
+                    action = KeyAction.CommitText("O"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.EIGHT_WAY,
+                swipes = mapOf(
+					SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("Ó"),
+                        action = KeyAction.CommitText("Ó"),
+                    ),
+					SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("Ú"),
+                        action = KeyAction.CommitText("Ú"),
+                    ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("U"),
+                        action = KeyAction.CommitText("U"),
+                    ),
+                ),
+            ),
+            SETTINGS_KEY_ITEM,
+        ),
+        listOf(
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("N"),
+                    action = KeyAction.CommitText("N"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                swipes = mapOf(
+					SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("Ň"),
+                        action = KeyAction.CommitText("Ň"),
+                    ),
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("M"),
+                        action = KeyAction.CommitText("M"),
+                    ),
+					SwipeDirection.LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("Ä"),
+                        action = KeyAction.CommitText("Ä"),
+                    ),
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("H"),
+                    action = KeyAction.CommitText("H"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+				swipeType = SwipeNWay.EIGHT_WAY,
+                swipes = mapOf(
+                    SwipeDirection.TOP_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("J"),
+                        action = KeyAction.CommitText("J"),
+                    ),
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("Q"),
+                        action = KeyAction.CommitText("Q"),
+                    ),
+                    SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("B"),
+                        action = KeyAction.CommitText("B"),
+                    ),
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("P"),
+                        action = KeyAction.CommitText("P"),
+                    ),
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("Y"),
+                        action = KeyAction.CommitText("Y"),
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("X"),
+                        action = KeyAction.CommitText("X"),
+                    ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("V"),
+                        action = KeyAction.CommitText("V"),
+                    ),
+                    SwipeDirection.LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("K"),
+                        action = KeyAction.CommitText("K"),
+                    ),
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("A"),
+                    action = KeyAction.CommitText("A"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.EIGHT_WAY,
+                swipes = mapOf(
+					SwipeDirection.TOP_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("Ĺ"),
+                        action = KeyAction.CommitText("Ĺ"),
+                    ),
+					SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.IconDisplay(Icons.Outlined.KeyboardCapslock),
+                        capsModeDisplay = KeyDisplay.IconDisplay(Icons.Outlined.Copyright),
+                        action = KeyAction.ToggleCapsLock,
+                        color = ColorVariant.MUTED,
+                    ),
+					SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("Á"),
+                        action = KeyAction.CommitText("Á"),
+                    ),
+					SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("Ý"),
+                        action = KeyAction.CommitText("Ý"),
+                    ),
+					SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
+                        action = KeyAction.ToggleShiftMode(false),
+                        color = ColorVariant.MUTED,
+					),
+					SwipeDirection.BOTTOM_LEFT to KeyC(
+						display = KeyDisplay.TextDisplay("Ľ"),
+						action = KeyAction.CommitText("Ľ"),
+					),
+					SwipeDirection.LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("L"),
+                        action = KeyAction.CommitText("L"),
+                    ),
+                ),
+            ),
+            NUMERIC_KEY_ITEM,
+        ),
+        listOf(
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("T"),
+                    action = KeyAction.CommitText("T"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.EIGHT_WAY,
+                swipes = mapOf(
+					SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("Ť"),
+                        action = KeyAction.CommitText("Ť"),
+                    ),
+                    SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("C"),
+                        action = KeyAction.CommitText("C"),
+                    ),
+					SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("Č"),
+                        action = KeyAction.CommitText("Č"),
+                    ),
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("I"),
+                    action = KeyAction.CommitText("I"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+				swipeType = SwipeNWay.EIGHT_WAY,
+                swipes = mapOf(
+					SwipeDirection.TOP_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("Í"),
+                        action = KeyAction.CommitText("Í"),
+                        color = ColorVariant.MUTED,
+                    ),
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("F"),
+                        action = KeyAction.CommitText("F"),
+                    ),
+                    SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("'"),
+                        action = KeyAction.CommitText("'"),
+                        color = ColorVariant.MUTED,
+                    ),
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("Z"),
+                        action = KeyAction.CommitText("Z"),
+                    ),
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("-"),
+                        action = KeyAction.CommitText("-"),
+                        color = ColorVariant.MUTED,
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("."),
+                        action = KeyAction.CommitText("."),
+                        color = ColorVariant.MUTED,
+                    ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("*"),
+                        action = KeyAction.CommitText("*"),
+                        color = ColorVariant.MUTED,
+                    ),
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("E"),
+                    action = KeyAction.CommitText("E"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.EIGHT_WAY,
+                swipes = mapOf(
+                    SwipeDirection.TOP_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("D"),
+                        action = KeyAction.CommitText("D"),
+                    ),
+					SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("É"),
+                        action = KeyAction.CommitText("É"),
+                    ),
+					SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("Ž"),
+                        action = KeyAction.CommitText("Ž"),
+                    ),
+					SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("Ď"),
+                        action = KeyAction.CommitText("Ď"),
+                    ),
+                ),
+            ),
+            BACKSPACE_KEY_ITEM,
+        ),
+        listOf(
+            SPACEBAR_KEY_ITEM,
+            RETURN_KEY_ITEM,
+        ),
+    ),
+)
+
+val THUMBKEY_EN_V4_MULTI_KEYBOARD_MODES: Map<KeyboardMode, KeyboardC> = mapOf(
+    KeyboardMode.MAIN to THUMBKEY_EN_V4_MULTI_MAIN,
+    KeyboardMode.SHIFTED to THUMBKEY_EN_V4_MULTI_SHIFTED,
+    KeyboardMode.NUMERIC to NUMERIC_KEYBOARD,
+)

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
@@ -96,6 +96,7 @@ enum class KeyboardLayout(val title: String, val index: Int) {
     ThumbKeyENv4("Thumb-Key english v4", 0),
     ThumbKeyENv4Symbols("Thumb-Key english v4 with symbols", 21),
     ThumbKeyENv4Programmer("Thumb-Key english v4 (programmer)", 1),
+    ThumbKeyENv4Multi("Thumb-Key english v4 (EN+SK multi)", 48),
     ThumbKeyDEv2("Thumb-Key deutsch v2", 2),
     ThumbKeyDAv1("Thumb-Key dansk v1", 3),
     ThumbKeyESv1("Thumb-Key español v1", 4),

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
@@ -96,7 +96,6 @@ enum class KeyboardLayout(val title: String, val index: Int) {
     ThumbKeyENv4("Thumb-Key english v4", 0),
     ThumbKeyENv4Symbols("Thumb-Key english v4 with symbols", 21),
     ThumbKeyENv4Programmer("Thumb-Key english v4 (programmer)", 1),
-    ThumbKeyENv4Multi("Thumb-Key english v4 (EN+SK multi)", 48),
     ThumbKeyDEv2("Thumb-Key deutsch v2", 2),
     ThumbKeyDAv1("Thumb-Key dansk v1", 3),
     ThumbKeyESv1("Thumb-Key español v1", 4),
@@ -142,6 +141,7 @@ enum class KeyboardLayout(val title: String, val index: Int) {
     ThumbKeyHUv1("Thumb-Key magyar nyelv v1", 45),
     ThumbKeyESEOv1("Thumb-Key español esperanto v1", 46),
     MessageEaseIT("MessageEase italiano", 47),
+    ThumbKeyENv4Multi("Thumb-Key english v4 (EN+SK multi)", 48),
 }
 
 enum class KeyboardPosition(private val stringId: Int) {

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -44,6 +44,7 @@ import com.dessalines.thumbkey.keyboards.THUMBKEY_DA_V1_KEYBOARD_MODES
 import com.dessalines.thumbkey.keyboards.THUMBKEY_DE_V2_KEYBOARD_MODES
 import com.dessalines.thumbkey.keyboards.THUMBKEY_DE_V2_MULTILINGUAL_KEYBOARD_MODES
 import com.dessalines.thumbkey.keyboards.THUMBKEY_EN_V4_KEYBOARD_MODES
+import com.dessalines.thumbkey.keyboards.THUMBKEY_EN_V4_MULTI_KEYBOARD_MODES
 import com.dessalines.thumbkey.keyboards.THUMBKEY_EN_V4_PROGRAMMER_KEYBOARD_MODES
 import com.dessalines.thumbkey.keyboards.THUMBKEY_EN_V4_SYMBOLS_KEYBOARD_MODES
 import com.dessalines.thumbkey.keyboards.THUMBKEY_ES_EO_V1_KEYBOARD_MODES
@@ -113,6 +114,7 @@ fun keyboardLayoutToModes(layout: KeyboardLayout): Map<KeyboardMode, KeyboardC> 
     return when (layout) {
         KeyboardLayout.ThumbKeyENv4 -> THUMBKEY_EN_V4_KEYBOARD_MODES
         KeyboardLayout.ThumbKeyENv4Programmer -> THUMBKEY_EN_V4_PROGRAMMER_KEYBOARD_MODES
+        KeyboardLayout.ThumbKeyENv4Multi -> THUMBKEY_EN_V4_MULTI_KEYBOARD_MODES
         KeyboardLayout.ThumbKeyDEv2 -> THUMBKEY_DE_V2_KEYBOARD_MODES
         KeyboardLayout.ThumbKeyDAv1 -> THUMBKEY_DA_V1_KEYBOARD_MODES
         KeyboardLayout.ThumbKeyESv1 -> THUMBKEY_ES_V1_KEYBOARD_MODES


### PR DESCRIPTION
This PR adds a MultiLayout for English and Slovak, based on the ENv4 layout, as i already have that in my muscle memory.
- I added both the main & shifted layers
- changed the `swipeTypes` on keys where it was necessary
- renamed the keyboard layers and the `val` at the end of the file
- tried to add the accented characters where they would logically make sense, like near their base letter, or where it would minimize misstypes (`ô`, `ä` are positioned away from their base letter, because they are very infrequent, `o` and `a` were already pretty crowded.
- I edited this in VSCode, with just syntax highlighting but no Linting/checking. I double-checked both the regular layer & the shifted layer, but please give it a quick test to see if it works.
- I added `swipeType = SwipeNWay.EIGHT_WAY,` to the `h` and `i` keys, because it was missing from there - let me know if i should rever this
- the keyboard layout should match this mockup, please let me know if it does not match, as i couldn't test it with my current setup. (the screenshot does not include the position-changing right swipe, but i did not touch that - it should be included)
  
![image](https://github.com/dessalines/thumb-key/assets/21956756/8078c146-116d-4eca-a05e-3642a99dbbdf)

If there is something wrong with the layout, or it does not match the mockup, please use the 'Request Changes' feature and i'll fix it. Thank you!
