### PR TITLE
Update .woodpecker.yml

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -6,24 +6,28 @@ variables:
         - ".woodpecker.yml"
 
 steps:
+  prettier_markdown_check:
+    image: tmknom/prettier
+    commands:
+      - prettier -c "*.md" "*.yml"
+      
   check_formatting:
     image: cimg/android:2023.08
     commands:
       - sudo chown -R circleci:circleci .
       - ./gradlew lintKotlin
     when: *slow_check_paths
-
-  prettier_markdown_check:
-    image: tmknom/prettier
-    commands:
-      - prettier -c "*.md" "*.yml"
-
+    environment:
+      GRADLE_USER_HOME: ".gradle"
+      
   build_project:
     image: cimg/android:2023.08
     commands:
       - sudo chown -R circleci:circleci .
       - ./gradlew assembleDebug
     when: *slow_check_paths
+    environment:
+      GRADLE_USER_HOME: ".gradle"
 
   notify:
     image: alpine:3

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -10,7 +10,7 @@ steps:
     image: tmknom/prettier
     commands:
       - prettier -c "*.md" "*.yml"
-      
+
   check_formatting:
     image: cimg/android:2023.08
     commands:
@@ -19,7 +19,7 @@ steps:
     when: *slow_check_paths
     environment:
       GRADLE_USER_HOME: ".gradle"
-      
+
   build_project:
     image: cimg/android:2023.08
     commands:


### PR DESCRIPTION
Add env `.gradle` this makes so that it reuses the gradle cache at least between steps. Small improvement to the CI time (also will now only once download the wrapper)