### PR TITLE
Update build.gradle buildtools version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,6 +5,7 @@ plugins {
 }
 
 android {
+    buildToolsVersion = "34.0.0-rc3"
     compileSdk 34
 
     defaultConfig {


### PR DESCRIPTION
Like Jerboa this sets the exact set version of the buildtools instead of the default of the AGP. This version is set to the same version as the CI, thus saving abt avg 2 minutes on installing build tools