### PR TITLE
Update ThumbKeyUKv1.kt - fix Ґ and Д conflict

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ThumbKeyUKv1.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ThumbKeyUKv1.kt
@@ -473,7 +473,7 @@ val THUMBKEY_UK_V1_SHIFTED = KeyboardC(
                         display = KeyDisplay.TextDisplay("Є"),
                         action = KeyAction.CommitText("Є"),
                     ),
-                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
                         display = KeyDisplay.TextDisplay("Ґ"),
                         action = KeyAction.CommitText("Ґ"),
                     ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ThumbKeyUKv1.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ThumbKeyUKv1.kt
@@ -473,7 +473,7 @@ val THUMBKEY_UK_V1_SHIFTED = KeyboardC(
                         display = KeyDisplay.TextDisplay("Є"),
                         action = KeyAction.CommitText("Є"),
                     ),
-                    SwipeDirection.TOP_LEFT to KeyC(
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("Ґ"),
                         action = KeyAction.CommitText("Ґ"),
                     ),


### PR DESCRIPTION
Currently, capital Д is unavailable in the Ukrainian layout. This PR fixes it (by moving capital Ґ to the bottom right where the lowercase ґ resides: looks like there was a typo with specifying `TOP_LEFT` twice for both Д and Ґ).