### PR TITLE
Fixed missing and overlapping keys on CZ keyboard

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ThumbKeyCZv1.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ThumbKeyCZv1.kt
@@ -516,6 +516,7 @@ val THUMBKEY_CZ_V1_SHIFTED = KeyboardC(
                     size = FontSizeVariant.LARGE,
                     color = ColorVariant.PRIMARY,
                 ),
+                swipeType = SwipeNWay.EIGHT_WAY,
                 swipes = mapOf(
                     SwipeDirection.TOP_LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("D"),
@@ -529,7 +530,7 @@ val THUMBKEY_CZ_V1_SHIFTED = KeyboardC(
                         display = KeyDisplay.TextDisplay("Ď"),
                         action = KeyAction.CommitText("Ď"),
                     ),
-                    SwipeDirection.TOP to KeyC(
+                    SwipeDirection.LEFT to KeyC(
                         display = KeyDisplay.TextDisplay("Ě"),
                         action = KeyAction.CommitText("Ě"),
                     ),
@@ -549,3 +550,4 @@ val THUMBKEY_CZ_V1_KEYBOARD_MODES: Map<KeyboardMode, KeyboardC> = mapOf(
     KeyboardMode.SHIFTED to THUMBKEY_CZ_V1_SHIFTED,
     KeyboardMode.NUMERIC to NUMERIC_KEYBOARD,
 )
+// čďě dvojté ť

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ThumbKeyCZv1.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ThumbKeyCZv1.kt
@@ -550,4 +550,3 @@ val THUMBKEY_CZ_V1_KEYBOARD_MODES: Map<KeyboardMode, KeyboardC> = mapOf(
     KeyboardMode.SHIFTED to THUMBKEY_CZ_V1_SHIFTED,
     KeyboardMode.NUMERIC to NUMERIC_KEYBOARD,
 )
-// čďě dvojté ť


### PR DESCRIPTION
When using the keyboard IRL, I found that the keys were missing, so I fixed it. Hopefully, I've setup Android Studio correctly and this will work.