### PR TITLE
Add slide selection and deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ This project is a follow-up to the now unmaintained (and closed-source) [Message
 - Slide right on the `#` key to switch keyboard position.
 - Practice typing, and check your words per minute, using [monkeytype.com](https://monkeytype.com)
 
+### Slide gestures
+
+Enabling `Slide gestures` in keyboard settings will enable the following gestures:
+
+- Slide spacebar horizontally to move cursor position left and right.
+- Slide upwards while sliding the spacebar to select text.
+- Slide backspace to the left to select text to be deleted. Text will be deleted when key is released.
+
 ## Thumb-Key Design
 
 ### A History of Phone Keyboards

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/CommonKeys.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/CommonKeys.kt
@@ -135,6 +135,7 @@ val BACKSPACE_KEY_ITEM =
             color = ColorVariant.SECONDARY,
         ),
         swipeType = SwipeNWay.TWO_WAY_HORIZONTAL,
+        slideType = SlideType.DELETE,
         swipes = mapOf(
             SwipeDirection.LEFT to KeyC(
                 action = KeyAction.DeleteLastWord,

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
@@ -205,7 +205,10 @@ fun KeyboardKey(
                                     } else {
                                         selection.right()
                                     }
-                                    ime.currentInputConnection.setSelection(selection.start, selection.end)
+                                    ime.currentInputConnection.setSelection(
+                                        selection.start,
+                                        selection.end,
+                                    )
                                     offsetX = 0f
                                 }
                             } else if (abs(offsetX) > slideSensitivity) {
@@ -215,13 +218,21 @@ fun KeyboardKey(
                                 var shouldMove = false
                                 if (offsetX < 0.00) {
                                     // move left
-                                    if (ime.currentInputConnection.getTextBeforeCursor(1, 0)?.length != 0) {
+                                    if (ime.currentInputConnection.getTextBeforeCursor(
+                                            1,
+                                            0,
+                                        )?.length != 0
+                                    ) {
                                         shouldMove = true
                                     }
                                     direction = KeyEvent.KEYCODE_DPAD_LEFT
                                 } else {
                                     // move right
-                                    if (ime.currentInputConnection.getTextAfterCursor(1, 0)?.length != 0) {
+                                    if (ime.currentInputConnection.getTextAfterCursor(
+                                            1,
+                                            0,
+                                        )?.length != 0
+                                    ) {
                                         shouldMove = true
                                     }
                                     direction = KeyEvent.KEYCODE_DPAD_RIGHT
@@ -251,30 +262,36 @@ fun KeyboardKey(
                             }
                         } else if (key.slideType == SlideType.DELETE && slideEnabled) {
                             if (!selection.active) {
-                                // Activate selection
-                                var cursorPosition =
-                                    ime.currentInputConnection.getTextBeforeCursor(
-                                        255, // Higher value mens slower execution
-                                        0,
-                                    )?.length
-                                cursorPosition?.let {
-                                    selection = Selection(it, it, true)
+                                // Activate selection, first detection is longer to preserve swipe actions
+                                if (abs(offsetX) > slideSensitivity * 10) {
+                                    var cursorPosition =
+                                        ime.currentInputConnection.getTextBeforeCursor(
+                                            255, // Higher value mens slower execution
+                                            0,
+                                        )?.length
+                                    cursorPosition?.let {
+                                        selection = Selection(it, it, true)
+                                    }
                                 }
-                            }
-                            if (abs(offsetX) > slideSensitivity) {
-                                if (offsetX < 0.00) {
-                                    selection.left()
-                                } else {
-                                    selection.right()
+                            } else {
+                                if (abs(offsetX) > slideSensitivity) {
+                                    if (offsetX < 0.00) {
+                                        selection.left()
+                                    } else {
+                                        selection.right()
+                                    }
+                                    ime.currentInputConnection.setSelection(
+                                        selection.start,
+                                        selection.end,
+                                    )
+                                    offsetX = 0f
                                 }
-                                ime.currentInputConnection.setSelection(selection.start, selection.end)
-                                offsetX = 0f
                             }
                         }
                     },
                     onDragEnd = {
                         lateinit var action: KeyAction
-                        if (key.slideType == SlideType.NONE || !slideEnabled) {
+                        if (key.slideType == SlideType.NONE || !slideEnabled || (key.slideType == SlideType.DELETE && !selection.active)) {
                             val swipeDirection =
                                 swipeDirection(offsetX, offsetY, minSwipeLength, key.swipeType)
                             action = key.swipes?.get(swipeDirection)?.action ?: key.center.action

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
@@ -55,6 +55,7 @@ import com.dessalines.thumbkey.utils.colorVariantToColor
 import com.dessalines.thumbkey.utils.doneKeyAction
 import com.dessalines.thumbkey.utils.fontSizeVariantToFontSize
 import com.dessalines.thumbkey.utils.performKeyAction
+import com.dessalines.thumbkey.utils.startSelection
 import com.dessalines.thumbkey.utils.swipeDirection
 import kotlin.math.abs
 
@@ -107,7 +108,7 @@ fun KeyboardKey(
     var offsetX by remember { mutableFloatStateOf(0f) }
     var offsetY by remember { mutableFloatStateOf(0f) }
 
-    var selection by remember { mutableStateOf<Selection>(Selection()) }
+    var selection by remember { mutableStateOf(Selection()) }
 
     val backgroundColor = if (!(isDragged.value || isPressed)) {
         colorVariantToColor(colorVariant = key.backgroundColor)
@@ -190,14 +191,7 @@ fun KeyboardKey(
                                 // If user slides upwards, enable selection
                                 if (!selection.active) {
                                     // Activate selection
-                                    var cursorPosition =
-                                        ime.currentInputConnection.getTextBeforeCursor(
-                                            255, // Higher value mens slower execution
-                                            0,
-                                        )?.length
-                                    cursorPosition?.let {
-                                        selection = Selection(it, it, true)
-                                    }
+                                    selection = startSelection(ime)
                                 }
                                 if (abs(offsetX) > slideSensitivity) {
                                     if (offsetX < 0.00) {
@@ -264,14 +258,7 @@ fun KeyboardKey(
                             if (!selection.active) {
                                 // Activate selection, first detection is longer to preserve swipe actions
                                 if (abs(offsetX) > slideSensitivity * 10) {
-                                    var cursorPosition =
-                                        ime.currentInputConnection.getTextBeforeCursor(
-                                            255, // Higher value mens slower execution
-                                            0,
-                                        )?.length
-                                    cursorPosition?.let {
-                                        selection = Selection(it, it, true)
-                                    }
+                                    selection = startSelection(ime)
                                 }
                             } else {
                                 if (abs(offsetX) > slideSensitivity) {
@@ -315,7 +302,7 @@ fun KeyboardKey(
                                 releasedKey,
                                 animationHelperSpeed,
                             )
-                        } else if (key.slideType == SlideType.DELETE && slideEnabled) {
+                        } else if (key.slideType == SlideType.DELETE) {
                             action = KeyAction.SendEvent(
                                 KeyEvent(
                                     KeyEvent.ACTION_DOWN,

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/lookandfeel/LookAndFeelActivity.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/lookandfeel/LookAndFeelActivity.kt
@@ -587,11 +587,11 @@ fun LookAndFeelActivity(
                     icon = {
                         Icon(
                             imageVector = Icons.Outlined.SpaceBar,
-                            contentDescription = stringResource(R.string.spacebar_slide),
+                            contentDescription = stringResource(R.string.slide_enable),
                         )
                     },
                     title = {
-                        Text(stringResource(R.string.spacebar_slide))
+                        Text(stringResource(R.string.slide_enable))
                     },
                     onCheckedChange = {
                         updateAppSettings(

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
@@ -191,4 +191,5 @@ enum class SwipeNWay {
 enum class SlideType {
     NONE,
     MOVE_CURSOR,
+    DELETE,
 }

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
@@ -193,3 +193,17 @@ enum class SlideType {
     MOVE_CURSOR,
     DELETE,
 }
+
+data class Selection(
+    var start: Int,
+    var end: Int,
+    var active: Boolean,
+) {
+    constructor() : this (0, 0, false)
+    fun left() {
+        end -= 1
+    }
+    fun right() {
+        end += 1
+    }
+}

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -602,3 +602,15 @@ fun Context.getVersionCode(): Int = if (Build.VERSION.SDK_INT >= Build.VERSION_C
     @Suppress("DEPRECATION")
     getPackageInfo().versionCode
 }
+
+fun startSelection(ime: IMEService): Selection {
+    val cursorPosition =
+        ime.currentInputConnection.getTextBeforeCursor(
+            1000, // Higher value mens slower execution
+            0,
+        )?.length
+    cursorPosition?.let {
+        return Selection(it, it, true)
+    }
+    return Selection()
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,7 +41,7 @@
     <string name="animation_speed">Animation Speed: %1$s</string>
     <string name="animation_helper_speed">Animation Helper Speed: %1$s</string>
     <string name="slide_sensitivity">Slide sensitivity: %1$s</string>
-    <string name="spacebar_slide">Spacebar Sliding Cursor</string>
+    <string name="slide_enable">Slide gestures</string>
     <string name="reset_to_defaults">Reset to defaults</string>
     <string name="reset_to_defaults_msg">Are you sure you want to reset settings to defaults?</string>
     <string name="reset_to_defaults_confirm">Reset</string>


### PR DESCRIPTION
First of all, congrats on releasing v2.0.0. Emoji support is a great addition to the keyboard! 

I've been working on slide selection and deletion. Implemented it first via keypress (Shift + arrows). That didn't work in every app so I tried to use ime functions. It seems like the current implementation is working ok, but please test it. Hard to find every bug as some apps behave differently. I introduced a new type, selection. This was just to keep things a little simpler, not having to pollute the keyBoardKey with several variables related to selection. 

Maybe the value 255 on line 195 and 257 should be larger. It was set this small in order not to slow down execution. I have since changed the code to not call it more than once per selection, so it probably can be set higher without impacting execution time.

This pull request also resets multitap actions after sliding. 

Selection:
![ThumbKeySelection](https://github.com/dessalines/thumb-key/assets/3438604/0266724c-48c3-4cfe-9a46-f455b2c66fcc)

Deletion:
![ThumbKeyDelete](https://github.com/dessalines/thumb-key/assets/3438604/923d721b-26ff-4505-b06e-3c8042a5be79)
