### PR TITLE
Haptic and audible feedback on emoji key press + key border displayed properly.

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
@@ -112,7 +112,9 @@ fun KeyboardScreen(
         val keyboardHeight = Dp((keySize * controllerKeys.size).toFloat()) + pushupSizeDp
 
         Row(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.onBackground),
         ) {
             Box(
                 modifier = Modifier.weight(1f), // Take up available space equally

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
@@ -110,6 +110,11 @@ fun KeyboardScreen(
 
         val keySize = settings?.keySize ?: DEFAULT_KEY_SIZE
         val keyboardHeight = Dp((keySize * controllerKeys.size).toFloat()) + pushupSizeDp
+        val keyBorderSize = if (keyBorders) {
+            0.5.dp
+        } else {
+            0.dp
+        }
 
         Row(
             modifier = Modifier
@@ -117,7 +122,8 @@ fun KeyboardScreen(
                 .background(MaterialTheme.colorScheme.onBackground),
         ) {
             Box(
-                modifier = Modifier.weight(1f), // Take up available space equally
+                modifier = Modifier.weight(1f) // Take up available space equally
+                    .padding(keyBorderSize),
             ) {
                 val haptic = LocalHapticFeedback.current
                 val audioManager = ctx.getSystemService(Context.AUDIO_SERVICE) as AudioManager

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
@@ -1,5 +1,7 @@
 package com.dessalines.thumbkey.ui.components.keyboard
 
+import android.content.Context
+import android.media.AudioManager
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,7 +16,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -113,11 +117,19 @@ fun KeyboardScreen(
             Box(
                 modifier = Modifier.weight(1f), // Take up available space equally
             ) {
+                val haptic = LocalHapticFeedback.current
+                val audioManager = ctx.getSystemService(Context.AUDIO_SERVICE) as AudioManager
                 AndroidView(
                     // Write the emoji to our text box when we tap one.
                     factory = { context ->
                         val emojiPicker = EmojiPickerView(context)
                         emojiPicker.setOnEmojiPickedListener {
+                            if (vibrateOnTap) {
+                                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                            }
+                            if (soundOnTap) {
+                                audioManager.playSoundEffect(AudioManager.FX_KEY_CLICK, .1f)
+                            }
                             ctx.currentInputConnection.commitText(
                                 it.emoji,
                                 1,


### PR DESCRIPTION
Fixes #421 and #422 
I just copied and pasted your code for the audible and haptic feedback that already existed.

**Issue:**
If we enable/disable the audible or haptic feedback whilst the emoji picker is open, the effects won't take place. We have to switch out of the emoji picker and back into it for the changes to take effect.
I'm not really sure how to fix that as I don't see how you've achieved it.

The key borders in emoji view were displayed incorrectly, and now they show as white in dark mode and black in light mode.