### PR TITLE
Add voice input button to emoji key

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/CommonKeys.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/CommonKeys.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.icons.outlined.KeyboardCapslock
 import androidx.compose.material.icons.outlined.KeyboardReturn
 import androidx.compose.material.icons.outlined.Language
 import androidx.compose.material.icons.outlined.LinearScale
+import androidx.compose.material.icons.outlined.Mic
 import androidx.compose.material.icons.outlined.Mood
 import androidx.compose.material.icons.outlined.Numbers
 import androidx.compose.material.icons.outlined.Redo
@@ -83,7 +84,7 @@ val EMOJI_KEY_ITEM =
             size = FontSizeVariant.LARGE,
             color = ColorVariant.SECONDARY,
         ),
-        swipeType = SwipeNWay.FOUR_WAY_CROSS,
+        swipeType = SwipeNWay.EIGHT_WAY,
         swipes = mapOf(
             SwipeDirection.TOP to KeyC(
                 display = KeyDisplay.IconDisplay(Icons.Outlined.Settings),
@@ -93,6 +94,11 @@ val EMOJI_KEY_ITEM =
             SwipeDirection.BOTTOM to KeyC(
                 display = KeyDisplay.IconDisplay(Icons.Outlined.Keyboard),
                 action = KeyAction.SwitchIME,
+                color = ColorVariant.MUTED,
+            ),
+            SwipeDirection.BOTTOM_LEFT to KeyC(
+              display = KeyDisplay.IconDisplay(Icons.Outlined.Mic),
+                action = KeyAction.SwitchIMEVoice,
                 color = ColorVariant.MUTED,
             ),
             SwipeDirection.LEFT to KeyC(

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
@@ -54,6 +54,7 @@ sealed class KeyAction {
     data object SwitchLanguage : KeyAction()
     data object SwitchPosition : KeyAction()
     data object SwitchIME : KeyAction()
+    data object SwitchIMEVoice : KeyAction()
 }
 
 enum class KeyboardMode {

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -10,6 +10,7 @@ import android.text.InputType
 import android.util.Log
 import android.view.KeyEvent
 import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodInfo
 import android.view.inputmethod.InputMethodManager
 import android.widget.Toast
 import androidx.compose.material.icons.Icons
@@ -409,9 +410,27 @@ fun performKeyAction(
         KeyAction.SwitchLanguage -> onSwitchLanguage()
         KeyAction.SwitchPosition -> onSwitchPosition()
         KeyAction.SwitchIME -> {
+             val imeManager =
+                 ime.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+             imeManager.showInputMethodPicker()
+        }
+        KeyAction.SwitchIMEVoice -> {
             val imeManager =
                 ime.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-            imeManager.showInputMethodPicker()
+            val list: List<InputMethodInfo> = imeManager.enabledInputMethodList
+            for (el in list) {
+                for (i in 0 until el.subtypeCount){
+                    if (el.getSubtypeAt(i).mode != "voice") continue
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                        ime.switchInputMethod(el.id)
+                    } else {
+                        ime.window.window?.let { window ->
+                            @Suppress("DEPRECATION")
+                            imeManager.setInputMethod(window.attributes.token, el.id)
+                        }
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
I occasionally use voice input when answering messages etc. Before using Thumb Key I was using Florisboard, which have a dedicated button for activating voice input. This pull request adds this. The code is more or less copied from Florisboard, and will use the first voice input available. Tested with both Google Voice and FUTO Voice Input (as seen in the Gif). 

![ThumbVoice](https://github.com/dessalines/thumb-key/assets/3438604/bea38254-e396-444f-b032-4cc2f427338c)
