### PR TITLE
Use common spacebar in numeric keyboard

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/Numeric.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/Numeric.kt
@@ -272,20 +272,7 @@ val NUMERIC_KEYBOARD = KeyboardC(
                 ),
                 widthMultiplier = 2,
             ),
-            KeyItemC(
-                center = KeyC(
-                    display = KeyDisplay.TextDisplay(" "),
-                    action = KeyAction.CommitText(" "),
-                ),
-                nextTapActions = listOf(
-                    KeyAction.ReplaceLastText(". ", trimCount = 1),
-                    KeyAction.ReplaceLastText(", "),
-                    KeyAction.ReplaceLastText("? "),
-                    KeyAction.ReplaceLastText("! "),
-                    KeyAction.ReplaceLastText(": "),
-                ),
-                backgroundColor = ColorVariant.SURFACE_VARIANT,
-            ),
+            SPACEBAR_SKINNY_KEY_ITEM,
             RETURN_KEY_ITEM,
         ),
     ),


### PR DESCRIPTION
I found that swiping left on the space-key in numeric mode didn't move the cursor.
This is my first experience of committing to an android project. I'm interested in potentially adding Bitwarden secret support or macros to thumb-key.