### PR TITLE
partially fix inconsistent layout naming (#495)

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbKeyMultiLingual.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbKeyMultiLingual.kt
@@ -724,7 +724,7 @@ val KB_DE_THUMBKEY_MULTILINGUAL_SHIFTED = KeyboardC(
 )
 
 val KB_DE_THUMBKEY_MULTILINGUAL: KeyboardDefinition = KeyboardDefinition(
-    title = "DE Thumb-Key deutsch v2 multilingual",
+    title = "DE Thumb-Key deutsch (DE+EN multi)",
     modes = KeyboardDefinitionModes(
         main = KB_DE_THUMBKEY_MULTILINGUAL_MAIN,
         shifted = KB_DE_THUMBKEY_MULTILINGUAL_SHIFTED,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyMultiEE.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyMultiEE.kt
@@ -488,7 +488,7 @@ val KB_EN_THUMBKEY_MULTI_EE_SHIFTED = KeyboardC(
 )
 
 val KB_EN_THUMBKEY_MULTI_EE: KeyboardDefinition = KeyboardDefinition(
-    title = "EN Thumb-Key english (EN+EE)",
+    title = "EN Thumb-Key english (EN+EE multi)",
     modes = KeyboardDefinitionModes(
         main = KB_EN_THUMBKEY_MULTI_EE_MAIN,
         shifted = KB_EN_THUMBKEY_MULTI_EE_SHIFTED,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/MATHThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/MATHThumbKey.kt
@@ -540,7 +540,7 @@ val KB_MATH_THUMBKEY_SLASH = KeyboardC(
 )
 
 val KB_MATH_THUMBKEY: KeyboardDefinition = KeyboardDefinition(
-    title = "Math Thumb-Key",
+    title = "MATH Thumb-Key",
     modes = KeyboardDefinitionModes(
         main = KB_MATH_THUMBKEY_MAIN,
         shifted = KB_MATH_THUMBKEY_SLASH,

--- a/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
@@ -19,6 +19,7 @@ import com.dessalines.thumbkey.keyboards.KB_EN_THUMBKEY_MULTI
 import com.dessalines.thumbkey.keyboards.KB_EN_THUMBKEY_MULTI_EE
 import com.dessalines.thumbkey.keyboards.KB_EN_THUMBKEY_MULTI_IT
 import com.dessalines.thumbkey.keyboards.KB_EN_THUMBKEY_PROGRAMMER
+import com.dessalines.thumbkey.keyboards.KB_EN_THUMBKEY_PROGRAMMER_WIDE
 import com.dessalines.thumbkey.keyboards.KB_EN_THUMBKEY_SYMBOLS
 import com.dessalines.thumbkey.keyboards.KB_EN_TWO_HANDS
 import com.dessalines.thumbkey.keyboards.KB_EN_TYPESPLIT
@@ -88,7 +89,7 @@ enum class KeyboardLayout(val index: Int, val keyboardDefinition: KeyboardDefini
     ENThumbKey(0, KB_EN_THUMBKEY),
     ENThumbKeySymbols(21, KB_EN_THUMBKEY_SYMBOLS),
     ENThumbKeyProgrammer(1, KB_EN_THUMBKEY_PROGRAMMER),
-    ENThumbKeyProgrammerWide(44, KB_EN_THUMBKEY_PROGRAMMER),
+    ENThumbKeyProgrammerWide(44, KB_EN_THUMBKEY_PROGRAMMER_WIDE),
     ENThumbKeyMulti(48, KB_EN_THUMBKEY_MULTI),
     ENMessageEase(15, KB_EN_MESSAGEEASE),
     ENMessageEaseSymbols(16, KB_EN_MESSAGEEASE_SYMBOLS),


### PR DESCRIPTION
i've implemented fixes for points 3, 5 and 7 of #495 
about the other points:
- 1. i could just rename the czech layout to `EN Thumb-key english (EN+CZ multi)`, if okayed.
- 2 and 4 - how should i differentiate these layouts? how should i name them?
- 6. i don't know how to fix this one, it would require some ui change.