### PR TITLE
Implement EN layout with composable keys

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyCompose.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyCompose.kt
@@ -1,0 +1,550 @@
+package com.dessalines.thumbkey.keyboards
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowDropDown
+import androidx.compose.material.icons.outlined.ArrowDropUp
+import androidx.compose.material.icons.outlined.Copyright
+import androidx.compose.material.icons.outlined.KeyboardCapslock
+import com.dessalines.thumbkey.utils.ColorVariant
+import com.dessalines.thumbkey.utils.FontSizeVariant
+import com.dessalines.thumbkey.utils.KeyAction
+import com.dessalines.thumbkey.utils.KeyC
+import com.dessalines.thumbkey.utils.KeyDisplay
+import com.dessalines.thumbkey.utils.KeyItemC
+import com.dessalines.thumbkey.utils.KeyboardC
+import com.dessalines.thumbkey.utils.KeyboardDefinition
+import com.dessalines.thumbkey.utils.KeyboardDefinitionModes
+import com.dessalines.thumbkey.utils.KeyboardDefinitionSettings
+import com.dessalines.thumbkey.utils.SwipeDirection
+import com.dessalines.thumbkey.utils.SwipeNWay
+import com.dessalines.thumbkey.utils.autoCapitalizeI
+
+var KB_EN_THUMBKEY_COMPOSE_MAIN =  KeyboardC(
+    listOf(
+        listOf(
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("s"),
+                    action = KeyAction.CommitText("s"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
+                swipes = mapOf(
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("w"),
+                        action = KeyAction.CommitText("w"),
+                    ),
+                    SwipeDirection.TOP_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("\""),
+                        action = KeyAction.ComposeLastKey("\""),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("^"),
+                        action = KeyAction.ComposeLastKey("^"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("~"),
+                        action = KeyAction.ComposeLastKey("~"),
+                        color = ColorVariant.MUTED
+                    ),
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("r"),
+                    action = KeyAction.CommitText("r"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.TWO_WAY_VERTICAL,
+                swipes = mapOf(
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("g"),
+                        action = KeyAction.CommitText("g"),
+                    ),
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("o"),
+                    action = KeyAction.CommitText("o"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
+                swipes = mapOf(
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("u"),
+                        action = KeyAction.CommitText("u"),
+                    ),
+                ),
+            ),
+            EMOJI_KEY_ITEM,
+        ),
+        listOf(
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("n"),
+                    action = KeyAction.CommitText("n"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.EIGHT_WAY,
+                swipes = mapOf(
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("m"),
+                        action = KeyAction.CommitText("m"),
+                    ),
+                    SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay(""),
+                        action = KeyAction.CommitText("m"),
+                    ),
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay(""),
+                        action = KeyAction.CommitText("m"),
+                    ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("`"),
+                        action = KeyAction.ComposeLastKey("`"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.TOP_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("'"),
+                        action = KeyAction.ComposeLastKey("'"),
+                        color = ColorVariant.MUTED
+                    )
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("h"),
+                    action = KeyAction.CommitText("h"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipes = mapOf(
+                    SwipeDirection.TOP_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("j"),
+                        action = KeyAction.CommitText("j"),
+                    ),
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("q"),
+                        action = KeyAction.CommitText("q"),
+                    ),
+                    SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("b"),
+                        action = KeyAction.CommitText("b"),
+                    ),
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("p"),
+                        action = KeyAction.CommitText("p"),
+                    ),
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("y"),
+                        action = KeyAction.CommitText("y"),
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("x"),
+                        action = KeyAction.CommitText("x"),
+                    ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("v"),
+                        action = KeyAction.CommitText("v"),
+                    ),
+                    SwipeDirection.LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("k"),
+                        action = KeyAction.CommitText("k"),
+                    ),
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("a"),
+                    action = KeyAction.CommitText("a"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                swipes = mapOf(
+                    SwipeDirection.LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("l"),
+                        action = KeyAction.CommitText("l"),
+                    ),
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
+                        action = KeyAction.ToggleShiftMode(true),
+                        color = ColorVariant.MUTED,
+                    ),
+                ),
+            ),
+            NUMERIC_KEY_ITEM,
+        ),
+        listOf(
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("t"),
+                    action = KeyAction.CommitText("t"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
+                swipes = mapOf(
+                    SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("c"),
+                        action = KeyAction.CommitText("c"),
+                    ),
+                    SwipeDirection.TOP_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("°/"),
+                        action = KeyAction.ComposeLastKey("°"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("¿¡"),
+                        action = KeyAction.ComposeLastKey("!"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("\$"),
+                        action = KeyAction.ComposeLastKey("\$"),
+                        color = ColorVariant.MUTED
+                    ),
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("i"),
+                    action = KeyAction.CommitText("i"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipes = mapOf(
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("f"),
+                        action = KeyAction.CommitText("f"),
+                    ),
+                    SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("'"),
+                        action = KeyAction.CommitText("'"),
+                        color = ColorVariant.MUTED,
+                    ),
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("z"),
+                        action = KeyAction.CommitText("z"),
+                    ),
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("-"),
+                        action = KeyAction.CommitText("-"),
+                        color = ColorVariant.MUTED,
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("."),
+                        action = KeyAction.CommitText("."),
+                        color = ColorVariant.MUTED,
+                    ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("*"),
+                        action = KeyAction.CommitText("*"),
+                        color = ColorVariant.MUTED,
+                    ),
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("e"),
+                    action = KeyAction.CommitText("e"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
+                swipes = mapOf(
+                    SwipeDirection.TOP_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("d"),
+                        action = KeyAction.CommitText("d"),
+                    ),
+                ),
+            ),
+            BACKSPACE_KEY_ITEM,
+        ),
+        listOf(
+            SPACEBAR_KEY_ITEM,
+            RETURN_KEY_ITEM,
+        ),
+    ),
+)
+
+val KB_EN_THUMBKEY_COMPOSE_SHIFTED = KeyboardC(
+    listOf(
+        listOf(
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("S"),
+                    action = KeyAction.CommitText("S"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
+                swipes = mapOf(
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("W"),
+                        action = KeyAction.CommitText("W"),
+                    ),
+                    SwipeDirection.TOP_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("\""),
+                        action = KeyAction.ComposeLastKey("\""),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("^"),
+                        action = KeyAction.ComposeLastKey("^"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("~"),
+                        action = KeyAction.ComposeLastKey("~"),
+                        color = ColorVariant.MUTED
+                    ),
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("R"),
+                    action = KeyAction.CommitText("R"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.TWO_WAY_VERTICAL,
+                swipes = mapOf(
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("G"),
+                        action = KeyAction.CommitText("G"),
+                    ),
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("O"),
+                    action = KeyAction.CommitText("O"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
+                swipes = mapOf(
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("U"),
+                        action = KeyAction.CommitText("U"),
+                    ),
+                ),
+            ),
+            EMOJI_KEY_ITEM,
+        ),
+        listOf(
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("N"),
+                    action = KeyAction.CommitText("N"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.EIGHT_WAY,
+                swipes = mapOf(
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("M"),
+                        action = KeyAction.CommitText("M"),
+                    ),
+                    SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay(""),
+                        action = KeyAction.CommitText("M"),
+                    ),
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay(""),
+                        action = KeyAction.CommitText("M"),
+                    ),
+                    SwipeDirection.TOP_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("'"),
+                        action = KeyAction.ComposeLastKey("'"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("`"),
+                        action = KeyAction.ComposeLastKey("`"),
+                        color = ColorVariant.MUTED
+                    )
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("H"),
+                    action = KeyAction.CommitText("H"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipes = mapOf(
+                    SwipeDirection.TOP_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("J"),
+                        action = KeyAction.CommitText("J"),
+                    ),
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("Q"),
+                        action = KeyAction.CommitText("Q"),
+                    ),
+                    SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("B"),
+                        action = KeyAction.CommitText("B"),
+                    ),
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("P"),
+                        action = KeyAction.CommitText("P"),
+                    ),
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("Y"),
+                        action = KeyAction.CommitText("Y"),
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("X"),
+                        action = KeyAction.CommitText("X"),
+                    ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("V"),
+                        action = KeyAction.CommitText("V"),
+                    ),
+                    SwipeDirection.LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("K"),
+                        action = KeyAction.CommitText("K"),
+                    ),
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("A"),
+                    action = KeyAction.CommitText("A"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                swipes = mapOf(
+                    SwipeDirection.LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("L"),
+                        action = KeyAction.CommitText("L"),
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
+                        action = KeyAction.ToggleShiftMode(false),
+                        color = ColorVariant.MUTED,
+                    ),
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.IconDisplay(Icons.Outlined.KeyboardCapslock),
+                        capsModeDisplay = KeyDisplay.IconDisplay(Icons.Outlined.Copyright),
+                        action = KeyAction.ToggleCapsLock,
+                        color = ColorVariant.MUTED,
+                    ),
+                ),
+            ),
+            NUMERIC_KEY_ITEM,
+        ),
+        listOf(
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("T"),
+                    action = KeyAction.CommitText("T"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
+                swipes = mapOf(
+                    SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("C"),
+                        action = KeyAction.CommitText("C"),
+                    ),
+                    SwipeDirection.TOP_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("°/"),
+                        action = KeyAction.ComposeLastKey("°"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("¿¡"),
+                        action = KeyAction.ComposeLastKey("!"),
+                        color = ColorVariant.MUTED
+                    ),
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("\$"),
+                        action = KeyAction.ComposeLastKey("\$"),
+                        color = ColorVariant.MUTED
+                    ),
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("I"),
+                    action = KeyAction.CommitText("I"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipes = mapOf(
+                    SwipeDirection.TOP to KeyC(
+                        display = KeyDisplay.TextDisplay("F"),
+                        action = KeyAction.CommitText("F"),
+                    ),
+                    SwipeDirection.TOP_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("'"),
+                        action = KeyAction.CommitText("'"),
+                        color = ColorVariant.MUTED,
+                    ),
+                    SwipeDirection.RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("Z"),
+                        action = KeyAction.CommitText("Z"),
+                    ),
+                    SwipeDirection.BOTTOM_RIGHT to KeyC(
+                        display = KeyDisplay.TextDisplay("-"),
+                        action = KeyAction.CommitText("-"),
+                        color = ColorVariant.MUTED,
+                    ),
+                    SwipeDirection.BOTTOM to KeyC(
+                        display = KeyDisplay.TextDisplay("."),
+                        action = KeyAction.CommitText("."),
+                        color = ColorVariant.MUTED,
+                    ),
+                    SwipeDirection.BOTTOM_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("*"),
+                        action = KeyAction.CommitText("*"),
+                        color = ColorVariant.MUTED,
+                    ),
+                ),
+            ),
+            KeyItemC(
+                center = KeyC(
+                    display = KeyDisplay.TextDisplay("E"),
+                    action = KeyAction.CommitText("E"),
+                    size = FontSizeVariant.LARGE,
+                    color = ColorVariant.PRIMARY,
+                ),
+                swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
+                swipes = mapOf(
+                    SwipeDirection.TOP_LEFT to KeyC(
+                        display = KeyDisplay.TextDisplay("D"),
+                        action = KeyAction.CommitText("D"),
+                    ),
+                ),
+            ),
+            BACKSPACE_KEY_ITEM,
+        ),
+        listOf(
+            SPACEBAR_KEY_ITEM,
+            RETURN_KEY_ITEM,
+        ),
+    ),
+)
+
+val KB_EN_THUMBKEY_COMPOSE: KeyboardDefinition = KeyboardDefinition(
+    title = "EN Thumb-Key english (composed)",
+    modes = KeyboardDefinitionModes(
+        main = KB_EN_THUMBKEY_COMPOSE_MAIN,
+        shifted = KB_EN_THUMBKEY_COMPOSE_SHIFTED,
+        numeric = NUMERIC_KEYBOARD,
+    ),
+    settings = KeyboardDefinitionSettings(
+        autoCapitalizers = arrayOf(::autoCapitalizeI),
+    ),
+)

--- a/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
@@ -15,6 +15,7 @@ import com.dessalines.thumbkey.keyboards.KB_EN_MESSAGEEASE
 import com.dessalines.thumbkey.keyboards.KB_EN_MESSAGEEASE_SYMBOLS
 import com.dessalines.thumbkey.keyboards.KB_EN_NO_TYPESPLIT
 import com.dessalines.thumbkey.keyboards.KB_EN_THUMBKEY
+import com.dessalines.thumbkey.keyboards.KB_EN_THUMBKEY_COMPOSE
 import com.dessalines.thumbkey.keyboards.KB_EN_THUMBKEY_MULTI
 import com.dessalines.thumbkey.keyboards.KB_EN_THUMBKEY_MULTI_CZ
 import com.dessalines.thumbkey.keyboards.KB_EN_THUMBKEY_MULTI_EE
@@ -89,6 +90,7 @@ enum class KeyboardLayout(val index: Int, val keyboardDefinition: KeyboardDefini
     DEMessageEaseSymbols(68, KB_DE_MESSAGEEASE_SYMBOLS),
     DETypeSplit(38, KB_DE_TYPESPLIT),
     ENThumbKey(0, KB_EN_THUMBKEY),
+    ENThumbKeyCompose(74, KB_EN_THUMBKEY_COMPOSE),
     ENThumbKeySymbols(21, KB_EN_THUMBKEY_SYMBOLS),
     ENThumbKeyProgrammer(1, KB_EN_THUMBKEY_PROGRAMMER),
     ENThumbKeyProgrammerWide(44, KB_EN_THUMBKEY_PROGRAMMER_WIDE),

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
@@ -57,6 +57,7 @@ sealed class KeyAction {
     class ToggleShiftMode(val enable: Boolean) : KeyAction()
     class ToggleNumericMode(val enable: Boolean) : KeyAction()
     class ToggleEmojiMode(val enable: Boolean) : KeyAction()
+    class ComposeLastKey(val text: String) : KeyAction()
     data object DeleteLastWord : KeyAction()
     data object GotoSettings : KeyAction()
     data object IMECompleteAction : KeyAction()

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -201,6 +201,125 @@ fun performKeyAction(
             }
         }
 
+        is KeyAction.ComposeLastKey -> {
+            Log.d(TAG, "composing last key")
+            val text = action.text
+            val textBefore = ime.currentInputConnection.getTextBeforeCursor(1, 0)
+
+            val textNew = when (text) {
+                "\"" -> when(textBefore) {
+                    "a" -> "ä"; "A" -> "Ä"
+                    "e" -> "ë"; "E" -> "Ë"
+                    "h" -> "ḧ"; "H" -> "Ḧ"
+                    "i" -> "ï"; "I" -> "Ï"
+                    "o" -> "ö"; "O" -> "Ö"
+                    "t" -> "ẗ"
+                    "u" -> "ü"; "U" -> "Ü"
+                    "w" -> "ẅ"; "W" -> "Ẅ"
+                    "x" -> "ẍ"; "X" -> "Ẍ"
+                    "y" -> "ÿ"; "Y" -> "Ÿ"
+                    " " -> "\""
+                    else -> textBefore
+                }
+                "'" -> when(textBefore) {
+                    "a" -> "á"; "A" -> "Á"
+                    "c" -> "ć"; "C" -> "Ć"
+                    "e" -> "é"; "E" -> "É"
+                    "g" -> "ǵ"; "G" -> "Ǵ"
+                    "i" -> "í"; "I" -> "Í"
+                    "j" -> "j́"; "J" -> "J́"
+                    "k" -> "ḱ"; "K" -> "Ḱ"
+                    "l" -> "ĺ"; "L" -> "Ĺ"
+                    "m" -> "ḿ"; "M" -> "Ḿ"
+                    "n" -> "ń"; "N" -> "Ń"
+                    "o" -> "ó"; "O" -> "Ó"
+                    "p" -> "ṕ"; "P" -> "Ṕ"
+                    "r" -> "ŕ"; "R" -> "Ŕ"
+                    "s" -> "ś"; "S" -> "Ś"
+                    "u" -> "ú"; "U" -> "Ú"
+                    "w" -> "ẃ"; "W" -> "Ẃ"
+                    "y" -> "ý"; "Y" -> "Ý"
+                    "z" -> "ź"; "Z" -> "Ź"
+                    " " -> "'"
+                    else -> textBefore
+                }
+                "`" -> when(textBefore) {
+                    "a" -> "à"; "A" -> "À"
+                    "e" -> "è"; "E" -> "È"
+                    "i" -> "ì"; "I" -> "Ì"
+                    "n" -> "ǹ"; "N" -> "Ǹ"
+                    "o" -> "ò"; "O" -> "Ò"
+                    "u" -> "ù"; "U" -> "Ù"
+                    "ü" -> "ǜ"; "Ü" -> "Ǜ"
+                    "w" -> "ẁ"; "W" -> "Ẁ"
+                    "y" -> "ỳ"; "Y" -> "Ỳ"
+                    " " -> "`"
+                    else -> textBefore
+                }
+                "^" -> when(textBefore) {
+                    "a" -> "â"; "A" -> "Â"
+                    "c" -> "ĉ"; "C" -> "Ĉ"
+                    "e" -> "ê"; "E" -> "Ê"
+                    "g" -> "ĝ"; "G" -> "Ĝ"
+                    "h" -> "ĥ"; "H" -> "Ĥ"
+                    "i" -> "î"; "I" -> "Î"
+                    "j" -> "ĵ"; "J" -> "Ĵ"
+                    "o" -> "ô"; "O" -> "Ô"
+                    "s" -> "ŝ"; "S" -> "Ŝ"
+                    "u" -> "û"; "U" -> "Û"
+                    "w" -> "ŵ"; "W" -> "Ŵ"
+                    "y" -> "ŷ"; "Y" -> "Ŷ"
+                    "z" -> "ẑ"; "Z" -> "Ẑ"
+                    " " -> "^"
+                    else -> textBefore
+                }
+                "~" -> when(textBefore) {
+                    "a" -> "ã"; "A" -> "Ã"
+                    "c" -> "ç"; "C" -> "Ç"
+                    "e" -> "ẽ"; "E" -> "Ẽ"
+                    "i" -> "ĩ"; "I" -> "Ĩ"
+                    "n" -> "ñ"; "N" -> "Ñ"
+                    "o" -> "õ"; "O" -> "Õ"
+                    "u" -> "ũ"; "U" -> "Ũ"
+                    "v" -> "ṽ"; "V" -> "Ṽ"
+                    "y" -> "ỹ"; "Y" -> "Ỹ"
+                    " " -> "~"
+                    else -> textBefore
+                }
+                "°" -> when(textBefore) {
+                    "a" -> "å"; "A" -> "Å"
+                    "o" -> "ø"; "O" -> "Ø"
+                    "u" -> "ů"; "U" -> "Ů"
+                    " " -> "°"
+                    else -> textBefore
+                }
+                "!" -> when(textBefore) {
+                    "a" -> "æ"; "A" -> "Æ"
+                    "c" -> "ç"; "C" -> "Ç"
+                    "e" -> "æ"; "E" -> "Æ"
+                    "s" -> "ß"; "S" -> "ẞ"
+                    "!" -> "¡"
+                    "?" -> "¿"
+                    " " -> "!"
+                    else -> textBefore
+                }
+                "\$" -> when(textBefore) {
+                    "e" -> "€"; "E" -> "€"
+                    "f" -> "₣"; "F" -> "₣"
+                    "l" -> "£"; "L" -> "£"
+                    "y" -> "¥"; "Y" -> "¥"
+                    "w" -> "₩"; "W" -> "₩"
+                    " " -> "\$"
+                    else -> textBefore
+                }
+                else -> throw IllegalStateException("Invalid key modifier")
+            }
+
+            if (textNew != textBefore) {
+                ime.currentInputConnection.deleteSurroundingText(1, 0)
+                ime.currentInputConnection.commitText(textNew, 1)
+            }
+        }
         is KeyAction.ToggleShiftMode -> {
             val enable = action.enable
             Log.d(TAG, "Toggling Shifted: $enable")


### PR DESCRIPTION
Copy of EN layout with added accents on the left side that act as modifiers for previously typed keys. That way it's usable for several Latin based languages while keeping letter positions the same (switching between different other language-specific layouts can be otherwise quite confusing).

I've been using this for several months now, see also issue #204.

Added a new KeyAction to accomplish this.

On a normal qwerty keyboard I'm using [Xcompose](https://wiki.debian.org/XCompose) the same way and that's also where I got most key combinations from.