### PR TITLE
Added slide gestures to Type-Split layouts

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/CommonKeys.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/CommonKeys.kt
@@ -282,6 +282,7 @@ val SPACEBAR_TYPESPLIT_TOP_KEY_ITEM =
             action = KeyAction.CommitText(" "),
         ),
         swipeType = SwipeNWay.FOUR_WAY_CROSS,
+        slideType = SlideType.MOVE_CURSOR,
         swipes = mapOf(
             SwipeDirection.LEFT to KeyC(
                 action = KeyAction.SendEvent(
@@ -471,6 +472,7 @@ val BACKSPACE_TYPESPLIT_KEY_ITEM =
             color = ColorVariant.SECONDARY,
         ),
         swipeType = SwipeNWay.FOUR_WAY_CROSS,
+        slideType = SlideType.DELETE,
         swipes = mapOf(
             SwipeDirection.LEFT to KeyC(
                 action = KeyAction.DeleteWordBeforeCursor,


### PR DESCRIPTION
A very small PR to save me having to deal with a merge conflict from my last PR. This will also add slide gestures to any layout that uses the type-split space key or backspace bar.