### PR TITLE
Added emoji key to Type-Split layout. Fixes #432

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/CommonKeys.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/CommonKeys.kt
@@ -275,7 +275,7 @@ val RETURN_KEY_ITEM =
         backgroundColor = ColorVariant.SURFACE_VARIANT,
     )
 
-val SPACEBAR_TYPESPLIT_TOP_KEY_ITEM =
+val SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM =
     KeyItemC(
         center = KeyC(
             display = KeyDisplay.TextDisplay(" "),
@@ -302,15 +302,15 @@ val SPACEBAR_TYPESPLIT_TOP_KEY_ITEM =
                 ),
                 display = null,
             ),
-            SwipeDirection.BOTTOM to KeyC(
-                display = KeyDisplay.TextDisplay("*"),
-                action = KeyAction.CommitText("*"),
+            SwipeDirection.TOP to KeyC(
+                display = KeyDisplay.TextDisplay("'"),
+                action = KeyAction.CommitText("'"),
                 color = ColorVariant.MUTED,
             ),
-            SwipeDirection.TOP to KeyC(
-                display = KeyDisplay.IconDisplay(Icons.Outlined.Settings),
-                action = KeyAction.GotoSettings,
-                color = ColorVariant.SECONDARY,
+            SwipeDirection.BOTTOM to KeyC(
+                display = KeyDisplay.TextDisplay(","),
+                action = KeyAction.CommitText(","),
+                color = ColorVariant.MUTED,
             ),
         ),
         nextTapActions = listOf(
@@ -323,7 +323,8 @@ val SPACEBAR_TYPESPLIT_TOP_KEY_ITEM =
         ),
         backgroundColor = ColorVariant.SURFACE_VARIANT,
     )
-val SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM = SPACEBAR_TYPESPLIT_TOP_KEY_ITEM.copy(
+val SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM = SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM.copy(
+    swipeType = SwipeNWay.EIGHT_WAY,
     swipes = mapOf(
         SwipeDirection.LEFT to KeyC(
             action = KeyAction.SendEvent(
@@ -342,53 +343,26 @@ val SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM = SPACEBAR_TYPESPLIT_TOP_KEY_ITEM.copy(
                 ),
             ),
             display = null,
-        ),
-        SwipeDirection.BOTTOM to KeyC(
-            display = KeyDisplay.TextDisplay(","),
-            action = KeyAction.CommitText(","),
-            color = ColorVariant.MUTED,
         ),
         SwipeDirection.TOP to KeyC(
-            display = KeyDisplay.TextDisplay("'"),
-            action = KeyAction.CommitText("'"),
+            display = KeyDisplay.TextDisplay("-"),
+            action = KeyAction.CommitText("-"),
             color = ColorVariant.MUTED,
-        ),
-    ),
-)
-val SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM = SPACEBAR_TYPESPLIT_TOP_KEY_ITEM.copy(
-    swipes = mapOf(
-        SwipeDirection.LEFT to KeyC(
-            action = KeyAction.SendEvent(
-                KeyEvent(
-                    KeyEvent.ACTION_DOWN,
-                    KeyEvent.KEYCODE_DPAD_LEFT,
-                ),
-            ),
-            display = null,
-        ),
-        SwipeDirection.RIGHT to KeyC(
-            action = KeyAction.SendEvent(
-                KeyEvent(
-                    KeyEvent.ACTION_DOWN,
-                    KeyEvent.KEYCODE_DPAD_RIGHT,
-                ),
-            ),
-            display = null,
         ),
         SwipeDirection.BOTTOM to KeyC(
             display = KeyDisplay.TextDisplay("."),
             action = KeyAction.CommitText("."),
             color = ColorVariant.MUTED,
         ),
-        SwipeDirection.TOP to KeyC(
-            display = KeyDisplay.TextDisplay("-"),
-            action = KeyAction.CommitText("-"),
+        SwipeDirection.BOTTOM_LEFT to KeyC(
+            display = KeyDisplay.TextDisplay("*"),
+            action = KeyAction.CommitText("*"),
             color = ColorVariant.MUTED,
         ),
     ),
 )
 
-val SPACEBAR_ALL_SYMBOLS = SPACEBAR_TYPESPLIT_TOP_KEY_ITEM.copy(
+val SPACEBAR_ALL_SYMBOLS = SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM.copy(
     swipes = mapOf(
         SwipeDirection.LEFT to KeyC(
             display = KeyDisplay.TextDisplay(","),
@@ -400,19 +374,19 @@ val SPACEBAR_ALL_SYMBOLS = SPACEBAR_TYPESPLIT_TOP_KEY_ITEM.copy(
             action = KeyAction.CommitText("'"),
             color = ColorVariant.MUTED,
         ),
-        SwipeDirection.BOTTOM to KeyC(
-            display = KeyDisplay.TextDisplay("."),
-            action = KeyAction.CommitText("."),
-            color = ColorVariant.MUTED,
-        ),
         SwipeDirection.TOP to KeyC(
             display = KeyDisplay.TextDisplay("-"),
             action = KeyAction.CommitText("-"),
             color = ColorVariant.MUTED,
         ),
+        SwipeDirection.BOTTOM to KeyC(
+            display = KeyDisplay.TextDisplay("."),
+            action = KeyAction.CommitText("."),
+            color = ColorVariant.MUTED,
+        ),
     ),
 )
-val SPACEBAR_ALL_DIRECTIONS = SPACEBAR_TYPESPLIT_TOP_KEY_ITEM.copy(
+val SPACEBAR_ALL_DIRECTIONS = SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM.copy(
     swipes = mapOf(
         SwipeDirection.LEFT to KeyC(
             display = KeyDisplay.TextDisplay("←"),
@@ -434,22 +408,22 @@ val SPACEBAR_ALL_DIRECTIONS = SPACEBAR_TYPESPLIT_TOP_KEY_ITEM.copy(
             ),
             color = ColorVariant.MUTED,
         ),
-        SwipeDirection.BOTTOM to KeyC(
-            display = KeyDisplay.TextDisplay("↓"),
-            action = KeyAction.SendEvent(
-                KeyEvent(
-                    KeyEvent.ACTION_DOWN,
-                    KeyEvent.KEYCODE_DPAD_DOWN,
-                ),
-            ),
-            color = ColorVariant.MUTED,
-        ),
         SwipeDirection.TOP to KeyC(
             display = KeyDisplay.TextDisplay("↑"),
             action = KeyAction.SendEvent(
                 KeyEvent(
                     KeyEvent.ACTION_DOWN,
                     KeyEvent.KEYCODE_DPAD_UP,
+                ),
+            ),
+            color = ColorVariant.MUTED,
+        ),
+        SwipeDirection.BOTTOM to KeyC(
+            display = KeyDisplay.TextDisplay("↓"),
+            action = KeyAction.SendEvent(
+                KeyEvent(
+                    KeyEvent.ACTION_DOWN,
+                    KeyEvent.KEYCODE_DPAD_DOWN,
                 ),
             ),
             color = ColorVariant.MUTED,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DETypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DETypeSplit.kt
@@ -46,7 +46,7 @@ val KB_DE_TYPESPLIT_MAIN = KeyboardC(
                     color = ColorVariant.PRIMARY,
                 ),
             ),
-            SPACEBAR_TYPESPLIT_TOP_KEY_ITEM,
+            EMOJI_KEY_ITEM,
             KeyItemC(
                 center = KeyC(
                     display = KeyDisplay.TextDisplay("t"),
@@ -319,7 +319,7 @@ val KB_DE_TYPESPLIT_SHIFTED = KeyboardC(
                     color = ColorVariant.PRIMARY,
                 ),
             ),
-            SPACEBAR_TYPESPLIT_TOP_KEY_ITEM,
+            EMOJI_KEY_ITEM,
             KeyItemC(
                 center = KeyC(
                     display = KeyDisplay.TextDisplay("T"),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENNOTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENNOTypeSplit.kt
@@ -53,7 +53,7 @@ val KB_EN_NO_TYPESPLIT_MAIN = KeyboardC(
                     ),
                 ),
             ),
-            SPACEBAR_TYPESPLIT_TOP_KEY_ITEM,
+            EMOJI_KEY_ITEM,
             KeyItemC(
                 center = KeyC(
                     display = KeyDisplay.TextDisplay("i"),
@@ -309,7 +309,7 @@ val KB_EN_NO_TYPESPLIT_SHIFTED = KeyboardC(
                     ),
                 ),
             ),
-            SPACEBAR_TYPESPLIT_TOP_KEY_ITEM,
+            EMOJI_KEY_ITEM,
             KeyItemC(
                 center = KeyC(
                     display = KeyDisplay.TextDisplay("I"),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENTypeSplit.kt
@@ -53,7 +53,7 @@ val KB_EN_TYPESPLIT_MAIN = KeyboardC(
                     ),
                 ),
             ),
-            SPACEBAR_TYPESPLIT_TOP_KEY_ITEM,
+            EMOJI_KEY_ITEM,
             KeyItemC(
                 center = KeyC(
                     display = KeyDisplay.TextDisplay("i"),
@@ -294,7 +294,7 @@ val KB_EN_TYPESPLIT_SHIFTED = KeyboardC(
                     ),
                 ),
             ),
-            SPACEBAR_TYPESPLIT_TOP_KEY_ITEM,
+            EMOJI_KEY_ITEM,
             KeyItemC(
                 center = KeyC(
                     display = KeyDisplay.TextDisplay("I"),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ESTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ESTypeSplit.kt
@@ -67,7 +67,7 @@ val KB_ES_TYPESPLIT_MAIN = KeyboardC(
                     ),
                 ),
             ),
-            SPACEBAR_TYPESPLIT_TOP_KEY_ITEM,
+            EMOJI_KEY_ITEM,
             KeyItemC(
                 center = KeyC(
                     display = KeyDisplay.TextDisplay("i"),
@@ -381,7 +381,7 @@ val KB_ES_TYPESPLIT_SHIFTED = KeyboardC(
                     ),
                 ),
             ),
-            SPACEBAR_TYPESPLIT_TOP_KEY_ITEM,
+            EMOJI_KEY_ITEM,
             KeyItemC(
                 center = KeyC(
                     display = KeyDisplay.TextDisplay("I"),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FITypesSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FITypesSplit.kt
@@ -61,7 +61,7 @@ val KB_FI_TYPESPLIT_MAIN = KeyboardC(
                     ),
                 ),
             ),
-            SPACEBAR_TYPESPLIT_TOP_KEY_ITEM,
+            EMOJI_KEY_ITEM,
             KeyItemC(
                 center = KeyC(
                     display = KeyDisplay.TextDisplay("y"),
@@ -321,7 +321,7 @@ val KB_FI_TYPESPLIT_SHIFTED = KeyboardC(
                     ),
                 ),
             ),
-            SPACEBAR_TYPESPLIT_TOP_KEY_ITEM,
+            EMOJI_KEY_ITEM,
             KeyItemC(
                 center = KeyC(
                     display = KeyDisplay.TextDisplay("Y"),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FRTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FRTypeSplit.kt
@@ -74,7 +74,7 @@ val KB_FR_TYPESPLIT_MAIN = KeyboardC(
                     ),
                 ),
             ),
-            SPACEBAR_TYPESPLIT_TOP_KEY_ITEM,
+            EMOJI_KEY_ITEM,
             KeyItemC(
                 center = KeyC(
                     display = KeyDisplay.TextDisplay("t"),
@@ -377,7 +377,7 @@ val KB_FR_TYPESPLIT_SHIFTED = KeyboardC(
                     ),
                 ),
             ),
-            SPACEBAR_TYPESPLIT_TOP_KEY_ITEM,
+            EMOJI_KEY_ITEM,
             KeyItemC(
                 center = KeyC(
                     display = KeyDisplay.TextDisplay("T"),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ITTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ITTypeSplit.kt
@@ -67,7 +67,7 @@ val KB_IT_TYPESPLIT_MAIN = KeyboardC(
                     ),
                 ),
             ),
-            SPACEBAR_TYPESPLIT_TOP_KEY_ITEM,
+            EMOJI_KEY_ITEM,
             KeyItemC(
                 center = KeyC(
                     display = KeyDisplay.TextDisplay("i"),
@@ -334,7 +334,7 @@ val KB_IT_TYPESPLIT_SHIFTED = KeyboardC(
                     ),
                 ),
             ),
-            SPACEBAR_TYPESPLIT_TOP_KEY_ITEM,
+            EMOJI_KEY_ITEM,
             KeyItemC(
                 center = KeyC(
                     display = KeyDisplay.TextDisplay("I"),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/PLTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/PLTypeSplit.kt
@@ -58,7 +58,7 @@ val KB_PL_TYPESPLIT_MAIN = KeyboardC(
                     ),
                 ),
             ),
-            SPACEBAR_TYPESPLIT_TOP_KEY_ITEM,
+            EMOJI_KEY_ITEM,
             KeyItemC(
                 center = KeyC(
                     display = KeyDisplay.TextDisplay("i"),
@@ -369,7 +369,7 @@ val KB_PL_TYPESPLIT_SHIFTED = KeyboardC(
                     ),
                 ),
             ),
-            SPACEBAR_TYPESPLIT_TOP_KEY_ITEM,
+            EMOJI_KEY_ITEM,
             KeyItemC(
                 center = KeyC(
                     display = KeyDisplay.TextDisplay("I"),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/PTTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/PTTypeSplit.kt
@@ -67,7 +67,7 @@ val KB_PT_TYPESPLIT_MAIN = KeyboardC(
                     ),
                 ),
             ),
-            SPACEBAR_TYPESPLIT_TOP_KEY_ITEM,
+            EMOJI_KEY_ITEM,
             KeyItemC(
                 center = KeyC(
                     display = KeyDisplay.TextDisplay("i"),
@@ -364,7 +364,7 @@ val KB_PT_TYPESPLIT_SHIFTED = KeyboardC(
                     ),
                 ),
             ),
-            SPACEBAR_TYPESPLIT_TOP_KEY_ITEM,
+            EMOJI_KEY_ITEM,
             KeyItemC(
                 center = KeyC(
                     display = KeyDisplay.TextDisplay("I"),


### PR DESCRIPTION
- Added emoji key to the top row of all the type-split layouts.
- Removed SPACEBAR_TYPESPLIT_  **TOP_**  _KEY_ITEM, and changed all references to point to the middle spacebar key.
- Made SPACEBAR_TYPESPLIT_  **_MIDDLE**  _KEY_ITEM its own KeyItemC, and not a copy of a KeyItemC
- Moved the '*' symbol to the bottom left corner of the bottom space key.

![thumbkey_typesplit](https://github.com/dessalines/thumb-key/assets/43177940/0d6fcdae-66d4-4248-9462-67c208d0c3ac)
