### PR TITLE
AutoCapitalize "i\'" ("I'm" and "I'd")

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/utils/AutoCapitalizers.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/AutoCapitalizers.kt
@@ -16,6 +16,12 @@ fun autoCapitalizeI(
                 "I ",
                 1,
             )
+        } else if (textBefore == " i\'") {
+            ime.currentInputConnection.deleteSurroundingText(2, 0)
+            ime.currentInputConnection.commitText(
+                "I\'",
+                1,
+            )
         }
     }
 }


### PR DESCRIPTION
Possible improvements: only autocapitalize if language is English. See also issue #500