### PR TITLE
Add English-Norwegian Thumb-Key layout

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENNOThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENNOThumbKey.kt
@@ -1,0 +1,594 @@
+package com.dessalines.thumbkey.keyboards
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowDropDown
+import androidx.compose.material.icons.outlined.ArrowDropUp
+import androidx.compose.material.icons.outlined.Copyright
+import androidx.compose.material.icons.outlined.KeyboardCapslock
+import com.dessalines.thumbkey.utils.ColorVariant
+import com.dessalines.thumbkey.utils.FontSizeVariant
+import com.dessalines.thumbkey.utils.KeyAction
+import com.dessalines.thumbkey.utils.KeyC
+import com.dessalines.thumbkey.utils.KeyDisplay
+import com.dessalines.thumbkey.utils.KeyItemC
+import com.dessalines.thumbkey.utils.KeyboardC
+import com.dessalines.thumbkey.utils.KeyboardDefinition
+import com.dessalines.thumbkey.utils.KeyboardDefinitionModes
+import com.dessalines.thumbkey.utils.SwipeDirection
+import com.dessalines.thumbkey.utils.SwipeNWay
+
+val KB_EN_NO_THUMBKEY_MAIN =
+    KeyboardC(
+        listOf(
+            listOf(
+                KeyItemC(
+                    center =
+                    KeyC(
+                        display = KeyDisplay.TextDisplay("s"),
+                        action = KeyAction.CommitText("s"),
+                        size = FontSizeVariant.LARGE,
+                        color = ColorVariant.PRIMARY,
+                    ),
+                    swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
+                    swipes =
+                    mapOf(
+                        SwipeDirection.BOTTOM_RIGHT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("w"),
+                                action = KeyAction.CommitText("w"),
+                            ),
+                    ),
+                ),
+                KeyItemC(
+                    center =
+                    KeyC(
+                        display = KeyDisplay.TextDisplay("r"),
+                        action = KeyAction.CommitText("r"),
+                        size = FontSizeVariant.LARGE,
+                        color = ColorVariant.PRIMARY,
+                    ),
+                    swipeType = SwipeNWay.TWO_WAY_VERTICAL,
+                    swipes =
+                    mapOf(
+                        SwipeDirection.BOTTOM to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("g"),
+                                action = KeyAction.CommitText("g"),
+                            ),
+                    ),
+                ),
+                KeyItemC(
+                    center =
+                    KeyC(
+                        display = KeyDisplay.TextDisplay("o"),
+                        action = KeyAction.CommitText("o"),
+                        size = FontSizeVariant.LARGE,
+                        color = ColorVariant.PRIMARY,
+                    ),
+                    swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
+                    swipes =
+                    mapOf(
+                        SwipeDirection.BOTTOM_LEFT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("u"),
+                                action = KeyAction.CommitText("u"),
+                            ),
+                        SwipeDirection.BOTTOM_RIGHT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("ø"),
+                                action = KeyAction.CommitText("ø"),
+                            ),
+                        SwipeDirection.TOP_LEFT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("ò"),
+                                action = KeyAction.CommitText("ò"),
+                            ),
+                        SwipeDirection.TOP_RIGHT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("ô"),
+                                action = KeyAction.CommitText("ô"),
+                            ),
+                    ),
+                ),
+                EMOJI_KEY_ITEM,
+            ),
+            listOf(
+                KeyItemC(
+                    center =
+                    KeyC(
+                        display = KeyDisplay.TextDisplay("n"),
+                        action = KeyAction.CommitText("n"),
+                        size = FontSizeVariant.LARGE,
+                        color = ColorVariant.PRIMARY,
+                    ),
+                    swipeType = SwipeNWay.TWO_WAY_HORIZONTAL,
+                    swipes =
+                    mapOf(
+                        SwipeDirection.RIGHT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("m"),
+                                action = KeyAction.CommitText("m"),
+                            ),
+                    ),
+                ),
+                KeyItemC(
+                    center =
+                    KeyC(
+                        display = KeyDisplay.TextDisplay("h"),
+                        action = KeyAction.CommitText("h"),
+                        size = FontSizeVariant.LARGE,
+                        color = ColorVariant.PRIMARY,
+                    ),
+                    swipes =
+                    mapOf(
+                        SwipeDirection.TOP_LEFT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("j"),
+                                action = KeyAction.CommitText("j"),
+                            ),
+                        SwipeDirection.TOP to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("q"),
+                                action = KeyAction.CommitText("q"),
+                            ),
+                        SwipeDirection.TOP_RIGHT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("b"),
+                                action = KeyAction.CommitText("b"),
+                            ),
+                        SwipeDirection.RIGHT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("p"),
+                                action = KeyAction.CommitText("p"),
+                            ),
+                        SwipeDirection.BOTTOM_RIGHT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("y"),
+                                action = KeyAction.CommitText("y"),
+                            ),
+                        SwipeDirection.BOTTOM to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("x"),
+                                action = KeyAction.CommitText("x"),
+                            ),
+                        SwipeDirection.BOTTOM_LEFT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("v"),
+                                action = KeyAction.CommitText("v"),
+                            ),
+                        SwipeDirection.LEFT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("k"),
+                                action = KeyAction.CommitText("k"),
+                            ),
+                    ),
+                ),
+                KeyItemC(
+                    center =
+                    KeyC(
+                        display = KeyDisplay.TextDisplay("a"),
+                        action = KeyAction.CommitText("a"),
+                        size = FontSizeVariant.LARGE,
+                        color = ColorVariant.PRIMARY,
+                    ),
+                    swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                    swipes =
+                    mapOf(
+                        SwipeDirection.LEFT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("l"),
+                                action = KeyAction.CommitText("l"),
+                            ),
+                        SwipeDirection.TOP to
+                            KeyC(
+                                display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
+                                action = KeyAction.ToggleShiftMode(true),
+                                color = ColorVariant.MUTED,
+                            ),
+                        SwipeDirection.RIGHT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("å"),
+                                action = KeyAction.CommitText("å"),
+                            ),
+                    ),
+                ),
+                NUMERIC_KEY_ITEM,
+            ),
+            listOf(
+                KeyItemC(
+                    center =
+                    KeyC(
+                        display = KeyDisplay.TextDisplay("t"),
+                        action = KeyAction.CommitText("t"),
+                        size = FontSizeVariant.LARGE,
+                        color = ColorVariant.PRIMARY,
+                    ),
+                    swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
+                    swipes =
+                    mapOf(
+                        SwipeDirection.TOP_RIGHT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("c"),
+                                action = KeyAction.CommitText("c"),
+                            ),
+                    ),
+                ),
+                KeyItemC(
+                    center =
+                    KeyC(
+                        display = KeyDisplay.TextDisplay("i"),
+                        action = KeyAction.CommitText("i"),
+                        size = FontSizeVariant.LARGE,
+                        color = ColorVariant.PRIMARY,
+                    ),
+                    swipes =
+                    mapOf(
+                        SwipeDirection.TOP to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("f"),
+                                action = KeyAction.CommitText("f"),
+                            ),
+                        SwipeDirection.TOP_RIGHT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("'"),
+                                action = KeyAction.CommitText("'"),
+                                color = ColorVariant.MUTED,
+                            ),
+                        SwipeDirection.RIGHT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("z"),
+                                action = KeyAction.CommitText("z"),
+                            ),
+                        SwipeDirection.BOTTOM_RIGHT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("-"),
+                                action = KeyAction.CommitText("-"),
+                                color = ColorVariant.MUTED,
+                            ),
+                        SwipeDirection.BOTTOM to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("."),
+                                action = KeyAction.CommitText("."),
+                                color = ColorVariant.MUTED,
+                            ),
+                        SwipeDirection.BOTTOM_LEFT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("*"),
+                                action = KeyAction.CommitText("*"),
+                                color = ColorVariant.MUTED,
+                            ),
+                    ),
+                ),
+                KeyItemC(
+                    center =
+                    KeyC(
+                        display = KeyDisplay.TextDisplay("e"),
+                        action = KeyAction.CommitText("e"),
+                        size = FontSizeVariant.LARGE,
+                        color = ColorVariant.PRIMARY,
+                    ),
+                    swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
+                    swipes =
+                    mapOf(
+                        SwipeDirection.TOP_LEFT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("d"),
+                                action = KeyAction.CommitText("d"),
+                            ),
+                        SwipeDirection.TOP_RIGHT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("æ"),
+                                action = KeyAction.CommitText("æ"),
+                            ),
+                        SwipeDirection.BOTTOM_LEFT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("é"),
+                                action = KeyAction.CommitText("é"),
+                            ),
+                    ),
+                ),
+                BACKSPACE_KEY_ITEM,
+            ),
+            listOf(
+                SPACEBAR_KEY_ITEM,
+                RETURN_KEY_ITEM,
+            ),
+        ),
+    )
+
+val KB_EN_NO_THUMBKEY_SHIFTED =
+    KeyboardC(
+        listOf(
+            listOf(
+                KeyItemC(
+                    center =
+                    KeyC(
+                        display = KeyDisplay.TextDisplay("S"),
+                        action = KeyAction.CommitText("S"),
+                        size = FontSizeVariant.LARGE,
+                        color = ColorVariant.PRIMARY,
+                    ),
+                    swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
+                    swipes =
+                    mapOf(
+                        SwipeDirection.BOTTOM_RIGHT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("W"),
+                                action = KeyAction.CommitText("W"),
+                            ),
+                    ),
+                ),
+                KeyItemC(
+                    center =
+                    KeyC(
+                        display = KeyDisplay.TextDisplay("R"),
+                        action = KeyAction.CommitText("R"),
+                        size = FontSizeVariant.LARGE,
+                        color = ColorVariant.PRIMARY,
+                    ),
+                    swipeType = SwipeNWay.TWO_WAY_VERTICAL,
+                    swipes =
+                    mapOf(
+                        SwipeDirection.BOTTOM to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("G"),
+                                action = KeyAction.CommitText("G"),
+                            ),
+                    ),
+                ),
+                KeyItemC(
+                    center =
+                    KeyC(
+                        display = KeyDisplay.TextDisplay("O"),
+                        action = KeyAction.CommitText("O"),
+                        size = FontSizeVariant.LARGE,
+                        color = ColorVariant.PRIMARY,
+                    ),
+                    swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
+                    swipes =
+                    mapOf(
+                        SwipeDirection.BOTTOM_LEFT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("U"),
+                                action = KeyAction.CommitText("U"),
+                            ),
+                        SwipeDirection.BOTTOM_RIGHT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("Ø"),
+                                action = KeyAction.CommitText("Ø"),
+                            ),
+                        SwipeDirection.TOP_LEFT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("Ò"),
+                                action = KeyAction.CommitText("Ò"),
+                            ),
+                        SwipeDirection.TOP_RIGHT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("Ô"),
+                                action = KeyAction.CommitText("Ô"),
+                            ),
+                    ),
+                ),
+                EMOJI_KEY_ITEM,
+            ),
+            listOf(
+                KeyItemC(
+                    center =
+                    KeyC(
+                        display = KeyDisplay.TextDisplay("N"),
+                        action = KeyAction.CommitText("N"),
+                        size = FontSizeVariant.LARGE,
+                        color = ColorVariant.PRIMARY,
+                    ),
+                    swipeType = SwipeNWay.TWO_WAY_HORIZONTAL,
+                    swipes =
+                    mapOf(
+                        SwipeDirection.RIGHT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("M"),
+                                action = KeyAction.CommitText("M"),
+                            ),
+                    ),
+                ),
+                KeyItemC(
+                    center =
+                    KeyC(
+                        display = KeyDisplay.TextDisplay("H"),
+                        action = KeyAction.CommitText("H"),
+                        size = FontSizeVariant.LARGE,
+                        color = ColorVariant.PRIMARY,
+                    ),
+                    swipes =
+                    mapOf(
+                        SwipeDirection.TOP_LEFT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("J"),
+                                action = KeyAction.CommitText("J"),
+                            ),
+                        SwipeDirection.TOP to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("Q"),
+                                action = KeyAction.CommitText("Q"),
+                            ),
+                        SwipeDirection.TOP_RIGHT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("B"),
+                                action = KeyAction.CommitText("B"),
+                            ),
+                        SwipeDirection.RIGHT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("P"),
+                                action = KeyAction.CommitText("P"),
+                            ),
+                        SwipeDirection.BOTTOM_RIGHT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("Y"),
+                                action = KeyAction.CommitText("Y"),
+                            ),
+                        SwipeDirection.BOTTOM to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("X"),
+                                action = KeyAction.CommitText("X"),
+                            ),
+                        SwipeDirection.BOTTOM_LEFT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("V"),
+                                action = KeyAction.CommitText("V"),
+                            ),
+                        SwipeDirection.LEFT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("K"),
+                                action = KeyAction.CommitText("K"),
+                            ),
+                    ),
+                ),
+                KeyItemC(
+                    center =
+                    KeyC(
+                        display = KeyDisplay.TextDisplay("A"),
+                        action = KeyAction.CommitText("A"),
+                        size = FontSizeVariant.LARGE,
+                        color = ColorVariant.PRIMARY,
+                    ),
+                    swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                    swipes =
+                    mapOf(
+                        SwipeDirection.LEFT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("L"),
+                                action = KeyAction.CommitText("L"),
+                            ),
+                        SwipeDirection.BOTTOM to
+                            KeyC(
+                                display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
+                                action = KeyAction.ToggleShiftMode(false),
+                                color = ColorVariant.MUTED,
+                            ),
+                        SwipeDirection.TOP to
+                            KeyC(
+                                display = KeyDisplay.IconDisplay(Icons.Outlined.KeyboardCapslock),
+                                capsModeDisplay = KeyDisplay.IconDisplay(Icons.Outlined.Copyright),
+                                action = KeyAction.ToggleCapsLock,
+                                color = ColorVariant.MUTED,
+                            ),
+                        SwipeDirection.RIGHT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("Å"),
+                                action = KeyAction.CommitText("Å"),
+                            ),
+                    ),
+                ),
+                NUMERIC_KEY_ITEM,
+            ),
+            listOf(
+                KeyItemC(
+                    center =
+                    KeyC(
+                        display = KeyDisplay.TextDisplay("T"),
+                        action = KeyAction.CommitText("T"),
+                        size = FontSizeVariant.LARGE,
+                        color = ColorVariant.PRIMARY,
+                    ),
+                    swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
+                    swipes =
+                    mapOf(
+                        SwipeDirection.TOP_RIGHT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("C"),
+                                action = KeyAction.CommitText("C"),
+                            ),
+                    ),
+                ),
+                KeyItemC(
+                    center =
+                    KeyC(
+                        display = KeyDisplay.TextDisplay("I"),
+                        action = KeyAction.CommitText("I"),
+                        size = FontSizeVariant.LARGE,
+                        color = ColorVariant.PRIMARY,
+                    ),
+                    swipes =
+                    mapOf(
+                        SwipeDirection.TOP to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("F"),
+                                action = KeyAction.CommitText("F"),
+                            ),
+                        SwipeDirection.TOP_RIGHT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("'"),
+                                action = KeyAction.CommitText("'"),
+                                color = ColorVariant.MUTED,
+                            ),
+                        SwipeDirection.RIGHT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("Z"),
+                                action = KeyAction.CommitText("Z"),
+                            ),
+                        SwipeDirection.BOTTOM_RIGHT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("-"),
+                                action = KeyAction.CommitText("-"),
+                                color = ColorVariant.MUTED,
+                            ),
+                        SwipeDirection.BOTTOM to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("."),
+                                action = KeyAction.CommitText("."),
+                                color = ColorVariant.MUTED,
+                            ),
+                        SwipeDirection.BOTTOM_LEFT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("*"),
+                                action = KeyAction.CommitText("*"),
+                                color = ColorVariant.MUTED,
+                            ),
+                    ),
+                ),
+                KeyItemC(
+                    center =
+                    KeyC(
+                        display = KeyDisplay.TextDisplay("E"),
+                        action = KeyAction.CommitText("E"),
+                        size = FontSizeVariant.LARGE,
+                        color = ColorVariant.PRIMARY,
+                    ),
+                    swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
+                    swipes =
+                    mapOf(
+                        SwipeDirection.TOP_LEFT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("D"),
+                                action = KeyAction.CommitText("D"),
+                            ),
+                        SwipeDirection.TOP_RIGHT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("Æ"),
+                                action = KeyAction.CommitText("Æ"),
+                            ),
+                        SwipeDirection.BOTTOM_LEFT to
+                            KeyC(
+                                display = KeyDisplay.TextDisplay("É"),
+                                action = KeyAction.CommitText("É"),
+                            ),
+                    ),
+                ),
+                BACKSPACE_KEY_ITEM,
+            ),
+            listOf(
+                SPACEBAR_KEY_ITEM,
+                RETURN_KEY_ITEM,
+            ),
+        ),
+    )
+
+val KB_EN_NO_THUMBKEY: KeyboardDefinition =
+    KeyboardDefinition(
+        title = "english norsk thumb-key",
+        modes =
+        KeyboardDefinitionModes(
+            main = KB_EN_NO_THUMBKEY_MAIN,
+            shifted = KB_EN_NO_THUMBKEY_SHIFTED,
+            numeric = NUMERIC_KEYBOARD,
+        ),
+    )

--- a/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
@@ -16,6 +16,7 @@ import com.dessalines.thumbkey.keyboards.KB_EN_EE_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_EN_IT_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_EN_MESSAGEEASE
 import com.dessalines.thumbkey.keyboards.KB_EN_MESSAGEEASE_SYMBOLS
+import com.dessalines.thumbkey.keyboards.KB_EN_NO_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_EN_NO_TYPESPLIT
 import com.dessalines.thumbkey.keyboards.KB_EN_SK_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_EN_THUMBKEY
@@ -154,4 +155,5 @@ enum class KeyboardLayout(val index: Int, val keyboardDefinition: KeyboardDefini
     SKThumbKey(72, KB_SK_THUMBKEY),
     ENNOTypeSplit(73, KB_EN_NO_TYPESPLIT),
     ENThumbKeyCompose(74, KB_EN_THUMBKEY_COMPOSE),
+    ENNOThumbKey(75, KB_EN_NO_THUMBKEY),
 }


### PR DESCRIPTION
Derived from the English Thumb-Key layout, with the Norwegian-specific vowels added plus a couple of accented letters that are common in Norwegian.

<img width="240" src="https://github.com/dessalines/thumb-key/assets/88139840/6d335e4b-28a2-400d-b5b3-67a62f95d7da">
