### PR TITLE
fix apostrophe autocorrect in the other two-handed layouts

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENTwoHandsSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENTwoHandsSymbols.kt
@@ -17,6 +17,7 @@ import com.dessalines.thumbkey.utils.KeyboardDefinitionSettings
 import com.dessalines.thumbkey.utils.SwipeDirection
 import com.dessalines.thumbkey.utils.SwipeNWay
 import com.dessalines.thumbkey.utils.autoCapitalizeI
+import com.dessalines.thumbkey.utils.autoCapitalizeIApostrophe
 
 val KB_EN_TWO_HANDS_SYMBOLS_MAIN =
     KeyboardC(
@@ -1731,6 +1732,6 @@ val KB_EN_TWO_HANDS_SYMBOLS: KeyboardDefinition =
         ),
         settings =
         KeyboardDefinitionSettings(
-            autoCapitalizers = arrayOf(::autoCapitalizeI),
+            autoCapitalizers = arrayOf(::autoCapitalizeI, ::autoCapitalizeIApostrophe),
         ),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENTwoHandsSymbolsNumbers.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENTwoHandsSymbolsNumbers.kt
@@ -17,6 +17,7 @@ import com.dessalines.thumbkey.utils.KeyboardDefinitionSettings
 import com.dessalines.thumbkey.utils.SwipeDirection
 import com.dessalines.thumbkey.utils.SwipeNWay
 import com.dessalines.thumbkey.utils.autoCapitalizeI
+import com.dessalines.thumbkey.utils.autoCapitalizeIApostrophe
 
 val KB_EN_TWO_HANDS_SYMBOLS_NUMBERS_MAIN =
     KeyboardC(
@@ -1991,6 +1992,6 @@ val KB_EN_TWO_HANDS_SYMBOLS_NUMBERS: KeyboardDefinition =
         ),
         settings =
         KeyboardDefinitionSettings(
-            autoCapitalizers = arrayOf(::autoCapitalizeI),
+            autoCapitalizers = arrayOf(::autoCapitalizeI, ::autoCapitalizeIApostrophe),
         ),
     )


### PR DESCRIPTION
Quick fix, adds I'm/I'd autocorrect to the other twohands keyboards