### PR TITLE
Update HUThumbKey.kt

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/HUThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/HUThumbKey.kt
@@ -185,7 +185,6 @@ val KB_HU_THUMBKEY_MAIN =
                             size = FontSizeVariant.LARGE,
                             color = ColorVariant.PRIMARY,
                         ),
-                    swipeType = SwipeNWay.FOUR_WAY_CROSS,
                     swipes =
                         mapOf(
                             SwipeDirection.TOP to
@@ -286,7 +285,6 @@ val KB_HU_THUMBKEY_MAIN =
                             size = FontSizeVariant.LARGE,
                             color = ColorVariant.PRIMARY,
                         ),
-                    swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
                     swipes =
                         mapOf(
                             SwipeDirection.TOP_LEFT to
@@ -478,7 +476,6 @@ val KB_HU_THUMBKEY_SHIFTED =
                             size = FontSizeVariant.LARGE,
                             color = ColorVariant.PRIMARY,
                         ),
-                    swipeType = SwipeNWay.FOUR_WAY_CROSS,
                     swipes =
                         mapOf(
                             SwipeDirection.TOP to
@@ -586,7 +583,6 @@ val KB_HU_THUMBKEY_SHIFTED =
                             size = FontSizeVariant.LARGE,
                             color = ColorVariant.PRIMARY,
                         ),
-                    swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
                     swipes =
                         mapOf(
                             SwipeDirection.TOP_LEFT to


### PR DESCRIPTION
This is (hopefully) the last fix for the Hungarian layout. Á and É are now typable.