### PR TITLE
Fix issues with Japanese TypeSplit layouts

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/JATypeSplitHiragana.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/JATypeSplitHiragana.kt
@@ -438,19 +438,67 @@ val KB_JA_TYPESPLIT_HIRAGANA_SHIFTED =
                 KeyItemC(
                     center =
                         KeyC(
-                            display = KeyDisplay.TextDisplay("ゔ"),
-                            action = KeyAction.CommitText("ゔ"),
+                            display = KeyDisplay.TextDisplay("¥"),
+                            action = KeyAction.CommitText("¥"),
                             size = FontSizeVariant.LARGE,
                             color = ColorVariant.PRIMARY,
+                        ),
+                    swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                    swipes =
+                        mapOf(
+                            SwipeDirection.RIGHT to
+                                KeyC(
+                                    display = null,
+                                    action = KeyAction.CommitText("※"),
+                                ),
+                            SwipeDirection.LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("※"),
+                                    action = KeyAction.CommitText("※"),
+                                ),
+                            SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("ヶ"),
+                                    action = KeyAction.CommitText("ヶ"),
+                                ),
+                            SwipeDirection.TOP to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("ヵ"),
+                                    action = KeyAction.CommitText("ヵ"),
+                                ),
                         ),
                 ),
                 KeyItemC(
                     center =
                         KeyC(
-                            display = KeyDisplay.TextDisplay("っ"),
-                            action = KeyAction.CommitText("っ"),
+                            display = KeyDisplay.TextDisplay("だ"),
+                            action = KeyAction.CommitText("だ"),
                             size = FontSizeVariant.LARGE,
                             color = ColorVariant.PRIMARY,
+                        ),
+                    swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                    swipes =
+                        mapOf(
+                            SwipeDirection.RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("で"),
+                                    action = KeyAction.CommitText("で"),
+                                ),
+                            SwipeDirection.LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("ぢ"),
+                                    action = KeyAction.CommitText("ぢ"),
+                                ),
+                            SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("ど"),
+                                    action = KeyAction.CommitText("ど"),
+                                ),
+                            SwipeDirection.TOP to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("づ"),
+                                    action = KeyAction.CommitText("づ"),
+                                ),
                         ),
                 ),
                 EMOJI_KEY_ITEM,
@@ -467,13 +515,13 @@ val KB_JA_TYPESPLIT_HIRAGANA_SHIFTED =
                         mapOf(
                             SwipeDirection.RIGHT to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("ゅ"),
+                                    display = null,
                                     action = KeyAction.CommitText("ゅ"),
                                 ),
                             SwipeDirection.LEFT to
                                 KeyC(
                                     display = null,
-                                    action = KeyAction.CommitText("ゅ"),
+                                    action = KeyAction.CommitText("ょ"),
                                 ),
                             SwipeDirection.BOTTOM to
                                 KeyC(
@@ -482,7 +530,7 @@ val KB_JA_TYPESPLIT_HIRAGANA_SHIFTED =
                                 ),
                             SwipeDirection.TOP to
                                 KeyC(
-                                    display = null,
+                                    display = KeyDisplay.TextDisplay("ゅ"),
                                     action = KeyAction.CommitText("ゅ"),
                                 ),
                         ),
@@ -490,34 +538,10 @@ val KB_JA_TYPESPLIT_HIRAGANA_SHIFTED =
                 KeyItemC(
                     center =
                         KeyC(
-                            display = KeyDisplay.TextDisplay("ぱ"),
-                            action = KeyAction.CommitText("ぱ"),
+                            display = KeyDisplay.TextDisplay("ゔ"),
+                            action = KeyAction.CommitText("ゔ"),
                             size = FontSizeVariant.LARGE,
                             color = ColorVariant.PRIMARY,
-                        ),
-                    swipeType = SwipeNWay.FOUR_WAY_CROSS,
-                    swipes =
-                        mapOf(
-                            SwipeDirection.RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("ぺ"),
-                                    action = KeyAction.CommitText("ぺ"),
-                                ),
-                            SwipeDirection.LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("ぴ"),
-                                    action = KeyAction.CommitText("ぴ"),
-                                ),
-                            SwipeDirection.BOTTOM to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("ぽ"),
-                                    action = KeyAction.CommitText("ぽ"),
-                                ),
-                            SwipeDirection.TOP to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("ぷ"),
-                                    action = KeyAction.CommitText("ぷ"),
-                                ),
                         ),
                 ),
             ),
@@ -558,8 +582,8 @@ val KB_JA_TYPESPLIT_HIRAGANA_SHIFTED =
                 KeyItemC(
                     center =
                         KeyC(
-                            display = KeyDisplay.TextDisplay("だ"),
-                            action = KeyAction.CommitText("だ"),
+                            display = KeyDisplay.TextDisplay("ざ"),
+                            action = KeyAction.CommitText("ざ"),
                             size = FontSizeVariant.LARGE,
                             color = ColorVariant.PRIMARY,
                         ),
@@ -568,27 +592,60 @@ val KB_JA_TYPESPLIT_HIRAGANA_SHIFTED =
                         mapOf(
                             SwipeDirection.RIGHT to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("で"),
-                                    action = KeyAction.CommitText("で"),
+                                    display = KeyDisplay.TextDisplay("ぜ"),
+                                    action = KeyAction.CommitText("ぜ"),
                                 ),
                             SwipeDirection.LEFT to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("ぢ"),
-                                    action = KeyAction.CommitText("ぢ"),
+                                    display = KeyDisplay.TextDisplay("じ"),
+                                    action = KeyAction.CommitText("じ"),
                                 ),
                             SwipeDirection.BOTTOM to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("ど"),
-                                    action = KeyAction.CommitText("ど"),
+                                    display = KeyDisplay.TextDisplay("ぞ"),
+                                    action = KeyAction.CommitText("ぞ"),
                                 ),
                             SwipeDirection.TOP to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("づ"),
-                                    action = KeyAction.CommitText("づ"),
+                                    display = KeyDisplay.TextDisplay("ず"),
+                                    action = KeyAction.CommitText("ず"),
                                 ),
                         ),
                 ),
                 SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM,
+                KeyItemC(
+                    center =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("ば"),
+                            action = KeyAction.CommitText("ば"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
+                    swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                    swipes =
+                        mapOf(
+                            SwipeDirection.RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("び"),
+                                    action = KeyAction.CommitText("び"),
+                                ),
+                            SwipeDirection.LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("べ"),
+                                    action = KeyAction.CommitText("べ"),
+                                ),
+                            SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("ぼ"),
+                                    action = KeyAction.CommitText("ぼ"),
+                                ),
+                            SwipeDirection.TOP to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("ぶ"),
+                                    action = KeyAction.CommitText("ぶ"),
+                                ),
+                        ),
+                ),
                 KeyItemC(
                     center =
                         KeyC(
@@ -602,13 +659,13 @@ val KB_JA_TYPESPLIT_HIRAGANA_SHIFTED =
                         mapOf(
                             SwipeDirection.RIGHT to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("ぎ"),
-                                    action = KeyAction.CommitText("ぎ"),
+                                    display = KeyDisplay.TextDisplay("げ"),
+                                    action = KeyAction.CommitText("げ"),
                                 ),
                             SwipeDirection.LEFT to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("げ"),
-                                    action = KeyAction.CommitText("げ"),
+                                    display = KeyDisplay.TextDisplay("ぎ"),
+                                    action = KeyAction.CommitText("ぎ"),
                                 ),
                             SwipeDirection.BOTTOM to
                                 KeyC(
@@ -622,6 +679,8 @@ val KB_JA_TYPESPLIT_HIRAGANA_SHIFTED =
                                 ),
                         ),
                 ),
+            ),
+            listOf(
                 KeyItemC(
                     center =
                         KeyC(
@@ -637,123 +696,25 @@ val KB_JA_TYPESPLIT_HIRAGANA_SHIFTED =
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("】"),
                                     action = KeyAction.CommitText("】"),
+                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("【"),
                                     action = KeyAction.CommitText("【"),
+                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.BOTTOM to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("："),
                                     action = KeyAction.CommitText("："),
+                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.TOP to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("〃"),
                                     action = KeyAction.CommitText("〃"),
-                                ),
-                        ),
-                ),
-            ),
-            listOf(
-                KeyItemC(
-                    center =
-                        KeyC(
-                            display = KeyDisplay.TextDisplay("ざ"),
-                            action = KeyAction.CommitText("ざ"),
-                            size = FontSizeVariant.LARGE,
-                            color = ColorVariant.PRIMARY,
-                        ),
-                    swipeType = SwipeNWay.FOUR_WAY_CROSS,
-                    swipes =
-                        mapOf(
-                            SwipeDirection.RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("じ"),
-                                    action = KeyAction.CommitText("じ"),
-                                ),
-                            SwipeDirection.LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("ぜ"),
-                                    action = KeyAction.CommitText("ぜ"),
-                                ),
-                            SwipeDirection.BOTTOM to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("ぞ"),
-                                    action = KeyAction.CommitText("ぞ"),
-                                ),
-                            SwipeDirection.TOP to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("ず"),
-                                    action = KeyAction.CommitText("ず"),
-                                ),
-                        ),
-                ),
-                KeyItemC(
-                    center =
-                        KeyC(
-                            display = KeyDisplay.TextDisplay("ば"),
-                            action = KeyAction.CommitText("ば"),
-                            size = FontSizeVariant.LARGE,
-                            color = ColorVariant.PRIMARY,
-                        ),
-                    swipeType = SwipeNWay.FOUR_WAY_CROSS,
-                    swipes =
-                        mapOf(
-                            SwipeDirection.RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("べ"),
-                                    action = KeyAction.CommitText("べ"),
-                                ),
-                            SwipeDirection.LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("び"),
-                                    action = KeyAction.CommitText("び"),
-                                ),
-                            SwipeDirection.BOTTOM to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("ぼ"),
-                                    action = KeyAction.CommitText("ぼ"),
-                                ),
-                            SwipeDirection.TOP to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("ぶ"),
-                                    action = KeyAction.CommitText("ぶ"),
-                                ),
-                        ),
-                ),
-                SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
-                KeyItemC(
-                    center =
-                        KeyC(
-                            display = KeyDisplay.TextDisplay("¥"),
-                            action = KeyAction.CommitText("¥"),
-                            size = FontSizeVariant.LARGE,
-                            color = ColorVariant.PRIMARY,
-                        ),
-                    swipeType = SwipeNWay.FOUR_WAY_CROSS,
-                    swipes =
-                        mapOf(
-                            SwipeDirection.RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("※"),
-                                    action = KeyAction.CommitText("※"),
-                                ),
-                            SwipeDirection.LEFT to
-                                KeyC(
-                                    display = null,
-                                    action = KeyAction.CommitText("※"),
-                                ),
-                            SwipeDirection.BOTTOM to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("ヶ"),
-                                    action = KeyAction.CommitText("ヶ"),
-                                ),
-                            SwipeDirection.TOP to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("ヵ"),
-                                    action = KeyAction.CommitText("ヵ"),
+                                    color = ColorVariant.MUTED,
                                 ),
                         ),
                 ),
@@ -770,14 +731,14 @@ val KB_JA_TYPESPLIT_HIRAGANA_SHIFTED =
                         mapOf(
                             SwipeDirection.RIGHT to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("÷"),
-                                    action = KeyAction.CommitText("÷"),
+                                    display = KeyDisplay.TextDisplay("×"),
+                                    action = KeyAction.CommitText("×"),
                                     color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.LEFT to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("×"),
-                                    action = KeyAction.CommitText("×"),
+                                    display = KeyDisplay.TextDisplay("÷"),
+                                    action = KeyAction.CommitText("÷"),
                                     color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.BOTTOM to
@@ -792,6 +753,49 @@ val KB_JA_TYPESPLIT_HIRAGANA_SHIFTED =
                                     action = KeyAction.CommitText("－"),
                                     color = ColorVariant.MUTED,
                                 ),
+                        ),
+                ),
+                SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
+                KeyItemC(
+                    center =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("ぱ"),
+                            action = KeyAction.CommitText("ぱ"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
+                    swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                    swipes =
+                        mapOf(
+                            SwipeDirection.RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("ぴ"),
+                                    action = KeyAction.CommitText("ぴ"),
+                                ),
+                            SwipeDirection.LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("ぺ"),
+                                    action = KeyAction.CommitText("ぺ"),
+                                ),
+                            SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("ぽ"),
+                                    action = KeyAction.CommitText("ぽ"),
+                                ),
+                            SwipeDirection.TOP to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("ぷ"),
+                                    action = KeyAction.CommitText("ぷ"),
+                                ),
+                        ),
+                ),
+                KeyItemC(
+                    center =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("っ"),
+                            action = KeyAction.CommitText("っ"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
                         ),
                 ),
             ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/JATypeSplitHiragana.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/JATypeSplitHiragana.kt
@@ -67,13 +67,13 @@ val KB_JA_TYPESPLIT_HIRAGANA_MAIN =
                                 ),
                             SwipeDirection.BOTTOM to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("お"),
-                                    action = KeyAction.CommitText("お"),
+                                    display = KeyDisplay.TextDisplay("と"),
+                                    action = KeyAction.CommitText("と"),
                                 ),
                             SwipeDirection.TOP to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("う"),
-                                    action = KeyAction.CommitText("う"),
+                                    display = KeyDisplay.TextDisplay("つ"),
+                                    action = KeyAction.CommitText("つ"),
                                 ),
                         ),
                 ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/JATypeSplitHiragana.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/JATypeSplitHiragana.kt
@@ -91,13 +91,13 @@ val KB_JA_TYPESPLIT_HIRAGANA_MAIN =
                         mapOf(
                             SwipeDirection.RIGHT to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("ゆ"),
+                                    display = null,
                                     action = KeyAction.CommitText("ゆ"),
                                 ),
                             SwipeDirection.LEFT to
                                 KeyC(
                                     display = null,
-                                    action = KeyAction.CommitText("ゆ"),
+                                    action = KeyAction.CommitText("よ"),
                                 ),
                             SwipeDirection.BOTTOM to
                                 KeyC(
@@ -106,7 +106,7 @@ val KB_JA_TYPESPLIT_HIRAGANA_MAIN =
                                 ),
                             SwipeDirection.TOP to
                                 KeyC(
-                                    display = null,
+                                    display = KeyDisplay.TextDisplay("ゆ"),
                                     action = KeyAction.CommitText("ゆ"),
                                 ),
                         ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/JATypeSplitHiragana.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/JATypeSplitHiragana.kt
@@ -296,21 +296,25 @@ val KB_JA_TYPESPLIT_HIRAGANA_MAIN =
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("」"),
                                     action = KeyAction.CommitText("」"),
+                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("「"),
                                     action = KeyAction.CommitText("「"),
+                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.BOTTOM to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("ー"),
                                     action = KeyAction.CommitText("ー"),
+                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.TOP to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("～"),
                                     action = KeyAction.CommitText("～"),
+                                    color = ColorVariant.MUTED,
                                 ),
                         ),
                 ),
@@ -329,21 +333,25 @@ val KB_JA_TYPESPLIT_HIRAGANA_MAIN =
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("？"),
                                     action = KeyAction.CommitText("？"),
+                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("！"),
                                     action = KeyAction.CommitText("！"),
+                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.BOTTOM to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("："),
                                     action = KeyAction.CommitText("："),
+                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.TOP to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("…"),
                                     action = KeyAction.CommitText("…"),
+                                    color = ColorVariant.MUTED,
                                 ),
                         ),
                 ),
@@ -396,25 +404,21 @@ val KB_JA_TYPESPLIT_HIRAGANA_MAIN =
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("め"),
                                     action = KeyAction.CommitText("め"),
-                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("み"),
                                     action = KeyAction.CommitText("み"),
-                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.BOTTOM to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("も"),
                                     action = KeyAction.CommitText("も"),
-                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.TOP to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("む"),
                                     action = KeyAction.CommitText("む"),
-                                    color = ColorVariant.MUTED,
                                 ),
                         ),
                 ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/JATypeSplitKatakana.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/JATypeSplitKatakana.kt
@@ -67,13 +67,13 @@ val KB_JA_TYPESPLIT_KATAKANA_MAIN =
                                 ),
                             SwipeDirection.BOTTOM to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("オ"),
-                                    action = KeyAction.CommitText("オ"),
+                                    display = KeyDisplay.TextDisplay("ト"),
+                                    action = KeyAction.CommitText("ト"),
                                 ),
                             SwipeDirection.TOP to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("ウ"),
-                                    action = KeyAction.CommitText("ウ"),
+                                    display = KeyDisplay.TextDisplay("ツ"),
+                                    action = KeyAction.CommitText("ツ"),
                                 ),
                         ),
                 ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/JATypeSplitKatakana.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/JATypeSplitKatakana.kt
@@ -91,13 +91,13 @@ val KB_JA_TYPESPLIT_KATAKANA_MAIN =
                         mapOf(
                             SwipeDirection.RIGHT to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("ユ"),
+                                    display = null,
                                     action = KeyAction.CommitText("ユ"),
                                 ),
                             SwipeDirection.LEFT to
                                 KeyC(
                                     display = null,
-                                    action = KeyAction.CommitText("ユ"),
+                                    action = KeyAction.CommitText("ヨ"),
                                 ),
                             SwipeDirection.BOTTOM to
                                 KeyC(
@@ -106,7 +106,7 @@ val KB_JA_TYPESPLIT_KATAKANA_MAIN =
                                 ),
                             SwipeDirection.TOP to
                                 KeyC(
-                                    display = null,
+                                    display = KeyDisplay.TextDisplay("ユ"),
                                     action = KeyAction.CommitText("ユ"),
                                 ),
                         ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/JATypeSplitKatakana.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/JATypeSplitKatakana.kt
@@ -438,19 +438,67 @@ val KB_JA_TYPESPLIT_KATAKANA_SHIFTED =
                 KeyItemC(
                     center =
                         KeyC(
-                            display = KeyDisplay.TextDisplay("ヴ"),
-                            action = KeyAction.CommitText("ヴ"),
+                            display = KeyDisplay.TextDisplay("¥"),
+                            action = KeyAction.CommitText("¥"),
                             size = FontSizeVariant.LARGE,
                             color = ColorVariant.PRIMARY,
+                        ),
+                    swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                    swipes =
+                        mapOf(
+                            SwipeDirection.RIGHT to
+                                KeyC(
+                                    display = null,
+                                    action = KeyAction.CommitText("※"),
+                                ),
+                            SwipeDirection.LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("※"),
+                                    action = KeyAction.CommitText("※"),
+                                ),
+                            SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("ヶ"),
+                                    action = KeyAction.CommitText("ヶ"),
+                                ),
+                            SwipeDirection.TOP to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("ヵ"),
+                                    action = KeyAction.CommitText("ヵ"),
+                                ),
                         ),
                 ),
                 KeyItemC(
                     center =
                         KeyC(
-                            display = KeyDisplay.TextDisplay("ッ"),
-                            action = KeyAction.CommitText("ッ"),
+                            display = KeyDisplay.TextDisplay("ダ"),
+                            action = KeyAction.CommitText("ダ"),
                             size = FontSizeVariant.LARGE,
                             color = ColorVariant.PRIMARY,
+                        ),
+                    swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                    swipes =
+                        mapOf(
+                            SwipeDirection.RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("デ"),
+                                    action = KeyAction.CommitText("デ"),
+                                ),
+                            SwipeDirection.LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("ヂ"),
+                                    action = KeyAction.CommitText("ヂ"),
+                                ),
+                            SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("ド"),
+                                    action = KeyAction.CommitText("ド"),
+                                ),
+                            SwipeDirection.TOP to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("ヅ"),
+                                    action = KeyAction.CommitText("ヅ"),
+                                ),
                         ),
                 ),
                 EMOJI_KEY_ITEM,
@@ -467,13 +515,13 @@ val KB_JA_TYPESPLIT_KATAKANA_SHIFTED =
                         mapOf(
                             SwipeDirection.RIGHT to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("ュ"),
+                                    display = null,
                                     action = KeyAction.CommitText("ュ"),
                                 ),
                             SwipeDirection.LEFT to
                                 KeyC(
                                     display = null,
-                                    action = KeyAction.CommitText("ュ"),
+                                    action = KeyAction.CommitText("ョ"),
                                 ),
                             SwipeDirection.BOTTOM to
                                 KeyC(
@@ -482,7 +530,7 @@ val KB_JA_TYPESPLIT_KATAKANA_SHIFTED =
                                 ),
                             SwipeDirection.TOP to
                                 KeyC(
-                                    display = null,
+                                    display = KeyDisplay.TextDisplay("ュ"),
                                     action = KeyAction.CommitText("ュ"),
                                 ),
                         ),
@@ -490,34 +538,10 @@ val KB_JA_TYPESPLIT_KATAKANA_SHIFTED =
                 KeyItemC(
                     center =
                         KeyC(
-                            display = KeyDisplay.TextDisplay("パ"),
-                            action = KeyAction.CommitText("パ"),
+                            display = KeyDisplay.TextDisplay("ヴ"),
+                            action = KeyAction.CommitText("ヴ"),
                             size = FontSizeVariant.LARGE,
                             color = ColorVariant.PRIMARY,
-                        ),
-                    swipeType = SwipeNWay.FOUR_WAY_CROSS,
-                    swipes =
-                        mapOf(
-                            SwipeDirection.RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("ペ"),
-                                    action = KeyAction.CommitText("ペ"),
-                                ),
-                            SwipeDirection.LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("ピ"),
-                                    action = KeyAction.CommitText("ピ"),
-                                ),
-                            SwipeDirection.BOTTOM to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("ポ"),
-                                    action = KeyAction.CommitText("ポ"),
-                                ),
-                            SwipeDirection.TOP to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("プ"),
-                                    action = KeyAction.CommitText("プ"),
-                                ),
                         ),
                 ),
             ),
@@ -558,8 +582,8 @@ val KB_JA_TYPESPLIT_KATAKANA_SHIFTED =
                 KeyItemC(
                     center =
                         KeyC(
-                            display = KeyDisplay.TextDisplay("ダ"),
-                            action = KeyAction.CommitText("ダ"),
+                            display = KeyDisplay.TextDisplay("ザ"),
+                            action = KeyAction.CommitText("ザ"),
                             size = FontSizeVariant.LARGE,
                             color = ColorVariant.PRIMARY,
                         ),
@@ -568,27 +592,60 @@ val KB_JA_TYPESPLIT_KATAKANA_SHIFTED =
                         mapOf(
                             SwipeDirection.RIGHT to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("デ"),
-                                    action = KeyAction.CommitText("デ"),
+                                    display = KeyDisplay.TextDisplay("ゼ"),
+                                    action = KeyAction.CommitText("ゼ"),
                                 ),
                             SwipeDirection.LEFT to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("ヂ"),
-                                    action = KeyAction.CommitText("ヂ"),
+                                    display = KeyDisplay.TextDisplay("ジ"),
+                                    action = KeyAction.CommitText("ジ"),
                                 ),
                             SwipeDirection.BOTTOM to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("ド"),
-                                    action = KeyAction.CommitText("ド"),
+                                    display = KeyDisplay.TextDisplay("ゾ"),
+                                    action = KeyAction.CommitText("ゾ"),
                                 ),
                             SwipeDirection.TOP to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("ヅ"),
-                                    action = KeyAction.CommitText("ヅ"),
+                                    display = KeyDisplay.TextDisplay("ズ"),
+                                    action = KeyAction.CommitText("ズ"),
                                 ),
                         ),
                 ),
                 SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM,
+                KeyItemC(
+                    center =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("バ"),
+                            action = KeyAction.CommitText("バ"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
+                    swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                    swipes =
+                        mapOf(
+                            SwipeDirection.RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("ビ"),
+                                    action = KeyAction.CommitText("ビ"),
+                                ),
+                            SwipeDirection.LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("ベ"),
+                                    action = KeyAction.CommitText("ベ"),
+                                ),
+                            SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("ボ"),
+                                    action = KeyAction.CommitText("ボ"),
+                                ),
+                            SwipeDirection.TOP to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("ブ"),
+                                    action = KeyAction.CommitText("ブ"),
+                                ),
+                        ),
+                ),
                 KeyItemC(
                     center =
                         KeyC(
@@ -602,13 +659,13 @@ val KB_JA_TYPESPLIT_KATAKANA_SHIFTED =
                         mapOf(
                             SwipeDirection.RIGHT to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("ギ"),
-                                    action = KeyAction.CommitText("ギ"),
+                                    display = KeyDisplay.TextDisplay("ゲ"),
+                                    action = KeyAction.CommitText("ゲ"),
                                 ),
                             SwipeDirection.LEFT to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("ゲ"),
-                                    action = KeyAction.CommitText("ゲ"),
+                                    display = KeyDisplay.TextDisplay("ギ"),
+                                    action = KeyAction.CommitText("ギ"),
                                 ),
                             SwipeDirection.BOTTOM to
                                 KeyC(
@@ -622,6 +679,8 @@ val KB_JA_TYPESPLIT_KATAKANA_SHIFTED =
                                 ),
                         ),
                 ),
+            ),
+            listOf(
                 KeyItemC(
                     center =
                         KeyC(
@@ -637,123 +696,25 @@ val KB_JA_TYPESPLIT_KATAKANA_SHIFTED =
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("】"),
                                     action = KeyAction.CommitText("】"),
+                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("【"),
                                     action = KeyAction.CommitText("【"),
+                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.BOTTOM to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("："),
                                     action = KeyAction.CommitText("："),
+                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.TOP to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("〃"),
                                     action = KeyAction.CommitText("〃"),
-                                ),
-                        ),
-                ),
-            ),
-            listOf(
-                KeyItemC(
-                    center =
-                        KeyC(
-                            display = KeyDisplay.TextDisplay("ザ"),
-                            action = KeyAction.CommitText("ザ"),
-                            size = FontSizeVariant.LARGE,
-                            color = ColorVariant.PRIMARY,
-                        ),
-                    swipeType = SwipeNWay.FOUR_WAY_CROSS,
-                    swipes =
-                        mapOf(
-                            SwipeDirection.RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("ジ"),
-                                    action = KeyAction.CommitText("ジ"),
-                                ),
-                            SwipeDirection.LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("ゼ"),
-                                    action = KeyAction.CommitText("ゼ"),
-                                ),
-                            SwipeDirection.BOTTOM to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("ゾ"),
-                                    action = KeyAction.CommitText("ゾ"),
-                                ),
-                            SwipeDirection.TOP to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("ズ"),
-                                    action = KeyAction.CommitText("ズ"),
-                                ),
-                        ),
-                ),
-                KeyItemC(
-                    center =
-                        KeyC(
-                            display = KeyDisplay.TextDisplay("バ"),
-                            action = KeyAction.CommitText("バ"),
-                            size = FontSizeVariant.LARGE,
-                            color = ColorVariant.PRIMARY,
-                        ),
-                    swipeType = SwipeNWay.FOUR_WAY_CROSS,
-                    swipes =
-                        mapOf(
-                            SwipeDirection.RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("ベ"),
-                                    action = KeyAction.CommitText("ベ"),
-                                ),
-                            SwipeDirection.LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("ビ"),
-                                    action = KeyAction.CommitText("ビ"),
-                                ),
-                            SwipeDirection.BOTTOM to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("ボ"),
-                                    action = KeyAction.CommitText("ボ"),
-                                ),
-                            SwipeDirection.TOP to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("ブ"),
-                                    action = KeyAction.CommitText("ブ"),
-                                ),
-                        ),
-                ),
-                SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
-                KeyItemC(
-                    center =
-                        KeyC(
-                            display = KeyDisplay.TextDisplay("¥"),
-                            action = KeyAction.CommitText("¥"),
-                            size = FontSizeVariant.LARGE,
-                            color = ColorVariant.PRIMARY,
-                        ),
-                    swipeType = SwipeNWay.FOUR_WAY_CROSS,
-                    swipes =
-                        mapOf(
-                            SwipeDirection.RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("※"),
-                                    action = KeyAction.CommitText("※"),
-                                ),
-                            SwipeDirection.LEFT to
-                                KeyC(
-                                    display = null,
-                                    action = KeyAction.CommitText("※"),
-                                ),
-                            SwipeDirection.BOTTOM to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("ヶ"),
-                                    action = KeyAction.CommitText("ヶ"),
-                                ),
-                            SwipeDirection.TOP to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("ヵ"),
-                                    action = KeyAction.CommitText("ヵ"),
+                                    color = ColorVariant.MUTED,
                                 ),
                         ),
                 ),
@@ -770,14 +731,14 @@ val KB_JA_TYPESPLIT_KATAKANA_SHIFTED =
                         mapOf(
                             SwipeDirection.RIGHT to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("÷"),
-                                    action = KeyAction.CommitText("÷"),
+                                    display = KeyDisplay.TextDisplay("×"),
+                                    action = KeyAction.CommitText("×"),
                                     color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.LEFT to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("×"),
-                                    action = KeyAction.CommitText("×"),
+                                    display = KeyDisplay.TextDisplay("÷"),
+                                    action = KeyAction.CommitText("÷"),
                                     color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.BOTTOM to
@@ -792,6 +753,49 @@ val KB_JA_TYPESPLIT_KATAKANA_SHIFTED =
                                     action = KeyAction.CommitText("－"),
                                     color = ColorVariant.MUTED,
                                 ),
+                        ),
+                ),
+                SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
+                KeyItemC(
+                    center =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("パ"),
+                            action = KeyAction.CommitText("パ"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
+                    swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                    swipes =
+                        mapOf(
+                            SwipeDirection.RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("ピ"),
+                                    action = KeyAction.CommitText("ピ"),
+                                ),
+                            SwipeDirection.LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("ペ"),
+                                    action = KeyAction.CommitText("ペ"),
+                                ),
+                            SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("ポ"),
+                                    action = KeyAction.CommitText("ポ"),
+                                ),
+                            SwipeDirection.TOP to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("プ"),
+                                    action = KeyAction.CommitText("プ"),
+                                ),
+                        ),
+                ),
+                KeyItemC(
+                    center =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("ッ"),
+                            action = KeyAction.CommitText("ッ"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
                         ),
                 ),
             ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/JATypeSplitKatakana.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/JATypeSplitKatakana.kt
@@ -296,21 +296,25 @@ val KB_JA_TYPESPLIT_KATAKANA_MAIN =
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("」"),
                                     action = KeyAction.CommitText("」"),
+                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("「"),
                                     action = KeyAction.CommitText("「"),
+                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.BOTTOM to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("ー"),
                                     action = KeyAction.CommitText("ー"),
+                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.TOP to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("～"),
                                     action = KeyAction.CommitText("～"),
+                                    color = ColorVariant.MUTED,
                                 ),
                         ),
                 ),
@@ -329,21 +333,25 @@ val KB_JA_TYPESPLIT_KATAKANA_MAIN =
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("？"),
                                     action = KeyAction.CommitText("？"),
+                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("！"),
                                     action = KeyAction.CommitText("！"),
+                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.BOTTOM to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("："),
                                     action = KeyAction.CommitText("："),
+                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.TOP to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("…"),
                                     action = KeyAction.CommitText("…"),
+                                    color = ColorVariant.MUTED,
                                 ),
                         ),
                 ),
@@ -396,25 +404,21 @@ val KB_JA_TYPESPLIT_KATAKANA_MAIN =
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("メ"),
                                     action = KeyAction.CommitText("メ"),
-                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("ミ"),
                                     action = KeyAction.CommitText("ミ"),
-                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.BOTTOM to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("モ"),
                                     action = KeyAction.CommitText("モ"),
-                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.TOP to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("ム"),
                                     action = KeyAction.CommitText("ム"),
-                                    color = ColorVariant.MUTED,
                                 ),
                         ),
                 ),


### PR DESCRIPTION
Fixes problems that I described in #567. I made some other adjustments:

- Put `ゆ` visually on the top of the `や` key instead of on the right, to match the normal pattern of vowel sounds (I noticed that Gboard does it this way as well). Swiping to the right will still insert `ゆ` even though it's not visible.
- Removed muted colours from the `ま` key which seemed to be accidentally left-over from copying the default English layout.
- Put muted colours on the keys that only have punctuation, since this is similar to the use on the English layout. I left the centre symbol as non-muted but I don't really know for sure if it ought to be muted as well.

My logic when rearranging the "shifted" layouts was to make the dakuten/handakuten forms of characters line up with their normal forms whenever possible. With `ぱ` I preferred to put it close to `ば` orthogonally rather than diagonally. I moved the `・` and `=` keys to appear as alternates of the other punctuation, `、` and `。`. I moved `ゔ` to the right side because `っ` already had to be moved there, and I thought they should stay on the same hand. This just left `¥` to be moved to the top left.

And everything I just said goes the same for the katakana.

| Old  | New |
| ------------- | ------------- |
| ![Screenshot from 2023-12-18 23-55-00](https://github.com/dessalines/thumb-key/assets/13155128/ee01c004-f723-4146-8981-085fcc0ea53a) | ![Screenshot from 2023-12-18 23-51-03](https://github.com/dessalines/thumb-key/assets/13155128/2dcd0741-ae4d-4f01-954c-c8d86b942b41) |
| ![Screenshot from 2023-12-18 23-55-05](https://github.com/dessalines/thumb-key/assets/13155128/a78bc09d-a51e-4563-90c5-73b60a9233af) | ![Screenshot from 2023-12-18 23-51-09](https://github.com/dessalines/thumb-key/assets/13155128/110c8517-072a-436a-9db8-e8f2051f7c07) |
| ![Screenshot from 2023-12-18 23-55-15](https://github.com/dessalines/thumb-key/assets/13155128/4cf05f71-1194-4500-97c8-fa187dbc0fe2) | ![Screenshot from 2023-12-18 23-51-16](https://github.com/dessalines/thumb-key/assets/13155128/c8addae6-08a8-4f31-b38d-cc9bf4410eca) |
| ![Screenshot from 2023-12-18 23-55-21](https://github.com/dessalines/thumb-key/assets/13155128/85da44b4-1a47-40a1-9c08-4b1ee7a59df8) | ![Screenshot from 2023-12-18 23-51-26](https://github.com/dessalines/thumb-key/assets/13155128/e3fb9309-c3dd-4ebe-874e-db3e60b65a71) |
