### PR TITLE
Added Danish and Norwegian letters to DEThumbKeyMultiLingual.kt

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbKeyMultiLingual.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbKeyMultiLingual.kt
@@ -618,6 +618,7 @@ val KB_DE_THUMBKEY_MULTILINGUAL_SHIFTED =
                                     display = KeyDisplay.TextDisplay("Ø"),
                                     action = KeyAction.CommitText("Ø"),
                                     color = ColorVariant.MUTED,
+                                ),
                             SwipeDirection.LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("Ò"),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbKeyMultiLingual.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbKeyMultiLingual.kt
@@ -47,6 +47,12 @@ val KB_DE_THUMBKEY_MULTILINGUAL_MAIN =
                                     action = KeyAction.CommitText("ç"),
                                     color = ColorVariant.MUTED,
                                 ),
+                            SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("…"),
+                                    action = KeyAction.CommitText("…"),
+                                    color = ColorVariant.MUTED,
+                                ),
                             SwipeDirection.BOTTOM_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("c"),
@@ -103,6 +109,18 @@ val KB_DE_THUMBKEY_MULTILINGUAL_MAIN =
                                     action = KeyAction.CommitText("à"),
                                     color = ColorVariant.MUTED,
                                 ),
+                            SwipeDirection.LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("å"),
+                                    action = KeyAction.CommitText("å"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("æ"),
+                                    action = KeyAction.CommitText("æ"),
+                                    color = ColorVariant.MUTED,
+                                ),
                             SwipeDirection.TOP_LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("€"),
@@ -145,6 +163,13 @@ val KB_DE_THUMBKEY_MULTILINGUAL_MAIN =
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("ó"),
                                     action = KeyAction.CommitText("ó"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.BOTTOM_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("ø"),
+                                    action = KeyAction.CommitText("ø"),
+                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.LEFT to
                                 KeyC(
@@ -470,6 +495,12 @@ val KB_DE_THUMBKEY_MULTILINGUAL_SHIFTED =
                                     action = KeyAction.CommitText("Ç"),
                                     color = ColorVariant.MUTED,
                                 ),
+                            SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("…"),
+                                    action = KeyAction.CommitText("…"),
+                                    color = ColorVariant.MUTED,
+                                ),
                             SwipeDirection.BOTTOM_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("C"),
@@ -526,6 +557,18 @@ val KB_DE_THUMBKEY_MULTILINGUAL_SHIFTED =
                                     action = KeyAction.CommitText("À"),
                                     color = ColorVariant.MUTED,
                                 ),
+                            SwipeDirection.LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("Å"),
+                                    action = KeyAction.CommitText("Å"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("Æ"),
+                                    action = KeyAction.CommitText("Æ"),
+                                    color = ColorVariant.MUTED,
+                                ),
                             SwipeDirection.TOP_LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("€"),
@@ -570,6 +613,11 @@ val KB_DE_THUMBKEY_MULTILINGUAL_SHIFTED =
                                     action = KeyAction.CommitText("Ó"),
                                     color = ColorVariant.MUTED,
                                 ),
+                            SwipeDirection.BOTTOM_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("Ø"),
+                                    action = KeyAction.CommitText("Ø"),
+                                    color = ColorVariant.MUTED,
                             SwipeDirection.LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("Ò"),


### PR DESCRIPTION
Hi,

I love the concept of a multilingual layout :) 
I often need to type English, German and Norwegian – but the Norwegian letters were unfortunately missing here.

So I added them here :)
In addition, I added the ellipsis (…) which is used quite frequently and almost always incorrectly typed as three periods…

Regards
Hagen