### PR TITLE
Add "shifted" return for hard newline (needed for some buggy apps, e.g. Discord)

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/CommonKeys.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/CommonKeys.kt
@@ -319,6 +319,17 @@ val RETURN_KEY_ITEM =
         backgroundColor = ColorVariant.SURFACE_VARIANT,
     )
 
+val RETURN_SHIFTED_KEY_ITEM =
+    RETURN_KEY_ITEM.copy(
+        center =
+        KeyC(
+            display = KeyDisplay.TextDisplay("CR"),
+            action = KeyAction.CommitText("\n"),
+            size = FontSizeVariant.LARGE,
+            color = ColorVariant.SECONDARY,
+        ),
+    )
+
 val SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM =
     KeyItemC(
         center =

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyProgrammer.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyProgrammer.kt
@@ -831,7 +831,7 @@ val KB_EN_THUMBKEY_PROGRAMMER_SHIFTED =
             ),
             listOf(
                 SPACEBAR_PROGRAMMER_KEY_ITEM,
-                RETURN_KEY_ITEM,
+                RETURN_SHIFTED_KEY_ITEM,
             ),
         ),
     )


### PR DESCRIPTION
Tested locally and it allows me to send a newline, enabling multiline comments on Discord, Slack and other apps that don't provide proper IME actions (see issue #136).

So far I've only enabled this for the "english programmer thumb-key" layout, as a separate `RETURN_SHIFTED_KEY_ITEM`. It might be better to have this as a swipe action on the enter key instead of a shifted mode, but am not sure how best to do it. Putting it out now for feedback / ideas.