### PR TITLE
Fix 'å' shadowing 'unshift' in 'english dansk symbols thumb-key'

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDAThumbKeySymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDAThumbKeySymbols.kt
@@ -146,6 +146,11 @@ val KB_EN_DA_THUMBKEY_SYMBOLS_MAIN =
                                     action = KeyAction.CommitText("="),
                                     color = ColorVariant.MUTED,
                                 ),
+                            SwipeDirection.TOP to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("å"),
+                                    action = KeyAction.CommitText("å"),
+                                ),
                         ),
                 ),
                 EMOJI_KEY_ITEM,
@@ -288,11 +293,6 @@ val KB_EN_DA_THUMBKEY_SYMBOLS_MAIN =
                                     display = KeyDisplay.TextDisplay(")"),
                                     action = KeyAction.CommitText(")"),
                                     color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("å"),
-                                    action = KeyAction.CommitText("å"),
                                 ),
                             SwipeDirection.BOTTOM_RIGHT to
                                 KeyC(
@@ -591,6 +591,11 @@ val KB_EN_DA_THUMBKEY_SYMBOLS_SHIFTED =
                                     action = KeyAction.CommitText("="),
                                     color = ColorVariant.MUTED,
                                 ),
+                            SwipeDirection.TOP to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("Å"),
+                                    action = KeyAction.CommitText("Å"),
+                                ),
                         ),
                 ),
                 EMOJI_KEY_ITEM,
@@ -740,11 +745,6 @@ val KB_EN_DA_THUMBKEY_SYMBOLS_SHIFTED =
                                     display = KeyDisplay.TextDisplay(")"),
                                     action = KeyAction.CommitText(")"),
                                     color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("Å"),
-                                    action = KeyAction.CommitText("Å"),
                                 ),
                             SwipeDirection.BOTTOM_RIGHT to
                                 KeyC(


### PR DESCRIPTION
Follow-up to #633 

I realized I made a mistake of shadowing "unshift" key, which is only visible in the shifted layout.

Therefore I moved `å` onto the `o` letter instead (which is even phonetically closer to `o` than to `a`, so mnemonically makes more sense).

The new layout looks like this:

![image](https://github.com/dessalines/thumb-key/assets/1177900/942a5861-738c-47ff-ac09-919f6f8a0449)
![image](https://github.com/dessalines/thumb-key/assets/1177900/c61bbe71-8c4f-48d4-b03c-e645b4cd988b)
