### PR TITLE
Use fallback center action when doing a long press

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
@@ -106,6 +106,8 @@ fun KeyboardScreen(
             else -> KB_EN_THUMBKEY_MAIN
         }
 
+    val fallbackKeyboard = keyboardDefinition.modes.numeric
+
     val alignment =
         keyboardPositionToAlignment(
             KeyboardPosition.entries[
@@ -340,12 +342,13 @@ fun KeyboardScreen(
                             },
                         ),
             ) {
-                keyboard.arr.forEach { row ->
+                keyboard.arr.forEachIndexed { rowIndex, row ->
                     Row {
-                        row.forEach { key ->
+                        row.forEachIndexed { keyIndex, key ->
+                            val fallbackKey = fallbackKeyboard.arr.getOrNull(rowIndex)?.getOrNull(keyIndex)
                             Column {
                                 KeyboardKey(
-                                    key = key,
+                                    key = if (fallbackKey != null) key.merge(fallbackKey) else key,
                                     lastAction = lastAction,
                                     legendSize = legendSize,
                                     keyPadding = keyPadding,

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
@@ -48,12 +48,14 @@ data class KeyItemC(
     val backgroundColor: ColorVariant = ColorVariant.SURFACE,
     val swipeType: SwipeNWay = SwipeNWay.EIGHT_WAY,
     val slideType: SlideType = SlideType.NONE,
+    val centerHold: KeyC? = null,
 ) {
     fun merge(fallback: KeyItemC): KeyItemC =
         this.copy(
             swipes = fallback.swipes.orEmpty().mapValues { it.value.copy(color = ColorVariant.MUTED) }
                     + swipes.orEmpty(),
             swipeType = swipeType + fallback.swipeType,
+            centerHold = centerHold ?: fallback.centerHold ?: fallback.center
         )
 }
 

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
@@ -48,7 +48,14 @@ data class KeyItemC(
     val backgroundColor: ColorVariant = ColorVariant.SURFACE,
     val swipeType: SwipeNWay = SwipeNWay.EIGHT_WAY,
     val slideType: SlideType = SlideType.NONE,
-)
+) {
+    fun merge(fallback: KeyItemC): KeyItemC =
+        this.copy(
+            swipes = fallback.swipes.orEmpty().mapValues { it.value.copy(color = ColorVariant.MUTED) }
+                    + swipes.orEmpty(),
+            swipeType = swipeType + fallback.swipeType,
+        )
+}
 
 data class KeyC(
     val display: KeyDisplay?,
@@ -203,7 +210,27 @@ enum class SwipeNWay {
     FOUR_WAY_CROSS,
     FOUR_WAY_DIAGONAL,
     TWO_WAY_VERTICAL,
-    TWO_WAY_HORIZONTAL,
+    TWO_WAY_HORIZONTAL,;
+
+    // Combine two SwipeNWays, in such a way that the new one will be able to recognize
+    // at least all of those directions
+    operator fun plus(other: SwipeNWay): SwipeNWay {
+        // Discard order
+        val x = minOf(this, other)
+        val y = maxOf(this, other)
+        // This means that all checks after this point should be ordered the same way
+        // as in the enum definition
+
+        return if (x == y) {
+            x
+        } else if (x == TWO_WAY_VERTICAL && y == TWO_WAY_HORIZONTAL
+            || x == FOUR_WAY_CROSS && other == TWO_WAY_VERTICAL
+            || x == FOUR_WAY_CROSS && other == TWO_WAY_HORIZONTAL) {
+            FOUR_WAY_CROSS
+        } else {
+            EIGHT_WAY
+        }
+    }
 }
 
 enum class SlideType {

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -43,6 +43,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.text.NumberFormat
+import java.time.Instant
 import kotlin.math.abs
 import kotlin.math.atan2
 import kotlin.math.max
@@ -822,11 +823,11 @@ fun buildTapActions(keyItem: KeyItemC): List<KeyAction> {
 fun doneKeyAction(
     scope: CoroutineScope,
     action: KeyAction,
-    pressed: MutableState<Boolean>,
+    pressedSince: MutableState<Instant?>,
     releasedKey: MutableState<String?>,
     animationHelperSpeed: Int,
 ) {
-    pressed.value = false
+    pressedSince.value = null
     scope.launch {
         delay(animationHelperSpeed.toLong())
         releasedKey.value = null


### PR DESCRIPTION
Fixes #647 

This builds upon #651, and adds long-press support along the same principle. Not a huge fan of how complicated this makes the `pointerInput` code, and especially not the duplication between `onTap` and `clickable`... but it seems to be kind of unavoidable sadly, if we want to avoid sacrificing the "early input" of `clickable`.

Iff this is on track for merging then that should probably be factored out first.