### PR TITLE
Implement non-square keys

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/db/AppDb.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/db/AppDb.kt
@@ -27,8 +27,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.util.concurrent.Executors
 
-const val DEFAULT_KEY_HEIGHT = 64
-const val DEFAULT_KEY_WIDTH = 64
+const val DEFAULT_KEY_SIZE = 64
 const val DEFAULT_ANIMATION_SPEED = 250
 const val DEFAULT_ANIMATION_HELPER_SPEED = 250
 const val DEFAULT_POSITION = 0
@@ -58,13 +57,13 @@ const val DEFAULT_KEY_RADIUS = 0
 data class AppSettings(
     @PrimaryKey(autoGenerate = true) val id: Int,
     @ColumnInfo(
-        name = "key_height",
-        defaultValue = DEFAULT_KEY_HEIGHT.toString(),
+        name = "key_size",
+        defaultValue = DEFAULT_KEY_SIZE.toString(),
     )
-    val keyHeight: Int,
+    val keySize: Int,
     @ColumnInfo(
         name = "key_width",
-        defaultValue = DEFAULT_KEY_WIDTH.toString(),
+        defaultValue = "0",
     )
     val keyWidth: Int,
     @ColumnInfo(
@@ -220,9 +219,9 @@ data class LayoutsUpdate(
 data class LookAndFeelUpdate(
     val id: Int,
     @ColumnInfo(
-        name = "key_height",
+        name = "key_size",
     )
-    val keyHeight: Int,
+    val keySize: Int,
     @ColumnInfo(
         name = "key_width",
     )
@@ -504,8 +503,17 @@ val MIGRATION_12_13 =
         }
     }
 
+val MIGRATION_13_14 =
+    object : Migration(13, 14) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL(
+                "alter table AppSettings add column key_width INTEGER NOT NULL default 0",
+            )
+        }
+    }
+
 @Database(
-    version = 13,
+    version = 14,
     entities = [AppSettings::class],
     exportSchema = true,
 )
@@ -540,6 +548,7 @@ abstract class AppDB : RoomDatabase() {
                             MIGRATION_10_11,
                             MIGRATION_11_12,
                             MIGRATION_12_13,
+                            MIGRATION_13_14,
                         )
                         // Necessary because it can't insert data on creation
                         .addCallback(

--- a/app/src/main/java/com/dessalines/thumbkey/db/AppDb.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/db/AppDb.kt
@@ -27,7 +27,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.util.concurrent.Executors
 
-const val DEFAULT_KEY_SIZE = 64
+const val DEFAULT_KEY_HEIGHT = 64
+const val DEFAULT_KEY_WIDTH = 64
 const val DEFAULT_ANIMATION_SPEED = 250
 const val DEFAULT_ANIMATION_HELPER_SPEED = 250
 const val DEFAULT_POSITION = 0
@@ -57,10 +58,15 @@ const val DEFAULT_KEY_RADIUS = 0
 data class AppSettings(
     @PrimaryKey(autoGenerate = true) val id: Int,
     @ColumnInfo(
-        name = "key_size",
-        defaultValue = DEFAULT_KEY_SIZE.toString(),
+        name = "key_height",
+        defaultValue = DEFAULT_KEY_HEIGHT.toString(),
     )
-    val keySize: Int,
+    val keyHeight: Int,
+    @ColumnInfo(
+        name = "key_width",
+        defaultValue = DEFAULT_KEY_WIDTH.toString(),
+    )
+    val keyWidth: Int,
     @ColumnInfo(
         name = "animation_speed",
         defaultValue = DEFAULT_ANIMATION_SPEED.toString(),
@@ -214,9 +220,13 @@ data class LayoutsUpdate(
 data class LookAndFeelUpdate(
     val id: Int,
     @ColumnInfo(
-        name = "key_size",
+        name = "key_height",
     )
-    val keySize: Int,
+    val keyHeight: Int,
+    @ColumnInfo(
+        name = "key_width",
+    )
+    val keyWidth: Int,
     @ColumnInfo(
         name = "animation_speed",
     )

--- a/app/src/main/java/com/dessalines/thumbkey/db/AppDb.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/db/AppDb.kt
@@ -63,9 +63,8 @@ data class AppSettings(
     val keySize: Int,
     @ColumnInfo(
         name = "key_width",
-        defaultValue = "0",
     )
-    val keyWidth: Int,
+    val keyWidth: Int?,
     @ColumnInfo(
         name = "animation_speed",
         defaultValue = DEFAULT_ANIMATION_SPEED.toString(),
@@ -225,7 +224,7 @@ data class LookAndFeelUpdate(
     @ColumnInfo(
         name = "key_width",
     )
-    val keyWidth: Int,
+    val keyWidth: Int?,
     @ColumnInfo(
         name = "animation_speed",
     )
@@ -507,7 +506,7 @@ val MIGRATION_13_14 =
     object : Migration(13, 14) {
         override fun migrate(db: SupportSQLiteDatabase) {
             db.execSQL(
-                "alter table AppSettings add column key_width INTEGER NOT NULL default 0",
+                "alter table AppSettings add column key_width INTEGER",
             )
         }
     }

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
@@ -84,7 +84,8 @@ fun KeyboardKey(
     hideLetters: Boolean,
     hideSymbols: Boolean,
     capsLock: Boolean,
-    legendSize: Int,
+    legendHeight: Int,
+    legendWidth: Int,
     keyPadding: Int,
     keyBorderWidth: Float,
     keyRadius: Float,
@@ -105,7 +106,7 @@ fun KeyboardKey(
     // Necessary for swipe settings to get updated correctly
     val id =
         key.toString() + animationHelperSpeed + animationSpeed + autoCapitalize +
-            vibrateOnTap + soundOnTap + legendSize + minSwipeLength + slideSensitivity +
+            vibrateOnTap + soundOnTap + legendHeight + legendWidth + minSwipeLength + slideSensitivity +
             slideEnabled + slideCursorMovementMode + slideSpacebarDeadzoneEnabled +
             slideBackspaceDeadzoneEnabled
 
@@ -142,7 +143,9 @@ fun KeyboardKey(
         }
 
     val keyBorderColour = MaterialTheme.colorScheme.outline
-    val keySize = legendSize + (keyPadding * 2.0) + (keyBorderWidth * 2.0)
+    val keyHeight = legendHeight + (keyPadding * 2.0) + (keyBorderWidth * 2.0)
+    val keyWidth = legendWidth + (keyPadding * 2.0) + (keyBorderWidth * 2.0)
+    val keySize = (keyHeight + keyWidth) / 2.0
     val legendPadding = 4.dp + keyBorderWidth.dp
 
     val haptic = LocalHapticFeedback.current
@@ -161,8 +164,8 @@ fun KeyboardKey(
 
     val keyboardKeyModifier =
         Modifier
-            .height(keySize.dp)
-            .width(keySize.dp * key.widthMultiplier)
+            .height(keyHeight.dp)
+            .width(keyWidth.dp * key.widthMultiplier)
             .padding(keyPadding.dp)
             .clip(RoundedCornerShape(keyRadius.dp))
             .then(
@@ -516,7 +519,7 @@ fun KeyboardKey(
                     ),
         ) {
             key.swipes?.get(SwipeDirection.TOP_LEFT)?.let {
-                KeyText(it, (legendSize - keyBorderWidth).dp, hideLetters, hideSymbols, capsLock)
+                KeyText(it, (legendWidth - keyBorderWidth).dp, hideLetters, hideSymbols, capsLock)
             }
         }
         Box(
@@ -527,7 +530,7 @@ fun KeyboardKey(
                     .padding(vertical = yPadding),
         ) {
             key.swipes?.get(SwipeDirection.TOP)?.let {
-                KeyText(it, (legendSize - keyBorderWidth).dp, hideLetters, hideSymbols, capsLock)
+                KeyText(it, (legendWidth - keyBorderWidth).dp, hideLetters, hideSymbols, capsLock)
             }
         }
         Box(
@@ -541,7 +544,7 @@ fun KeyboardKey(
                     ),
         ) {
             key.swipes?.get(SwipeDirection.TOP_RIGHT)?.let {
-                KeyText(it, (legendSize - keyBorderWidth).dp, hideLetters, hideSymbols, capsLock)
+                KeyText(it, (legendWidth - keyBorderWidth).dp, hideLetters, hideSymbols, capsLock)
             }
         }
         Box(
@@ -552,7 +555,7 @@ fun KeyboardKey(
                     .padding(horizontal = legendPadding),
         ) {
             key.swipes?.get(SwipeDirection.LEFT)?.let {
-                KeyText(it, (legendSize - keyBorderWidth).dp, hideLetters, hideSymbols, capsLock)
+                KeyText(it, (legendWidth - keyBorderWidth).dp, hideLetters, hideSymbols, capsLock)
             }
         }
         Box(
@@ -562,7 +565,7 @@ fun KeyboardKey(
                     .fillMaxSize()
                     .padding(legendPadding),
         ) {
-            KeyText(key.center, (legendSize - keyBorderWidth).dp, hideLetters, hideSymbols, capsLock)
+            KeyText(key.center, (legendWidth - keyBorderWidth).dp, hideLetters, hideSymbols, capsLock)
         }
 
         Box(
@@ -573,7 +576,7 @@ fun KeyboardKey(
                     .padding(horizontal = legendPadding),
         ) {
             key.swipes?.get(SwipeDirection.RIGHT)?.let {
-                KeyText(it, (legendSize - keyBorderWidth).dp, hideLetters, hideSymbols, capsLock)
+                KeyText(it, (legendWidth - keyBorderWidth).dp, hideLetters, hideSymbols, capsLock)
             }
         }
         Box(
@@ -587,7 +590,7 @@ fun KeyboardKey(
                     ),
         ) {
             key.swipes?.get(SwipeDirection.BOTTOM_LEFT)?.let {
-                KeyText(it, (legendSize - keyBorderWidth).dp, hideLetters, hideSymbols, capsLock)
+                KeyText(it, (legendWidth - keyBorderWidth).dp, hideLetters, hideSymbols, capsLock)
             }
         }
         Box(
@@ -598,7 +601,7 @@ fun KeyboardKey(
                     .padding(vertical = yPadding),
         ) {
             key.swipes?.get(SwipeDirection.BOTTOM)?.let {
-                KeyText(it, (legendSize - keyBorderWidth).dp, hideLetters, hideSymbols, capsLock)
+                KeyText(it, (legendWidth - keyBorderWidth).dp, hideLetters, hideSymbols, capsLock)
             }
         }
         Box(
@@ -612,7 +615,7 @@ fun KeyboardKey(
                     ),
         ) {
             key.swipes?.get(SwipeDirection.BOTTOM_RIGHT)?.let {
-                KeyText(it, (legendSize - keyBorderWidth).dp, hideLetters, hideSymbols, capsLock)
+                KeyText(it, (legendWidth - keyBorderWidth).dp, hideLetters, hideSymbols, capsLock)
             }
         }
 
@@ -652,7 +655,7 @@ fun KeyboardKey(
                 val fontSize =
                     fontSizeVariantToFontSize(
                         fontSizeVariant = FontSizeVariant.LARGE,
-                        keySize = legendSize.dp,
+                        keySize = (legendHeight * legendWidth / 2.0).dp,
                         isUpperCase = false,
                     )
                 releasedKey.value?.let { text ->

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
@@ -146,6 +146,7 @@ fun KeyboardKey(
     val keyHeight = legendHeight + (keyPadding * 2.0) + (keyBorderWidth * 2.0)
     val keyWidth = legendWidth + (keyPadding * 2.0) + (keyBorderWidth * 2.0)
     val keySize = (keyHeight + keyWidth) / 2.0
+    val legendSize = (legendHeight + legendWidth) / 2
     val legendPadding = 4.dp + keyBorderWidth.dp
 
     val haptic = LocalHapticFeedback.current
@@ -519,7 +520,7 @@ fun KeyboardKey(
                     ),
         ) {
             key.swipes?.get(SwipeDirection.TOP_LEFT)?.let {
-                KeyText(it, (legendWidth - keyBorderWidth).dp, hideLetters, hideSymbols, capsLock)
+                KeyText(it, (legendSize - keyBorderWidth).dp, hideLetters, hideSymbols, capsLock)
             }
         }
         Box(
@@ -530,7 +531,7 @@ fun KeyboardKey(
                     .padding(vertical = yPadding),
         ) {
             key.swipes?.get(SwipeDirection.TOP)?.let {
-                KeyText(it, (legendWidth - keyBorderWidth).dp, hideLetters, hideSymbols, capsLock)
+                KeyText(it, (legendSize - keyBorderWidth).dp, hideLetters, hideSymbols, capsLock)
             }
         }
         Box(
@@ -544,7 +545,7 @@ fun KeyboardKey(
                     ),
         ) {
             key.swipes?.get(SwipeDirection.TOP_RIGHT)?.let {
-                KeyText(it, (legendWidth - keyBorderWidth).dp, hideLetters, hideSymbols, capsLock)
+                KeyText(it, (legendSize - keyBorderWidth).dp, hideLetters, hideSymbols, capsLock)
             }
         }
         Box(
@@ -555,7 +556,7 @@ fun KeyboardKey(
                     .padding(horizontal = legendPadding),
         ) {
             key.swipes?.get(SwipeDirection.LEFT)?.let {
-                KeyText(it, (legendWidth - keyBorderWidth).dp, hideLetters, hideSymbols, capsLock)
+                KeyText(it, (legendSize - keyBorderWidth).dp, hideLetters, hideSymbols, capsLock)
             }
         }
         Box(
@@ -565,7 +566,7 @@ fun KeyboardKey(
                     .fillMaxSize()
                     .padding(legendPadding),
         ) {
-            KeyText(key.center, (legendWidth - keyBorderWidth).dp, hideLetters, hideSymbols, capsLock)
+            KeyText(key.center, (legendSize - keyBorderWidth).dp, hideLetters, hideSymbols, capsLock)
         }
 
         Box(
@@ -576,7 +577,7 @@ fun KeyboardKey(
                     .padding(horizontal = legendPadding),
         ) {
             key.swipes?.get(SwipeDirection.RIGHT)?.let {
-                KeyText(it, (legendWidth - keyBorderWidth).dp, hideLetters, hideSymbols, capsLock)
+                KeyText(it, (legendSize - keyBorderWidth).dp, hideLetters, hideSymbols, capsLock)
             }
         }
         Box(
@@ -590,7 +591,7 @@ fun KeyboardKey(
                     ),
         ) {
             key.swipes?.get(SwipeDirection.BOTTOM_LEFT)?.let {
-                KeyText(it, (legendWidth - keyBorderWidth).dp, hideLetters, hideSymbols, capsLock)
+                KeyText(it, (legendSize - keyBorderWidth).dp, hideLetters, hideSymbols, capsLock)
             }
         }
         Box(
@@ -601,7 +602,7 @@ fun KeyboardKey(
                     .padding(vertical = yPadding),
         ) {
             key.swipes?.get(SwipeDirection.BOTTOM)?.let {
-                KeyText(it, (legendWidth - keyBorderWidth).dp, hideLetters, hideSymbols, capsLock)
+                KeyText(it, (legendSize - keyBorderWidth).dp, hideLetters, hideSymbols, capsLock)
             }
         }
         Box(
@@ -615,7 +616,7 @@ fun KeyboardKey(
                     ),
         ) {
             key.swipes?.get(SwipeDirection.BOTTOM_RIGHT)?.let {
-                KeyText(it, (legendWidth - keyBorderWidth).dp, hideLetters, hideSymbols, capsLock)
+                KeyText(it, (legendSize - keyBorderWidth).dp, hideLetters, hideSymbols, capsLock)
             }
         }
 

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
@@ -39,9 +39,10 @@ import com.dessalines.thumbkey.db.DEFAULT_HIDE_LETTERS
 import com.dessalines.thumbkey.db.DEFAULT_HIDE_SYMBOLS
 import com.dessalines.thumbkey.db.DEFAULT_KEYBOARD_LAYOUT
 import com.dessalines.thumbkey.db.DEFAULT_KEY_BORDER_WIDTH
+import com.dessalines.thumbkey.db.DEFAULT_KEY_HEIGHT
 import com.dessalines.thumbkey.db.DEFAULT_KEY_PADDING
 import com.dessalines.thumbkey.db.DEFAULT_KEY_RADIUS
-import com.dessalines.thumbkey.db.DEFAULT_KEY_SIZE
+import com.dessalines.thumbkey.db.DEFAULT_KEY_WIDTH
 import com.dessalines.thumbkey.db.DEFAULT_MIN_SWIPE_LENGTH
 import com.dessalines.thumbkey.db.DEFAULT_POSITION
 import com.dessalines.thumbkey.db.DEFAULT_PUSHUP_SIZE
@@ -130,17 +131,19 @@ fun KeyboardScreen(
     val backdropColor = MaterialTheme.colorScheme.background
     val backdropPadding = 6.dp
     val keyPadding = settings?.keyPadding ?: DEFAULT_KEY_PADDING
-    val legendSize = settings?.keySize ?: DEFAULT_KEY_SIZE
+    val legendHeight = settings?.keyHeight ?: DEFAULT_KEY_HEIGHT
+    val legendWidth = settings?.keyWidth ?: DEFAULT_KEY_WIDTH
     val keyRadius = settings?.keyRadius ?: DEFAULT_KEY_RADIUS
 
     val keyBorderWidthFloat = keyBorderWidth / 10.0f
     val keyBorderColour = MaterialTheme.colorScheme.outline
-    val keySize = legendSize + (keyPadding * 2.0f) + (keyBorderWidthFloat * 2.0f)
-    val cornerRadius = (keyRadius / 100.0f) * (keySize / 2.0f)
+    val keyHeight = legendHeight + (keyPadding * 2.0f) + (keyBorderWidthFloat * 2.0f)
+    val keyWidth = legendWidth + (keyPadding * 2.0f) + (keyBorderWidthFloat * 2.0f)
+    val cornerRadius = (keyRadius / 100.0f) * ((keyWidth + keyHeight) / 4.0f)
 
     if (mode == KeyboardMode.EMOJI) {
         val controllerKeys = listOf(EMOJI_BACK_KEY_ITEM, NUMERIC_KEY_ITEM, BACKSPACE_KEY_ITEM, RETURN_KEY_ITEM)
-        val keyboardHeight = Dp((keySize * controllerKeys.size) - (keyPadding * 2))
+        val keyboardHeight = Dp((keyHeight * controllerKeys.size) - (keyPadding * 2))
 
         ctx.currentInputConnection.requestCursorUpdates(0)
 
@@ -230,7 +233,8 @@ fun KeyboardScreen(
                             KeyboardKey(
                                 key = key,
                                 lastAction = lastAction,
-                                legendSize = legendSize,
+                                legendHeight = legendHeight,
+                                legendWidth = legendWidth,
                                 keyPadding = keyPadding,
                                 keyBorderWidth = keyBorderWidthFloat,
                                 keyRadius = cornerRadius,
@@ -347,7 +351,8 @@ fun KeyboardScreen(
                                 KeyboardKey(
                                     key = key,
                                     lastAction = lastAction,
-                                    legendSize = legendSize,
+                                    legendHeight = legendHeight,
+                                    legendWidth = legendWidth,
                                     keyPadding = keyPadding,
                                     keyBorderWidth = keyBorderWidthFloat,
                                     keyRadius = cornerRadius,

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
@@ -39,10 +39,9 @@ import com.dessalines.thumbkey.db.DEFAULT_HIDE_LETTERS
 import com.dessalines.thumbkey.db.DEFAULT_HIDE_SYMBOLS
 import com.dessalines.thumbkey.db.DEFAULT_KEYBOARD_LAYOUT
 import com.dessalines.thumbkey.db.DEFAULT_KEY_BORDER_WIDTH
-import com.dessalines.thumbkey.db.DEFAULT_KEY_HEIGHT
 import com.dessalines.thumbkey.db.DEFAULT_KEY_PADDING
 import com.dessalines.thumbkey.db.DEFAULT_KEY_RADIUS
-import com.dessalines.thumbkey.db.DEFAULT_KEY_WIDTH
+import com.dessalines.thumbkey.db.DEFAULT_KEY_SIZE
 import com.dessalines.thumbkey.db.DEFAULT_MIN_SWIPE_LENGTH
 import com.dessalines.thumbkey.db.DEFAULT_POSITION
 import com.dessalines.thumbkey.db.DEFAULT_PUSHUP_SIZE
@@ -131,8 +130,8 @@ fun KeyboardScreen(
     val backdropColor = MaterialTheme.colorScheme.background
     val backdropPadding = 6.dp
     val keyPadding = settings?.keyPadding ?: DEFAULT_KEY_PADDING
-    val legendHeight = settings?.keyHeight ?: DEFAULT_KEY_HEIGHT
-    val legendWidth = settings?.keyWidth ?: DEFAULT_KEY_WIDTH
+    val legendHeight = settings?.keySize ?: DEFAULT_KEY_SIZE
+    val legendWidth = (if ((settings?.keyWidth ?: 0) > 0) settings?.keyWidth else legendHeight) ?: legendHeight
     val keyRadius = settings?.keyRadius ?: DEFAULT_KEY_RADIUS
 
     val keyBorderWidthFloat = keyBorderWidth / 10.0f

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
@@ -131,7 +131,7 @@ fun KeyboardScreen(
     val backdropPadding = 6.dp
     val keyPadding = settings?.keyPadding ?: DEFAULT_KEY_PADDING
     val legendHeight = settings?.keySize ?: DEFAULT_KEY_SIZE
-    val legendWidth = (if ((settings?.keyWidth ?: 0) > 0) settings?.keyWidth else legendHeight) ?: legendHeight
+    val legendWidth = settings?.keyWidth ?: legendHeight
     val keyRadius = settings?.keyRadius ?: DEFAULT_KEY_RADIUS
 
     val keyBorderWidthFloat = keyBorderWidth / 10.0f

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/SettingsActivity.kt
@@ -49,9 +49,10 @@ import com.dessalines.thumbkey.db.DEFAULT_HIDE_SYMBOLS
 import com.dessalines.thumbkey.db.DEFAULT_KEYBOARD_LAYOUT
 import com.dessalines.thumbkey.db.DEFAULT_KEY_BORDERS
 import com.dessalines.thumbkey.db.DEFAULT_KEY_BORDER_WIDTH
+import com.dessalines.thumbkey.db.DEFAULT_KEY_HEIGHT
 import com.dessalines.thumbkey.db.DEFAULT_KEY_PADDING
 import com.dessalines.thumbkey.db.DEFAULT_KEY_RADIUS
-import com.dessalines.thumbkey.db.DEFAULT_KEY_SIZE
+import com.dessalines.thumbkey.db.DEFAULT_KEY_WIDTH
 import com.dessalines.thumbkey.db.DEFAULT_MIN_SWIPE_LENGTH
 import com.dessalines.thumbkey.db.DEFAULT_POSITION
 import com.dessalines.thumbkey.db.DEFAULT_PUSHUP_SIZE
@@ -277,7 +278,8 @@ private fun resetAppSettingsToDefault(
             hideLetters = DEFAULT_HIDE_LETTERS,
             hideSymbols = DEFAULT_HIDE_SYMBOLS,
             keyBorders = DEFAULT_KEY_BORDERS,
-            keySize = DEFAULT_KEY_SIZE,
+            keyHeight = DEFAULT_KEY_HEIGHT,
+            keyWidth = DEFAULT_KEY_WIDTH,
             spacebarMultiTaps = DEFAULT_SPACEBAR_MULTITAPS,
             theme = DEFAULT_THEME,
             themeColor = DEFAULT_THEME_COLOR,

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/SettingsActivity.kt
@@ -49,10 +49,9 @@ import com.dessalines.thumbkey.db.DEFAULT_HIDE_SYMBOLS
 import com.dessalines.thumbkey.db.DEFAULT_KEYBOARD_LAYOUT
 import com.dessalines.thumbkey.db.DEFAULT_KEY_BORDERS
 import com.dessalines.thumbkey.db.DEFAULT_KEY_BORDER_WIDTH
-import com.dessalines.thumbkey.db.DEFAULT_KEY_HEIGHT
 import com.dessalines.thumbkey.db.DEFAULT_KEY_PADDING
 import com.dessalines.thumbkey.db.DEFAULT_KEY_RADIUS
-import com.dessalines.thumbkey.db.DEFAULT_KEY_WIDTH
+import com.dessalines.thumbkey.db.DEFAULT_KEY_SIZE
 import com.dessalines.thumbkey.db.DEFAULT_MIN_SWIPE_LENGTH
 import com.dessalines.thumbkey.db.DEFAULT_POSITION
 import com.dessalines.thumbkey.db.DEFAULT_PUSHUP_SIZE
@@ -278,8 +277,8 @@ private fun resetAppSettingsToDefault(
             hideLetters = DEFAULT_HIDE_LETTERS,
             hideSymbols = DEFAULT_HIDE_SYMBOLS,
             keyBorders = DEFAULT_KEY_BORDERS,
-            keyHeight = DEFAULT_KEY_HEIGHT,
-            keyWidth = DEFAULT_KEY_WIDTH,
+            keySize = DEFAULT_KEY_SIZE,
+            keyWidth = 0,
             spacebarMultiTaps = DEFAULT_SPACEBAR_MULTITAPS,
             theme = DEFAULT_THEME,
             themeColor = DEFAULT_THEME_COLOR,

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/SettingsActivity.kt
@@ -278,7 +278,7 @@ private fun resetAppSettingsToDefault(
             hideSymbols = DEFAULT_HIDE_SYMBOLS,
             keyBorders = DEFAULT_KEY_BORDERS,
             keySize = DEFAULT_KEY_SIZE,
-            keyWidth = 0,
+            keyWidth = null,
             spacebarMultiTaps = DEFAULT_SPACEBAR_MULTITAPS,
             theme = DEFAULT_THEME,
             themeColor = DEFAULT_THEME_COLOR,

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/lookandfeel/LookAndFeelActivity.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/lookandfeel/LookAndFeelActivity.kt
@@ -52,9 +52,10 @@ import com.dessalines.thumbkey.db.DEFAULT_HIDE_LETTERS
 import com.dessalines.thumbkey.db.DEFAULT_HIDE_SYMBOLS
 import com.dessalines.thumbkey.db.DEFAULT_KEY_BORDERS
 import com.dessalines.thumbkey.db.DEFAULT_KEY_BORDER_WIDTH
+import com.dessalines.thumbkey.db.DEFAULT_KEY_HEIGHT
 import com.dessalines.thumbkey.db.DEFAULT_KEY_PADDING
 import com.dessalines.thumbkey.db.DEFAULT_KEY_RADIUS
-import com.dessalines.thumbkey.db.DEFAULT_KEY_SIZE
+import com.dessalines.thumbkey.db.DEFAULT_KEY_WIDTH
 import com.dessalines.thumbkey.db.DEFAULT_POSITION
 import com.dessalines.thumbkey.db.DEFAULT_PUSHUP_SIZE
 import com.dessalines.thumbkey.db.DEFAULT_SOUND_ON_TAP
@@ -82,9 +83,13 @@ fun LookAndFeelActivity(
 
     val settings by appSettingsViewModel.appSettings.observeAsState()
 
-    val keySizeState =
+    val keyHeightState =
         rememberFloatSettingState(
-            (settings?.keySize ?: DEFAULT_KEY_SIZE).toFloat(),
+            (settings?.keyHeight ?: DEFAULT_KEY_HEIGHT).toFloat(),
+        )
+    val keyWidthState =
+        rememberFloatSettingState(
+            (settings?.keyWidth ?: DEFAULT_KEY_WIDTH).toFloat(),
         )
     val pushupSizeState =
         rememberFloatSettingState(
@@ -177,7 +182,8 @@ fun LookAndFeelActivity(
                         themeState.value = i
                         updateLookAndFeel(
                             appSettingsViewModel,
-                            keySizeState,
+                            keyHeightState,
+                            keyWidthState,
                             pushupSizeState,
                             animationSpeedState,
                             animationHelperSpeedState,
@@ -212,7 +218,8 @@ fun LookAndFeelActivity(
                         themeColorState.value = i
                         updateLookAndFeel(
                             appSettingsViewModel,
-                            keySizeState,
+                            keyHeightState,
+                            keyWidthState,
                             pushupSizeState,
                             animationSpeedState,
                             animationHelperSpeedState,
@@ -247,7 +254,8 @@ fun LookAndFeelActivity(
                         positionState.value = i
                         updateLookAndFeel(
                             appSettingsViewModel,
-                            keySizeState,
+                            keyHeightState,
+                            keyWidthState,
                             pushupSizeState,
                             animationSpeedState,
                             animationHelperSpeedState,
@@ -280,7 +288,8 @@ fun LookAndFeelActivity(
                     onCheckedChange = {
                         updateLookAndFeel(
                             appSettingsViewModel,
-                            keySizeState,
+                            keyHeightState,
+                            keyWidthState,
                             pushupSizeState,
                             animationSpeedState,
                             animationHelperSpeedState,
@@ -313,7 +322,8 @@ fun LookAndFeelActivity(
                     onCheckedChange = {
                         updateLookAndFeel(
                             appSettingsViewModel,
-                            keySizeState,
+                            keyHeightState,
+                            keyWidthState,
                             pushupSizeState,
                             animationSpeedState,
                             animationHelperSpeedState,
@@ -346,7 +356,8 @@ fun LookAndFeelActivity(
                     onCheckedChange = {
                         updateLookAndFeel(
                             appSettingsViewModel,
-                            keySizeState,
+                            keyHeightState,
+                            keyWidthState,
                             pushupSizeState,
                             animationSpeedState,
                             animationHelperSpeedState,
@@ -365,10 +376,10 @@ fun LookAndFeelActivity(
                         )
                     },
                 )
-                val keySizeStr = stringResource(R.string.key_size, keySizeState.value.toInt().toString())
+                val keyHeightStr = stringResource(R.string.key_height, keyHeightState.value.toInt().toString())
                 SettingsSlider(
                     valueRange = 10f..200f,
-                    state = keySizeState,
+                    state = keyHeightState,
                     icon = {
                         Icon(
                             imageVector = Icons.Outlined.FormatSize,
@@ -376,12 +387,49 @@ fun LookAndFeelActivity(
                         )
                     },
                     title = {
-                        Text(keySizeStr)
+                        Text(keyHeightStr)
                     },
                     onValueChangeFinished = {
                         updateLookAndFeel(
                             appSettingsViewModel,
-                            keySizeState,
+                            keyHeightState,
+                            keyWidthState,
+                            pushupSizeState,
+                            animationSpeedState,
+                            animationHelperSpeedState,
+                            positionState,
+                            keyBordersState,
+                            vibrateOnTapState,
+                            soundOnTapState,
+                            hideLettersState,
+                            hideSymbolsState,
+                            themeState,
+                            themeColorState,
+                            backdropEnabledState,
+                            keyPaddingState,
+                            keyBorderWidthState,
+                            keyRadiusState,
+                        )
+                    },
+                )
+                val keyWidthStr = stringResource(R.string.key_width, keyWidthState.value.toInt().toString())
+                SettingsSlider(
+                    valueRange = 10f..200f,
+                    state = keyWidthState,
+                    icon = {
+                        Icon(
+                            imageVector = Icons.Outlined.FormatSize,
+                            contentDescription = null,
+                        )
+                    },
+                    title = {
+                        Text(keyWidthStr)
+                    },
+                    onValueChangeFinished = {
+                        updateLookAndFeel(
+                            appSettingsViewModel,
+                            keyHeightState,
+                            keyWidthState,
                             pushupSizeState,
                             animationSpeedState,
                             animationHelperSpeedState,
@@ -416,7 +464,8 @@ fun LookAndFeelActivity(
                     onValueChangeFinished = {
                         updateLookAndFeel(
                             appSettingsViewModel,
-                            keySizeState,
+                            keyHeightState,
+                            keyWidthState,
                             pushupSizeState,
                             animationSpeedState,
                             animationHelperSpeedState,
@@ -451,7 +500,8 @@ fun LookAndFeelActivity(
                     onValueChangeFinished = {
                         updateLookAndFeel(
                             appSettingsViewModel,
-                            keySizeState,
+                            keyHeightState,
+                            keyWidthState,
                             pushupSizeState,
                             animationSpeedState,
                             animationHelperSpeedState,
@@ -486,7 +536,8 @@ fun LookAndFeelActivity(
                     onValueChangeFinished = {
                         updateLookAndFeel(
                             appSettingsViewModel,
-                            keySizeState,
+                            keyHeightState,
+                            keyWidthState,
                             pushupSizeState,
                             animationSpeedState,
                             animationHelperSpeedState,
@@ -521,7 +572,8 @@ fun LookAndFeelActivity(
                     onValueChangeFinished = {
                         updateLookAndFeel(
                             appSettingsViewModel,
-                            keySizeState,
+                            keyHeightState,
+                            keyWidthState,
                             pushupSizeState,
                             animationSpeedState,
                             animationHelperSpeedState,
@@ -556,7 +608,8 @@ fun LookAndFeelActivity(
                     onValueChangeFinished = {
                         updateLookAndFeel(
                             appSettingsViewModel,
-                            keySizeState,
+                            keyHeightState,
+                            keyWidthState,
                             pushupSizeState,
                             animationSpeedState,
                             animationHelperSpeedState,
@@ -597,7 +650,8 @@ fun LookAndFeelActivity(
                     onValueChangeFinished = {
                         updateLookAndFeel(
                             appSettingsViewModel,
-                            keySizeState,
+                            keyHeightState,
+                            keyWidthState,
                             pushupSizeState,
                             animationSpeedState,
                             animationHelperSpeedState,
@@ -634,7 +688,8 @@ fun LookAndFeelActivity(
                     onCheckedChange = {
                         updateLookAndFeel(
                             appSettingsViewModel,
-                            keySizeState,
+                            keyHeightState,
+                            keyWidthState,
                             pushupSizeState,
                             animationSpeedState,
                             animationHelperSpeedState,
@@ -667,7 +722,8 @@ fun LookAndFeelActivity(
                     onCheckedChange = {
                         updateLookAndFeel(
                             appSettingsViewModel,
-                            keySizeState,
+                            keyHeightState,
+                            keyWidthState,
                             pushupSizeState,
                             animationSpeedState,
                             animationHelperSpeedState,
@@ -695,7 +751,8 @@ fun LookAndFeelActivity(
 
 private fun updateLookAndFeel(
     appSettingsViewModel: AppSettingsViewModel,
-    keySizeState: SettingValueState<Float>,
+    keyHeightState: SettingValueState<Float>,
+    keyWidthState: SettingValueState<Float>,
     pushupSizeState: SettingValueState<Float>,
     animationSpeedState: SettingValueState<Float>,
     animationHelperSpeedState: SettingValueState<Float>,
@@ -715,7 +772,8 @@ private fun updateLookAndFeel(
     appSettingsViewModel.updateLookAndFeel(
         LookAndFeelUpdate(
             id = 1,
-            keySize = keySizeState.value.toInt(),
+            keyHeight = keyHeightState.value.toInt(),
+            keyWidth = keyWidthState.value.toInt(),
             pushupSize = pushupSizeState.value.toInt(),
             animationSpeed = animationSpeedState.value.toInt(),
             animationHelperSpeed = animationHelperSpeedState.value.toInt(),

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/lookandfeel/LookAndFeelActivity.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/lookandfeel/LookAndFeelActivity.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Animation
 import androidx.compose.material.icons.outlined.BorderOuter
 import androidx.compose.material.icons.outlined.Colorize
+import androidx.compose.material.icons.outlined.Crop75
 import androidx.compose.material.icons.outlined.FormatSize
 import androidx.compose.material.icons.outlined.HideImage
 import androidx.compose.material.icons.outlined.LinearScale
@@ -52,10 +53,9 @@ import com.dessalines.thumbkey.db.DEFAULT_HIDE_LETTERS
 import com.dessalines.thumbkey.db.DEFAULT_HIDE_SYMBOLS
 import com.dessalines.thumbkey.db.DEFAULT_KEY_BORDERS
 import com.dessalines.thumbkey.db.DEFAULT_KEY_BORDER_WIDTH
-import com.dessalines.thumbkey.db.DEFAULT_KEY_HEIGHT
 import com.dessalines.thumbkey.db.DEFAULT_KEY_PADDING
 import com.dessalines.thumbkey.db.DEFAULT_KEY_RADIUS
-import com.dessalines.thumbkey.db.DEFAULT_KEY_WIDTH
+import com.dessalines.thumbkey.db.DEFAULT_KEY_SIZE
 import com.dessalines.thumbkey.db.DEFAULT_POSITION
 import com.dessalines.thumbkey.db.DEFAULT_PUSHUP_SIZE
 import com.dessalines.thumbkey.db.DEFAULT_SOUND_ON_TAP
@@ -83,13 +83,17 @@ fun LookAndFeelActivity(
 
     val settings by appSettingsViewModel.appSettings.observeAsState()
 
-    val keyHeightState =
+    val keySizeState =
         rememberFloatSettingState(
-            (settings?.keyHeight ?: DEFAULT_KEY_HEIGHT).toFloat(),
+            (settings?.keySize ?: DEFAULT_KEY_SIZE).toFloat(),
         )
     val keyWidthState =
         rememberFloatSettingState(
-            (settings?.keyWidth ?: DEFAULT_KEY_WIDTH).toFloat(),
+            ((if ((settings?.keyWidth ?: 0) > 0) settings?.keyWidth else keySizeState.value) ?: keySizeState.value).toFloat(),
+        )
+    val nonSquareKeysState =
+        rememberBooleanSettingState(
+            keySizeState.value != keyWidthState.value,
         )
     val pushupSizeState =
         rememberFloatSettingState(
@@ -182,7 +186,8 @@ fun LookAndFeelActivity(
                         themeState.value = i
                         updateLookAndFeel(
                             appSettingsViewModel,
-                            keyHeightState,
+                            keySizeState,
+                            nonSquareKeysState,
                             keyWidthState,
                             pushupSizeState,
                             animationSpeedState,
@@ -218,7 +223,8 @@ fun LookAndFeelActivity(
                         themeColorState.value = i
                         updateLookAndFeel(
                             appSettingsViewModel,
-                            keyHeightState,
+                            keySizeState,
+                            nonSquareKeysState,
                             keyWidthState,
                             pushupSizeState,
                             animationSpeedState,
@@ -254,7 +260,8 @@ fun LookAndFeelActivity(
                         positionState.value = i
                         updateLookAndFeel(
                             appSettingsViewModel,
-                            keyHeightState,
+                            keySizeState,
+                            nonSquareKeysState,
                             keyWidthState,
                             pushupSizeState,
                             animationSpeedState,
@@ -288,7 +295,8 @@ fun LookAndFeelActivity(
                     onCheckedChange = {
                         updateLookAndFeel(
                             appSettingsViewModel,
-                            keyHeightState,
+                            keySizeState,
+                            nonSquareKeysState,
                             keyWidthState,
                             pushupSizeState,
                             animationSpeedState,
@@ -322,7 +330,8 @@ fun LookAndFeelActivity(
                     onCheckedChange = {
                         updateLookAndFeel(
                             appSettingsViewModel,
-                            keyHeightState,
+                            keySizeState,
+                            nonSquareKeysState,
                             keyWidthState,
                             pushupSizeState,
                             animationSpeedState,
@@ -356,7 +365,8 @@ fun LookAndFeelActivity(
                     onCheckedChange = {
                         updateLookAndFeel(
                             appSettingsViewModel,
-                            keyHeightState,
+                            keySizeState,
+                            nonSquareKeysState,
                             keyWidthState,
                             pushupSizeState,
                             animationSpeedState,
@@ -376,10 +386,14 @@ fun LookAndFeelActivity(
                         )
                     },
                 )
-                val keyHeightStr = stringResource(R.string.key_height, keyHeightState.value.toInt().toString())
+                val keyHeightStr =
+                    stringResource(
+                        if (nonSquareKeysState.value) R.string.key_height else R.string.key_size,
+                        keySizeState.value.toInt().toString(),
+                    )
                 SettingsSlider(
                     valueRange = 10f..200f,
-                    state = keyHeightState,
+                    state = keySizeState,
                     icon = {
                         Icon(
                             imageVector = Icons.Outlined.FormatSize,
@@ -392,7 +406,8 @@ fun LookAndFeelActivity(
                     onValueChangeFinished = {
                         updateLookAndFeel(
                             appSettingsViewModel,
-                            keyHeightState,
+                            keySizeState,
+                            nonSquareKeysState,
                             keyWidthState,
                             pushupSizeState,
                             animationSpeedState,
@@ -412,23 +427,22 @@ fun LookAndFeelActivity(
                         )
                     },
                 )
-                val keyWidthStr = stringResource(R.string.key_width, keyWidthState.value.toInt().toString())
-                SettingsSlider(
-                    valueRange = 10f..200f,
-                    state = keyWidthState,
+                SettingsCheckbox(
+                    state = nonSquareKeysState,
                     icon = {
                         Icon(
-                            imageVector = Icons.Outlined.FormatSize,
+                            imageVector = Icons.Outlined.Crop75,
                             contentDescription = null,
                         )
                     },
                     title = {
-                        Text(keyWidthStr)
+                        Text(stringResource(R.string.key_non_square))
                     },
-                    onValueChangeFinished = {
+                    onCheckedChange = {
                         updateLookAndFeel(
                             appSettingsViewModel,
-                            keyHeightState,
+                            keySizeState,
+                            nonSquareKeysState,
                             keyWidthState,
                             pushupSizeState,
                             animationSpeedState,
@@ -448,6 +462,45 @@ fun LookAndFeelActivity(
                         )
                     },
                 )
+                if (nonSquareKeysState.value) {
+                    val keyWidthStr = stringResource(R.string.key_width, keyWidthState.value.toInt().toString())
+                    SettingsSlider(
+                        valueRange = 10f..200f,
+                        state = keyWidthState,
+                        icon = {
+                            Icon(
+                                imageVector = Icons.Outlined.Crop75,
+                                contentDescription = null,
+                            )
+                        },
+                        title = {
+                            Text(keyWidthStr)
+                        },
+                        onValueChangeFinished = {
+                            updateLookAndFeel(
+                                appSettingsViewModel,
+                                keySizeState,
+                                nonSquareKeysState,
+                                keyWidthState,
+                                pushupSizeState,
+                                animationSpeedState,
+                                animationHelperSpeedState,
+                                positionState,
+                                keyBordersState,
+                                vibrateOnTapState,
+                                soundOnTapState,
+                                hideLettersState,
+                                hideSymbolsState,
+                                themeState,
+                                themeColorState,
+                                backdropEnabledState,
+                                keyPaddingState,
+                                keyBorderWidthState,
+                                keyRadiusState,
+                            )
+                        },
+                    )
+                }
                 val keyPaddingStr = stringResource(R.string.key_padding, keyPaddingState.value.toInt().toString())
                 SettingsSlider(
                     valueRange = 0f..10f,
@@ -464,7 +517,8 @@ fun LookAndFeelActivity(
                     onValueChangeFinished = {
                         updateLookAndFeel(
                             appSettingsViewModel,
-                            keyHeightState,
+                            keySizeState,
+                            nonSquareKeysState,
                             keyWidthState,
                             pushupSizeState,
                             animationSpeedState,
@@ -500,7 +554,8 @@ fun LookAndFeelActivity(
                     onValueChangeFinished = {
                         updateLookAndFeel(
                             appSettingsViewModel,
-                            keyHeightState,
+                            keySizeState,
+                            nonSquareKeysState,
                             keyWidthState,
                             pushupSizeState,
                             animationSpeedState,
@@ -536,7 +591,8 @@ fun LookAndFeelActivity(
                     onValueChangeFinished = {
                         updateLookAndFeel(
                             appSettingsViewModel,
-                            keyHeightState,
+                            keySizeState,
+                            nonSquareKeysState,
                             keyWidthState,
                             pushupSizeState,
                             animationSpeedState,
@@ -572,7 +628,8 @@ fun LookAndFeelActivity(
                     onValueChangeFinished = {
                         updateLookAndFeel(
                             appSettingsViewModel,
-                            keyHeightState,
+                            keySizeState,
+                            nonSquareKeysState,
                             keyWidthState,
                             pushupSizeState,
                             animationSpeedState,
@@ -608,7 +665,8 @@ fun LookAndFeelActivity(
                     onValueChangeFinished = {
                         updateLookAndFeel(
                             appSettingsViewModel,
-                            keyHeightState,
+                            keySizeState,
+                            nonSquareKeysState,
                             keyWidthState,
                             pushupSizeState,
                             animationSpeedState,
@@ -650,7 +708,8 @@ fun LookAndFeelActivity(
                     onValueChangeFinished = {
                         updateLookAndFeel(
                             appSettingsViewModel,
-                            keyHeightState,
+                            keySizeState,
+                            nonSquareKeysState,
                             keyWidthState,
                             pushupSizeState,
                             animationSpeedState,
@@ -688,7 +747,8 @@ fun LookAndFeelActivity(
                     onCheckedChange = {
                         updateLookAndFeel(
                             appSettingsViewModel,
-                            keyHeightState,
+                            keySizeState,
+                            nonSquareKeysState,
                             keyWidthState,
                             pushupSizeState,
                             animationSpeedState,
@@ -722,7 +782,8 @@ fun LookAndFeelActivity(
                     onCheckedChange = {
                         updateLookAndFeel(
                             appSettingsViewModel,
-                            keyHeightState,
+                            keySizeState,
+                            nonSquareKeysState,
                             keyWidthState,
                             pushupSizeState,
                             animationSpeedState,
@@ -751,7 +812,8 @@ fun LookAndFeelActivity(
 
 private fun updateLookAndFeel(
     appSettingsViewModel: AppSettingsViewModel,
-    keyHeightState: SettingValueState<Float>,
+    keySizeState: SettingValueState<Float>,
+    nonSquareKeysState: SettingValueState<Boolean>,
     keyWidthState: SettingValueState<Float>,
     pushupSizeState: SettingValueState<Float>,
     animationSpeedState: SettingValueState<Float>,
@@ -772,8 +834,8 @@ private fun updateLookAndFeel(
     appSettingsViewModel.updateLookAndFeel(
         LookAndFeelUpdate(
             id = 1,
-            keyHeight = keyHeightState.value.toInt(),
-            keyWidth = keyWidthState.value.toInt(),
+            keySize = keySizeState.value.toInt(),
+            keyWidth = if (nonSquareKeysState.value) keyWidthState.value.toInt() else 0,
             pushupSize = pushupSizeState.value.toInt(),
             animationSpeed = animationSpeedState.value.toInt(),
             animationHelperSpeed = animationHelperSpeedState.value.toInt(),

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/lookandfeel/LookAndFeelActivity.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/lookandfeel/LookAndFeelActivity.kt
@@ -89,7 +89,7 @@ fun LookAndFeelActivity(
         )
     val keyWidthState =
         rememberFloatSettingState(
-            ((if ((settings?.keyWidth ?: 0) > 0) settings?.keyWidth else keySizeState.value) ?: keySizeState.value).toFloat(),
+            (settings?.keyWidth ?: keySizeState.value).toFloat(),
         )
     val nonSquareKeysState =
         rememberBooleanSettingState(
@@ -835,7 +835,7 @@ private fun updateLookAndFeel(
         LookAndFeelUpdate(
             id = 1,
             keySize = keySizeState.value.toInt(),
-            keyWidth = if (nonSquareKeysState.value) keyWidthState.value.toInt() else 0,
+            keyWidth = if (nonSquareKeysState.value) keyWidthState.value.toInt() else null,
             pushupSize = pushupSizeState.value.toInt(),
             animationSpeed = animationSpeedState.value.toInt(),
             animationHelperSpeed = animationHelperSpeedState.value.toInt(),

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -78,4 +78,7 @@
     <string name="key_padding">Espacement des touches : %1$s</string>
     <string name="key_border_width">Bordure des touches : %1$s</string>
     <string name="key_radius">Arrondi des touches : %1$s</string>
+    <string name="key_non_square">Touches non carrées</string>
+    <string name="key_width">Largeur des touches : %1$s</string>
+    <string name="key_height">Hauteur des touches : %1$s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,6 +42,8 @@
     <string name="vibrate_warning">Requires touch feedback to be enabled in system settings</string>
     <string name="play_sound_on_tap">Play sound on tap</string>
     <string name="auto_capitalize">Auto-Capitalize</string>
+    <string name="key_size">Key Size: %1$s</string>
+    <string name="key_non_square">Use Non-Square Keys</string>
     <string name="key_height">Key Height: %1$s</string>
     <string name="key_width">Key Width: %1$s</string>
     <string name="bottom_offset">Bottom Offset: %1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,7 +42,8 @@
     <string name="vibrate_warning">Requires touch feedback to be enabled in system settings</string>
     <string name="play_sound_on_tap">Play sound on tap</string>
     <string name="auto_capitalize">Auto-Capitalize</string>
-    <string name="key_size">Key Size: %1$s</string>
+    <string name="key_height">Key Height: %1$s</string>
+    <string name="key_width">Key Width: %1$s</string>
     <string name="bottom_offset">Bottom Offset: %1$s</string>
     <string name="min_swipe_length">Minimum Swipe Length: %1$s</string>
     <string name="animation_speed">Animation Speed: %1$s</string>


### PR DESCRIPTION
### Implement non-square keys

by splitting `key_size` in `key_height` and `key_width`

---

I think having `key height` and `key width` allows more precision than a `ratio` setting. It also doesn't require to know the screen width and the number of keys in the keyboard.

#### Notes

- See discussion in https://github.com/dessalines/thumb-key/issues/640.
- Please forgive this unannounced PR, I wasn't expected to have something working so quickly... now that I have it, I share it, but I wouldn't mind at all if this isn't accepted.
- If you want to test it, you will have to clear your app data (not of your main keyboard, just the debug one). This is because the database schema has changed.

#### Left to be done, if we choose to go ahead with this proposal
- write a migration for the database,
- update all translations of `key_size`.

---

![wide-keyboard](https://github.com/dessalines/thumb-key/assets/29386932/8dad73d4-0762-4e8f-9c8b-acfb415a993c)
