### PR TITLE
Added missing combine keys for french messageease keyboard

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FRMessageEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FRMessageEase.kt
@@ -364,6 +364,18 @@ val KB_FR_MESSAGEEASE_MAIN =
                                     action = KeyAction.CommitText("\u0009"),
                                     color = ColorVariant.MUTED,
                                 ),
+                            SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("¨"),
+                                    action = KeyAction.CommitText("\u0308"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.BOTTOM_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("ñ"),
+                                    action = KeyAction.CommitText("\u0303"),
+                                    color = ColorVariant.MUTED,
+                                ),
                         ),
                 ),
                 KeyItemC(
@@ -832,6 +844,18 @@ val KB_FR_MESSAGEEASE_SHIFTED =
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("␉"),
                                     action = KeyAction.CommitText("\u0009"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("¨"),
+                                    action = KeyAction.CommitText("\u0308"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.BOTTOM_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("ñ"),
+                                    action = KeyAction.CommitText("\u0303"),
                                     color = ColorVariant.MUTED,
                                 ),
                         ),


### PR DESCRIPTION
Added two more key swipes to the FRMessageEase keyboard, to match what is available on messageease:

- **¨** to create characters like ë, ï ö
- **~** to create characters like ñ, ã, õ

Although these characters are not all part of the french language, they are offered by the messageease equivalent, and are useful when working with words from different languages.

On messageease, a single ~ swipe is used to both create standalone ~ and, when done after N, A, U, I, O, create a composed Ñ, Ã, Ũ, Ĩ, Õ. Since that behaviour is AFAICS not yet available in thumb-key, I propose here to create an additional swipe key so the functionality is at least available to the user. 