### PR TITLE
Add long-press actions to keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,10 @@ This project is a follow-up to the now unmaintained (and closed-source) [Message
 - **Swipe up** or **down** on `A` to capitalize. (If you changed the layout, the button next to `#`)  
   <img width=60px height=60px src="https://i.postimg.cc/Znt2Ft9G/thumbkey-1-1.png">
 - **Double tap** the space bar to type a comma, triple tap to type a period. More taps have more punctuation.
-- **Swipe left** on the backspace key to delete whole words to the left of the cursor.
+- **Swipe left** or **long press** on the backspace key to delete whole words to the left of the cursor.
 - **Swipe right** on the backspace key to delete whole words to the right of the cursor.
 - **Swipe left** or **right** on the spacebar to move the cursor by 1 character.
+- **Long press** the return key to insert a line break
 
 ### Emoji Key
 

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/CommonKeys.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/CommonKeys.kt
@@ -186,6 +186,7 @@ val BACKSPACE_KEY_ITEM =
                     ),
             ),
         backgroundColor = ColorVariant.SURFACE_VARIANT,
+        longPress = KeyAction.DeleteWordBeforeCursor,
     )
 
 val SPACEBAR_KEY_ITEM =
@@ -329,6 +330,7 @@ val RETURN_KEY_ITEM =
                 color = ColorVariant.SECONDARY,
             ),
         backgroundColor = ColorVariant.SURFACE_VARIANT,
+        longPress = KeyAction.CommitText("\n"),
     )
 
 val SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM =

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
@@ -226,6 +226,12 @@ fun KeyboardKey(
                             onSwitchPosition = onSwitchPosition,
                         )
                         doneKeyAction(scope, action, isDragged, releasedKey, animationHelperSpeed)
+                        if (vibrateOnTap) {
+                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                        }
+                        if (soundOnTap) {
+                            audioManager.playSoundEffect(AudioManager.FX_KEY_CLICK, .1f)
+                        }
                     }
                 },
             )

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
@@ -1,7 +1,6 @@
 package com.dessalines.thumbkey.ui.components.keyboard
 import android.content.Context
 import android.media.AudioManager
-import android.util.Log
 import android.view.KeyEvent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.EnterTransition
@@ -11,7 +10,6 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -194,7 +192,7 @@ fun KeyboardKey(
                         }
                     }
                     lastAction.value = cAction
-                    
+
                     // Set the correct action
                     val action = tapActions[tapCount % tapActions.size]
                     performKeyAction(

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
@@ -1,15 +1,18 @@
 package com.dessalines.thumbkey.ui.components.keyboard
 import android.content.Context
 import android.media.AudioManager
+import android.util.Log
 import android.view.KeyEvent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
@@ -68,6 +71,7 @@ import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun KeyboardKey(
     key: KeyItemC,
@@ -176,36 +180,57 @@ fun KeyboardKey(
             )
             .background(color = backgroundColor)
             // Note: pointerInput has a delay when switching keyboards, so you must use this
-            .clickable(interactionSource = interactionSource, indication = null) {
-                // Set the last key info, and the tap count
-                val cAction = key.center.action
-                lastAction.value?.let { lastAction ->
-                    if (lastAction == cAction && !ime.didCursorMove()) {
-                        tapCount += 1
-                    } else {
-                        tapCount = 0
+            .combinedClickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = {
+                    // Set the last key info, and the tap count
+                    val cAction = key.center.action
+                    lastAction.value?.let { lastAction ->
+                        if (lastAction == cAction && !ime.didCursorMove()) {
+                            tapCount += 1
+                        } else {
+                            tapCount = 0
+                        }
                     }
-                }
-                lastAction.value = cAction
-
-                // Set the correct action
-                val action = tapActions[tapCount % tapActions.size]
-
-                performKeyAction(
-                    action = action,
-                    ime = ime,
-                    autoCapitalize = autoCapitalize,
-                    keyboardSettings = keyboardSettings,
-                    onToggleShiftMode = onToggleShiftMode,
-                    onToggleNumericMode = onToggleNumericMode,
-                    onToggleEmojiMode = onToggleEmojiMode,
-                    onToggleCapsLock = onToggleCapsLock,
-                    onAutoCapitalize = onAutoCapitalize,
-                    onSwitchLanguage = onSwitchLanguage,
-                    onSwitchPosition = onSwitchPosition,
-                )
-                doneKeyAction(scope, action, isDragged, releasedKey, animationHelperSpeed)
-            }
+                    lastAction.value = cAction
+                    
+                    // Set the correct action
+                    val action = tapActions[tapCount % tapActions.size]
+                    performKeyAction(
+                        action = action,
+                        ime = ime,
+                        autoCapitalize = autoCapitalize,
+                        keyboardSettings = keyboardSettings,
+                        onToggleShiftMode = onToggleShiftMode,
+                        onToggleNumericMode = onToggleNumericMode,
+                        onToggleEmojiMode = onToggleEmojiMode,
+                        onToggleCapsLock = onToggleCapsLock,
+                        onAutoCapitalize = onAutoCapitalize,
+                        onSwitchLanguage = onSwitchLanguage,
+                        onSwitchPosition = onSwitchPosition,
+                    )
+                    doneKeyAction(scope, action, isDragged, releasedKey, animationHelperSpeed)
+                },
+                onLongClick = {
+                    key.longPress?.let { action ->
+                        performKeyAction(
+                            action = action,
+                            ime = ime,
+                            autoCapitalize = autoCapitalize,
+                            keyboardSettings = keyboardSettings,
+                            onToggleShiftMode = onToggleShiftMode,
+                            onToggleNumericMode = onToggleNumericMode,
+                            onToggleEmojiMode = onToggleEmojiMode,
+                            onToggleCapsLock = onToggleCapsLock,
+                            onAutoCapitalize = onAutoCapitalize,
+                            onSwitchLanguage = onSwitchLanguage,
+                            onSwitchPosition = onSwitchPosition,
+                        )
+                        doneKeyAction(scope, action, isDragged, releasedKey, animationHelperSpeed)
+                    }
+                },
+            )
             // The key1 is necessary, otherwise new swipes wont work
             .pointerInput(key1 = id) {
                 detectDragGestures(

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
@@ -48,6 +48,7 @@ data class KeyItemC(
     val backgroundColor: ColorVariant = ColorVariant.SURFACE,
     val swipeType: SwipeNWay = SwipeNWay.EIGHT_WAY,
     val slideType: SlideType = SlideType.NONE,
+    val longPress: KeyAction? = null,
 )
 
 data class KeyC(


### PR DESCRIPTION
Add long-press actions to override default behaviors. Main use case is to insert a newline into a text field where it would otherwise perform a submit action.