### PR TITLE
Fixes for English MessagEase keyboard

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseNumeric.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseNumeric.kt
@@ -1,7 +1,5 @@
 package com.dessalines.thumbkey.keyboards
 
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Abc
 import com.dessalines.thumbkey.utils.ColorVariant
 import com.dessalines.thumbkey.utils.FontSizeVariant
 import com.dessalines.thumbkey.utils.KeyAction
@@ -226,16 +224,7 @@ val KB_EN_MESSAGEASE_NUMERIC =
                                 ),
                         ),
                 ),
-                KeyItemC(
-                    center =
-                        KeyC(
-                            display = KeyDisplay.IconDisplay(Icons.Outlined.Abc),
-                            action = KeyAction.ToggleNumericMode(false),
-                            size = FontSizeVariant.LARGE,
-                            color = ColorVariant.PRIMARY,
-                        ),
-                    backgroundColor = ColorVariant.SURFACE_VARIANT,
-                ),
+                ABC_KEY_ITEM,
             ),
             listOf(
                 KeyItemC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseNumeric.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseNumeric.kt
@@ -263,6 +263,11 @@ val KB_EN_MESSAGEASE_NUMERIC =
                                     display = KeyDisplay.TextDisplay("*"),
                                     action = KeyAction.CommitText("*"),
                                 ),
+                            SwipeDirection.BOTTOM_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("⇥"),
+                                    action = KeyAction.CommitText("\t"),
+                                ),
                         ),
                 ),
                 KeyItemC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseNumeric.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseNumeric.kt
@@ -242,7 +242,7 @@ val KB_EN_MESSAGEASE_NUMERIC =
                                     display = KeyDisplay.TextDisplay("~"),
                                     action = KeyAction.CommitText("~"),
                                 ),
-                            SwipeDirection.BOTTOM_LEFT to
+                            SwipeDirection.LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("<"),
                                     action = KeyAction.CommitText("<"),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseSymbols.kt
@@ -797,11 +797,11 @@ val KB_EN_MESSAGEASE_SYMBOLS_SHIFTED =
                     swipes =
                         mapOf(
                             SwipeDirection.TOP_LEFT to
-                                    KeyC(
-                                        display = KeyDisplay.TextDisplay("\""),
-                                        action = KeyAction.CommitText("\""),
-                                        color = ColorVariant.MUTED,
-                                    ),
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("\""),
+                                    action = KeyAction.CommitText("\""),
+                                    color = ColorVariant.MUTED,
+                                ),
                             SwipeDirection.TOP to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("W"),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseSymbols.kt
@@ -312,7 +312,6 @@ val KB_EN_MESSAGEASE_SYMBOLS_MAIN =
                             size = FontSizeVariant.LARGE,
                             color = ColorVariant.PRIMARY,
                         ),
-//                swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
                     swipes =
                         mapOf(
                             SwipeDirection.TOP_RIGHT to
@@ -334,8 +333,8 @@ val KB_EN_MESSAGEASE_SYMBOLS_MAIN =
                                 ),
                             SwipeDirection.BOTTOM_RIGHT to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay(":"),
-                                    action = KeyAction.CommitText(":"),
+                                    display = KeyDisplay.TextDisplay("⇥"),
+                                    action = KeyAction.CommitText("\t"),
                                     color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.LEFT to
@@ -356,6 +355,12 @@ val KB_EN_MESSAGEASE_SYMBOLS_MAIN =
                         ),
                     swipes =
                         mapOf(
+                            SwipeDirection.TOP_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("\""),
+                                    action = KeyAction.CommitText("\""),
+                                    color = ColorVariant.MUTED,
+                                ),
                             SwipeDirection.TOP to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("w"),
@@ -371,12 +376,6 @@ val KB_EN_MESSAGEASE_SYMBOLS_MAIN =
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("z"),
                                     action = KeyAction.CommitText("z"),
-                                ),
-                            SwipeDirection.TOP_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("\""),
-                                    action = KeyAction.CommitText("\""),
-                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.BOTTOM_RIGHT to
                                 KeyC(
@@ -754,7 +753,6 @@ val KB_EN_MESSAGEASE_SYMBOLS_SHIFTED =
                             size = FontSizeVariant.LARGE,
                             color = ColorVariant.PRIMARY,
                         ),
-//                swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
                     swipes =
                         mapOf(
                             SwipeDirection.TOP_RIGHT to
@@ -782,8 +780,8 @@ val KB_EN_MESSAGEASE_SYMBOLS_SHIFTED =
                                 ),
                             SwipeDirection.BOTTOM_RIGHT to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay(":"),
-                                    action = KeyAction.CommitText(":"),
+                                    display = KeyDisplay.TextDisplay("⇥"),
+                                    action = KeyAction.CommitText("\t"),
                                     color = ColorVariant.MUTED,
                                 ),
                         ),
@@ -798,6 +796,12 @@ val KB_EN_MESSAGEASE_SYMBOLS_SHIFTED =
                         ),
                     swipes =
                         mapOf(
+                            SwipeDirection.TOP_LEFT to
+                                    KeyC(
+                                        display = KeyDisplay.TextDisplay("\""),
+                                        action = KeyAction.CommitText("\""),
+                                        color = ColorVariant.MUTED,
+                                    ),
                             SwipeDirection.TOP to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("W"),
@@ -814,10 +818,10 @@ val KB_EN_MESSAGEASE_SYMBOLS_SHIFTED =
                                     display = KeyDisplay.TextDisplay("Z"),
                                     action = KeyAction.CommitText("Z"),
                                 ),
-                            SwipeDirection.TOP_LEFT to
+                            SwipeDirection.BOTTOM_RIGHT to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("\""),
-                                    action = KeyAction.CommitText("\""),
+                                    display = KeyDisplay.TextDisplay(":"),
+                                    action = KeyAction.CommitText(":"),
                                     color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.BOTTOM to


### PR DESCRIPTION
I've included @JDeeth's commit from #687 (making that PR obsolete) and updated it with the changes that have been made in the past few days. Many of his changes, like adding the numeric keyboard, have already been implemented by others, so the only things remaining from his commit are:
- Add `:` key on the bottom-right swipe of the shifted `E` key in the Symbols keyboard
- Add `⇥` (tab) key on the bottom-right swipe of the `t` key in the Numeric and Symbols keyboards

Additionally:
- I've made sure that `ENMessagEaseNumeric` uses the `ABC_KEY_ITEM` (which also happened in #696, this is the only keyboard layout that still used the manual key item).
- On `ENMessagEaseNumeric`, I've moved `<` from the bottom-left swipe of the `7` key to the left swipe of the `7` key.