### PR TITLE
CommonKeys.kt: Show swipes on NUMERIC_KEY_ITEM also on ABC_KEY_ITEM

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,22 +62,22 @@ This project is a follow-up to the now unmaintained (and closed-source) [Message
 
 ### Emoji Key
 
-- **Tap** to access the emoji picker
-- **Swipe up** to configure Thumb-key
-- **Swipe right** to change keyboard position
-- **Swipe down** to access IME switcher (switch between Thumb-key and other keyboards)
+- **Tap** to access the emoji picker.
+- **Swipe up** to configure Thumb-key.
+- **Swipe right** to change keyboard position.
+- **Swipe down** to access IME switcher (switch between Thumb-key and other keyboards).
 - **Swipe left** to cycle between selected layouts (languages).
 - **Swipe to bottom-left** to toggle voice input. Requires [FUTO Voice Input](https://play.google.com/store/apps/details?id=org.futo.voiceinput).
 
 ### Symbols / Letters Key
 
-- **Tap** to access numbers & symbols. **Tap again** to return to letters
-- **Swipe to top-left** to select all
+- **Tap** to access numbers & symbols. **Tap again** to return to letters.
+- **Swipe to top-left** to select all.
 - **Swipe up** to copy - If nothing is selected, all the text will be copied.
 - **Swipe to top-right** to cut - If nothing is selected, all the text will be selected and cut.
-- **Swipe right** to redo
-- **Swipe down** to paste
-- **Swipe left** to undo
+- **Swipe right** to redo.
+- **Swipe down** to paste.
+- **Swipe left** to undo.
 
 ### Slide gestures
 

--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ This project is a follow-up to the now unmaintained (and closed-source) [Message
 - **Swipe left** to cycle between selected layouts (languages).
 - **Swipe to bottom-left** to toggle voice input. Requires [FUTO Voice Input](https://play.google.com/store/apps/details?id=org.futo.voiceinput).
 
-### Symbol (`#`) Key
+### Symbols / Letters Key
 
-- **Tap** to access numbers & symbols
+- **Tap** to access numbers & symbols. **Tap again** to return to letters
 - **Swipe to top-left** to select all
 - **Swipe up** to copy - If nothing is selected, all the text will be copied.
 - **Swipe to top-right** to cut - If nothing is selected, all the text will be selected and cut.

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/CommonKeys.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/CommonKeys.kt
@@ -32,6 +32,46 @@ import com.dessalines.thumbkey.utils.SlideType
 import com.dessalines.thumbkey.utils.SwipeDirection
 import com.dessalines.thumbkey.utils.SwipeNWay
 
+val ABC_OR_NUMERIC_SWIPES =
+    mapOf(
+        SwipeDirection.TOP to
+            KeyC(
+                display = KeyDisplay.IconDisplay(Icons.Outlined.ContentCopy),
+                action = KeyAction.Copy,
+                color = ColorVariant.MUTED,
+            ),
+        SwipeDirection.TOP_LEFT to
+            KeyC(
+                display = KeyDisplay.IconDisplay(Icons.Outlined.SelectAll),
+                action = KeyAction.SelectAll,
+                color = ColorVariant.MUTED,
+            ),
+        SwipeDirection.TOP_RIGHT to
+            KeyC(
+                display = KeyDisplay.IconDisplay(Icons.Outlined.ContentCut),
+                action = KeyAction.Cut,
+                color = ColorVariant.MUTED,
+            ),
+        SwipeDirection.LEFT to
+            KeyC(
+                display = KeyDisplay.IconDisplay(Icons.AutoMirrored.Outlined.Undo),
+                action = KeyAction.Undo,
+                color = ColorVariant.MUTED,
+            ),
+        SwipeDirection.RIGHT to
+            KeyC(
+                display = KeyDisplay.IconDisplay(Icons.AutoMirrored.Outlined.Redo),
+                action = KeyAction.Redo,
+                color = ColorVariant.MUTED,
+            ),
+        SwipeDirection.BOTTOM to
+            KeyC(
+                display = KeyDisplay.IconDisplay(Icons.Outlined.ContentPaste),
+                action = KeyAction.Paste,
+                color = ColorVariant.MUTED,
+            ),
+    )
+
 val ABC_KEY_ITEM =
     KeyItemC(
         center =
@@ -41,6 +81,8 @@ val ABC_KEY_ITEM =
                 size = FontSizeVariant.LARGE,
                 color = ColorVariant.PRIMARY,
             ),
+        swipeType = SwipeNWay.EIGHT_WAY,
+        swipes = ABC_OR_NUMERIC_SWIPES,
         backgroundColor = ColorVariant.SURFACE_VARIANT,
     )
 
@@ -54,45 +96,7 @@ val NUMERIC_KEY_ITEM =
                 color = ColorVariant.SECONDARY,
             ),
         swipeType = SwipeNWay.EIGHT_WAY,
-        swipes =
-            mapOf(
-                SwipeDirection.TOP to
-                    KeyC(
-                        display = KeyDisplay.IconDisplay(Icons.Outlined.ContentCopy),
-                        action = KeyAction.Copy,
-                        color = ColorVariant.MUTED,
-                    ),
-                SwipeDirection.TOP_LEFT to
-                    KeyC(
-                        display = KeyDisplay.IconDisplay(Icons.Outlined.SelectAll),
-                        action = KeyAction.SelectAll,
-                        color = ColorVariant.MUTED,
-                    ),
-                SwipeDirection.TOP_RIGHT to
-                    KeyC(
-                        display = KeyDisplay.IconDisplay(Icons.Outlined.ContentCut),
-                        action = KeyAction.Cut,
-                        color = ColorVariant.MUTED,
-                    ),
-                SwipeDirection.LEFT to
-                    KeyC(
-                        display = KeyDisplay.IconDisplay(Icons.AutoMirrored.Outlined.Undo),
-                        action = KeyAction.Undo,
-                        color = ColorVariant.MUTED,
-                    ),
-                SwipeDirection.RIGHT to
-                    KeyC(
-                        display = KeyDisplay.IconDisplay(Icons.AutoMirrored.Outlined.Redo),
-                        action = KeyAction.Redo,
-                        color = ColorVariant.MUTED,
-                    ),
-                SwipeDirection.BOTTOM to
-                    KeyC(
-                        display = KeyDisplay.IconDisplay(Icons.Outlined.ContentPaste),
-                        action = KeyAction.Paste,
-                        color = ColorVariant.MUTED,
-                    ),
-            ),
+        swipes = ABC_OR_NUMERIC_SWIPES,
         backgroundColor = ColorVariant.SURFACE_VARIANT,
     )
 


### PR DESCRIPTION
I've extracted the swipes on the Symbol (`#`) Key to also show them on the Letters (`ABC`) Key. Great thanks to the fact that the common `ABC_KEY_ITEM` is in use for all keyboards now, since #696 and #719 :smile: 