### PR TITLE
MessagEase ES Numeric: add ¨, fix placing of < and >

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ESMessagEaseNumeric.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ESMessagEaseNumeric.kt
@@ -243,10 +243,10 @@ val KB_ES_MESSAGEASE_NUMERIC =
                                     action = KeyAction.CommitText("~"),
                                 ),
                             SwipeDirection.TOP to
-                                    KeyC(
-                                        display = KeyDisplay.TextDisplay("¨"),
-                                        action = KeyAction.CommitText("¨"),
-                                    ),
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("¨"),
+                                    action = KeyAction.CommitText("¨"),
+                                ),
                             SwipeDirection.LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("<"),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ESMessagEaseNumeric.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ESMessagEaseNumeric.kt
@@ -242,7 +242,12 @@ val KB_ES_MESSAGEASE_NUMERIC =
                                     display = KeyDisplay.TextDisplay("~"),
                                     action = KeyAction.CommitText("~"),
                                 ),
-                            SwipeDirection.BOTTOM_LEFT to
+                            SwipeDirection.TOP to
+                                    KeyC(
+                                        display = KeyDisplay.TextDisplay("¨"),
+                                        action = KeyAction.CommitText("¨"),
+                                    ),
+                            SwipeDirection.LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("<"),
                                     action = KeyAction.CommitText("<"),
@@ -311,7 +316,7 @@ val KB_ES_MESSAGEASE_NUMERIC =
                                     display = KeyDisplay.TextDisplay("°"),
                                     action = KeyAction.CommitText("°"),
                                 ),
-                            SwipeDirection.BOTTOM_RIGHT to
+                            SwipeDirection.RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay(">"),
                                     action = KeyAction.CommitText(">"),


### PR DESCRIPTION
# Changes
- `¨` was missing
- `<` and `>` were misplaced

| swipe | old | new |
| ----- | --- | --- |
| 7⬆️ |     | `¨` |
| 7⬅️ |     | `<` |
| 7↙️  | `<` |     |
| 9➡️ |     | `>` |
| 9↘️  | `>` |     |

# files changed:
`app/src/main/java/com/dessalines/thumbkey/keyboards/ESMessagEaseNumeric.kt`

# Evidence
MessagEase Spanish numeric (save the `¬` that I customized)
![image](https://github.com/dessalines/thumb-key/assets/3915542/51ca9273-2fda-4a30-ac96-fe7bd79b1c1a)

Tumb-key "Español MessagEase" numeric before the change
![image](https://github.com/dessalines/thumb-key/assets/3915542/d4574852-316b-48a0-93a4-e67effbe6981)

After the change:
![image](https://github.com/dessalines/thumb-key/assets/3915542/eab9e73c-fabc-467b-a955-c5311ed42f83)

