### PR TITLE
Hide small shift arrow up icon when letters are hidden

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
@@ -21,6 +21,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowDropUp
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -695,12 +697,14 @@ fun KeyText(
 
     when (display) {
         is KeyDisplay.IconDisplay -> {
-            Icon(
-                imageVector = display.icon,
-                contentDescription = display.icon.name,
-                tint = color,
-                modifier = Modifier.size(fontSize.value.dp),
-            )
+            if (!hideLetters || display.icon != Icons.Outlined.ArrowDropUp) {
+                Icon(
+                    imageVector = display.icon,
+                    contentDescription = display.icon.name,
+                    tint = color,
+                    modifier = Modifier.size(fontSize.value.dp),
+                )
+            }
         }
         is KeyDisplay.TextDisplay -> {
             // Only  hide the letters for text, not symbols


### PR DESCRIPTION
[Another suggestion, feel free to just ditch it if you don't like it :slightly_smiling_face:]

### Hide small shift arrow up icon when letters are hidden

I found that having just that little arrow when everything else is hidden isn't very useful/"beautiful".

Before:

![image](https://github.com/dessalines/thumb-key/assets/29386932/64f3ec8b-bf41-4b6b-8ca6-780d7d0ed0c3)

After:

![image](https://github.com/dessalines/thumb-key/assets/29386932/95787573-c9e4-4603-9e42-05b50882643e)

Note: only the arrow on the base layer is hidden. When you switch to the shift and caps lock layers, the arrows show up as normal:

![Screenshot_20240217-165637~2.png](https://github.com/dessalines/thumb-key/assets/29386932/9467aeb9-29b0-493e-a150-bac8464d14b7)

