### PR TITLE
[NLThumbKey] Accented letters didn't work yet and made them muted

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/NLThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/NLThumbKey.kt
@@ -247,7 +247,6 @@ val KB_NL_THUMBKEY_MAIN =
                             size = FontSizeVariant.LARGE,
                             color = ColorVariant.PRIMARY,
                         ),
-                    swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
                     swipes =
                         mapOf(
                             SwipeDirection.TOP_LEFT to
@@ -259,16 +258,19 @@ val KB_NL_THUMBKEY_MAIN =
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("ë"),
                                     action = KeyAction.CommitText("ë"),
+                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("é"),
                                     action = KeyAction.CommitText("é"),
+                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("è"),
                                     action = KeyAction.CommitText("è"),
+                                    color = ColorVariant.MUTED,
                                 ),
                         ),
                 ),
@@ -518,7 +520,6 @@ val KB_NL_THUMBKEY_SHIFTED =
                             size = FontSizeVariant.LARGE,
                             color = ColorVariant.PRIMARY,
                         ),
-                    swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
                     swipes =
                         mapOf(
                             SwipeDirection.TOP_LEFT to
@@ -530,16 +531,19 @@ val KB_NL_THUMBKEY_SHIFTED =
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("Ë"),
                                     action = KeyAction.CommitText("Ë"),
+                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("É"),
                                     action = KeyAction.CommitText("É"),
+                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("È"),
                                     action = KeyAction.CommitText("È"),
+                                    color = ColorVariant.MUTED,
                                 ),
                         ),
                 ),


### PR DESCRIPTION
I tested the change and although the accented e's were visible, they didn't work. I think it's because of the SwipeNWay.FOUR_WAY_DIAGONAL, to I removed that psrt to make it similar to other maps with more than 2 keys.