### PR TITLE
Fixed Hungarian Type-split layout

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/HUTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/HUTypeSplit.kt
@@ -420,7 +420,7 @@ val KB_HU_TYPESPLIT_SHIFTED =
                             size = FontSizeVariant.LARGE,
                             color = ColorVariant.PRIMARY,
                         ),
-                    swipeType = SwipeNWay.TWO_WAY_VERTICAL,
+                    swipeType = SwipeNWay.FOUR_WAY_CROSS,
                     swipes =
                         mapOf(
                             SwipeDirection.RIGHT to


### PR DESCRIPTION
Fixed a typical rookie mistake made by me. Specifically, the swipe type of the O key in the shifted layout has been changed to `FOUR_WAY_CROSS` (was incorrectly set to `TWO_WAY_VERTICAL`), so Ő and Ú should be type-able now.