### PR TITLE
Remove up down spacebar swipes. Fixes #766

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/CommonKeys.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/CommonKeys.kt
@@ -204,28 +204,6 @@ val SPACEBAR_KEY_ITEM =
         slideType = SlideType.MOVE_CURSOR,
         swipes =
             mapOf(
-                SwipeDirection.TOP to
-                    KeyC(
-                        action =
-                            KeyAction.SendEvent(
-                                KeyEvent(
-                                    KeyEvent.ACTION_DOWN,
-                                    KeyEvent.KEYCODE_DPAD_UP,
-                                ),
-                            ),
-                        display = null,
-                    ),
-                SwipeDirection.BOTTOM to
-                    KeyC(
-                        action =
-                            KeyAction.SendEvent(
-                                KeyEvent(
-                                    KeyEvent.ACTION_DOWN,
-                                    KeyEvent.KEYCODE_DPAD_DOWN,
-                                ),
-                            ),
-                        display = null,
-                    ),
                 SwipeDirection.LEFT to
                     KeyC(
                         action =


### PR DESCRIPTION
Should be fine, since these up-down swipes are separately defined for the programming spacebar.