### PR TITLE
Update quotes and numbers on BG ME Phonetic Symbols

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/BGMessagEasePhoneticSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/BGMessagEasePhoneticSymbols.kt
@@ -838,7 +838,6 @@ val KB_BG_PHONETIC_MESSAGEASE_SYMBOLS_SHIFTED =
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("Щ"),
                                     action = KeyAction.CommitText("Щ"),
-                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.RIGHT to
                                 KeyC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/BGMessagEasePhoneticSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/BGMessagEasePhoneticSymbols.kt
@@ -347,8 +347,8 @@ val KB_BG_PHONETIC_MESSAGEASE_SYMBOLS_MAIN =
                                 ),
                             SwipeDirection.BOTTOM_RIGHT to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay(":"),
-                                    action = KeyAction.CommitText(":"),
+                                    display = KeyDisplay.TextDisplay("⇥"),
+                                    action = KeyAction.CommitText("\t"),
                                     color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.LEFT to
@@ -384,10 +384,16 @@ val KB_BG_PHONETIC_MESSAGEASE_SYMBOLS_MAIN =
                                     display = KeyDisplay.TextDisplay("з"),
                                     action = KeyAction.CommitText("з"),
                                 ),
+                            SwipeDirection.LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("„"),
+                                    action = KeyAction.CommitText("„"),
+                                    color = ColorVariant.MUTED,
+                                ),
                             SwipeDirection.TOP_LEFT to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("\""),
-                                    action = KeyAction.CommitText("\""),
+                                    display = KeyDisplay.TextDisplay("“"),
+                                    action = KeyAction.CommitText("“"),
                                     color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.BOTTOM_RIGHT to
@@ -807,8 +813,8 @@ val KB_BG_PHONETIC_MESSAGEASE_SYMBOLS_SHIFTED =
                                 ),
                             SwipeDirection.BOTTOM_RIGHT to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay(":"),
-                                    action = KeyAction.CommitText(":"),
+                                    display = KeyDisplay.TextDisplay("⇥"),
+                                    action = KeyAction.CommitText("\t"),
                                     color = ColorVariant.MUTED,
                                 ),
                         ),
@@ -839,10 +845,16 @@ val KB_BG_PHONETIC_MESSAGEASE_SYMBOLS_SHIFTED =
                                     display = KeyDisplay.TextDisplay("З"),
                                     action = KeyAction.CommitText("З"),
                                 ),
+                            SwipeDirection.LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("„"),
+                                    action = KeyAction.CommitText("„"),
+                                    color = ColorVariant.MUTED,
+                                ),
                             SwipeDirection.TOP_LEFT to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("\""),
-                                    action = KeyAction.CommitText("\""),
+                                    display = KeyDisplay.TextDisplay("“"),
+                                    action = KeyAction.CommitText("“"),
                                     color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.BOTTOM_RIGHT to
@@ -928,7 +940,7 @@ val KB_BG_PHONETIC_MESSAGEASE_SYMBOLS: KeyboardDefinition =
             KeyboardDefinitionModes(
                 main = KB_BG_PHONETIC_MESSAGEASE_SYMBOLS_MAIN,
                 shifted = KB_BG_PHONETIC_MESSAGEASE_SYMBOLS_SHIFTED,
-                numeric = NUMERIC_KEYBOARD,
+                numeric = KB_EN_MESSAGEASE_NUMERIC,
             ),
         settings =
             KeyboardDefinitionSettings(


### PR DESCRIPTION
Make ME Bulgarian Phonetic Symbols keyboard more consistent with the ME English:
* Change the left and upper_left slot of a key from an empty slot and `"` to `„` and `“`, which are the standard quotation symbols in Bulgarian.
* update the numeric keyboard to be consistent with ME English Symbols keyboard.
* update the extra `:` symbol to `\t`, as per the last change in ME English Symbols