### PR TITLE
He messag ease symbols add qmark

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/HEMessagEaseSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/HEMessagEaseSymbols.kt
@@ -42,6 +42,11 @@ val KB_HE_MESSAGEASE_SYMBOLS_MAIN =
                                     action = KeyAction.CommitText("$"),
                                     color = ColorVariant.MUTED,
                                 ),
+							SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("ץ"),
+                                    action = KeyAction.CommitText("ץ"),
+                                ),
                         ),
                 ),
                 KeyItemC(
@@ -120,8 +125,8 @@ val KB_HE_MESSAGEASE_SYMBOLS_MAIN =
                                 ),
                             SwipeDirection.LEFT to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("ץ"),
-                                    action = KeyAction.CommitText("ץ"),
+                                    display = KeyDisplay.TextDisplay("?"),
+                                    action = KeyAction.CommitText("?"),
                                 ),
                             SwipeDirection.BOTTOM to
                                 KeyC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/HEMessagEaseSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/HEMessagEaseSymbols.kt
@@ -42,7 +42,7 @@ val KB_HE_MESSAGEASE_SYMBOLS_MAIN =
                                     action = KeyAction.CommitText("$"),
                                     color = ColorVariant.MUTED,
                                 ),
-							SwipeDirection.BOTTOM to
+                            SwipeDirection.BOTTOM to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("ץ"),
                                     action = KeyAction.CommitText("ץ"),


### PR DESCRIPTION
Add question mark (?) symbol to Hebrew MessagEase layout, as suggested in issue 815.

I really like the Hebrew MessagEase layout, but the ץ is located where the ? is in English, and the ? is missing altogether.
I suggest moving ץ to a swipe-down from the top left key (ר) and replacing it with ?, which is a very useful key.