### PR TITLE
Add breve supersign to compose layout

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseCompose.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseCompose.kt
@@ -121,6 +121,12 @@ val KB_EN_MESSAGEASE_COMPOSED_MAIN =
                         ),
                     swipes =
                         mapOf(
+                            SwipeDirection.TOP to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("˘"),
+                                    action = KeyAction.ComposeLastKey("˘"),
+                                    color = ColorVariant.MUTED,
+                                ),
                             SwipeDirection.TOP_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("\$"),

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -543,6 +543,23 @@ fun performKeyAction(
                             " " -> "°"
                             else -> textBefore
                         }
+                    "˘" ->
+                        when (textBefore) {
+                            "a" -> "ă"
+                            "A" -> "Ă"
+                            "e" -> "ĕ"
+                            "E" -> "Ĕ"
+                            "g" -> "ğ"
+                            "G" -> "Ğ"
+                            "i" -> "ĭ"
+                            "I" -> "Ĭ"
+                            "o" -> "ŏ"
+                            "O" -> "Ŏ"
+                            "u" -> "ŭ"
+                            "U" -> "Ŭ"
+                            " " -> "˘"
+                            else -> textBefore
+                        }
                     "!" ->
                         when (textBefore) {
                             "a" -> "æ"


### PR DESCRIPTION
Update ENMessagEaseCompose in order to support letters which use a breve supersign. It is needed e.g. to support Esperanto ŭ or Romanian ă without having an extra layout for it