### PR TITLE
Fixes to the Eng-Esp-Cat thumbkey layout

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENESCAThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENESCAThumbKey.kt
@@ -301,10 +301,15 @@ val KB_EN_ES_CA_THUMBKEY_MAIN =
                                     action = KeyAction.CommitText("*"),
                                     color = ColorVariant.MUTED,
                                 ),
-                            SwipeDirection.RIGHT to
+                            SwipeDirection.LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("í"),
                                     action = KeyAction.CommitText("í"),
+                                ),
+                            SwipeDirection.TOP_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("ï"),
+                                    action = KeyAction.CommitText("ï"),
                                 ),
                         ),
                 ),
@@ -555,6 +560,12 @@ val KB_EN_ES_CA_HUMBKEY_SHIFTED =
                                     action = KeyAction.ToggleCapsLock,
                                     color = ColorVariant.MUTED,
                                 ),
+                            SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
+                                    action = KeyAction.ToggleShiftMode(false),
+                                    color = ColorVariant.MUTED,
+                                ),
                         ),
                 ),
                 NUMERIC_KEY_ITEM,
@@ -627,10 +638,15 @@ val KB_EN_ES_CA_HUMBKEY_SHIFTED =
                                     action = KeyAction.CommitText("*"),
                                     color = ColorVariant.MUTED,
                                 ),
-                            SwipeDirection.RIGHT to
+                            SwipeDirection.LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("Í"),
                                     action = KeyAction.CommitText("Í"),
+                                ),
+                            SwipeDirection.TOP_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("Ï"),
+                                    action = KeyAction.CommitText("Ï"),
                                 ),
                         ),
                 ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENESCAThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENESCAThumbKey.kt
@@ -1,6 +1,7 @@
 package com.dessalines.thumbkey.keyboards
 
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowDropDown
 import androidx.compose.material.icons.outlined.ArrowDropUp
 import androidx.compose.material.icons.outlined.Copyright
 import androidx.compose.material.icons.outlined.KeyboardCapslock


### PR DESCRIPTION
Fixed a few accidents in my layout file that hid the letter 'z', omitted 'ï', and lost the downward case shift.

related to issue #841 

I'm afraid I still couldn't successfully run './gradlew formatKotlin'