### PR TITLE
Implement Drag-and-return & Circular drag

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/db/AppDb.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/db/AppDb.kt
@@ -52,6 +52,10 @@ const val DEFAULT_BACKDROP_ENABLED = 0
 const val DEFAULT_KEY_PADDING = 0
 const val DEFAULT_KEY_BORDER_WIDTH = 1
 const val DEFAULT_KEY_RADIUS = 0
+const val DEFAULT_DRAG_RETURN_ENABLED = 1
+const val DEFAULT_CIRCULAR_DRAG_ENABLED = 1
+const val DEFAULT_CLOCKWISE_DRAG_ACTION = 0
+const val DEFAULT_COUNTERCLOCKWISE_DRAG_ACTION = 1
 
 @Entity
 data class AppSettings(
@@ -202,6 +206,26 @@ data class AppSettings(
         defaultValue = DEFAULT_KEY_RADIUS.toString(),
     )
     val keyRadius: Int,
+    @ColumnInfo(
+        name = "drag_return_enabled",
+        defaultValue = DEFAULT_DRAG_RETURN_ENABLED.toString(),
+    )
+    val dragReturnEnabled: Int,
+    @ColumnInfo(
+        name = "circular_drag_enabled",
+        defaultValue = DEFAULT_CIRCULAR_DRAG_ENABLED.toString(),
+    )
+    val circularDragEnabled: Int,
+    @ColumnInfo(
+        name = "clockwise_drag_action",
+        defaultValue = DEFAULT_CLOCKWISE_DRAG_ACTION.toString(),
+    )
+    val clockwiseDragAction: Int,
+    @ColumnInfo(
+        name = "counterclockwise_drag_action",
+        defaultValue = DEFAULT_COUNTERCLOCKWISE_DRAG_ACTION.toString(),
+    )
+    val counterclockwiseDragAction: Int,
 )
 
 data class LayoutsUpdate(
@@ -302,6 +326,14 @@ data class BehaviorUpdate(
     val autoCapitalize: Int,
     @ColumnInfo(name = "spacebar_multitaps")
     val spacebarMultiTaps: Int,
+    @ColumnInfo(name = "drag_return_enabled")
+    val dragReturnEnabled: Int,
+    @ColumnInfo(name = "circular_drag_enabled")
+    val circularDragEnabled: Int,
+    @ColumnInfo(name = "clockwise_drag_action")
+    val clockwiseDragAction: Int,
+    @ColumnInfo(name = "counterclockwise_drag_action")
+    val counterclockwiseDragAction: Int,
 )
 
 @Dao
@@ -508,8 +540,27 @@ val MIGRATION_13_14 =
         }
     }
 
+val MIGRATION_14_15 =
+    object : Migration(14, 15) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL(
+                "alter table AppSettings add column drag_return_enabled INTEGER NOT NULL default $DEFAULT_DRAG_RETURN_ENABLED",
+            )
+            db.execSQL(
+                "alter table AppSettings add column circular_drag_enabled INTEGER NOT NULL default $DEFAULT_CIRCULAR_DRAG_ENABLED",
+            )
+            db.execSQL(
+                "alter table AppSettings add column clockwise_drag_action INTEGER NOT NULL default $DEFAULT_CLOCKWISE_DRAG_ACTION",
+            )
+            db.execSQL(
+                "alter table AppSettings add column counterclockwise_drag_action INTEGER NOT NULL " +
+                    "default $DEFAULT_COUNTERCLOCKWISE_DRAG_ACTION",
+            )
+        }
+    }
+
 @Database(
-    version = 14,
+    version = 15,
     entities = [AppSettings::class],
     exportSchema = true,
 )
@@ -545,6 +596,7 @@ abstract class AppDB : RoomDatabase() {
                             MIGRATION_11_12,
                             MIGRATION_12_13,
                             MIGRATION_13_14,
+                            MIGRATION_14_15,
                         )
                         // Necessary because it can't insert data on creation
                         .addCallback(

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
@@ -110,8 +110,8 @@ fun KeyboardKey(
     onAutoCapitalize: (enable: Boolean) -> Unit,
     onSwitchLanguage: () -> Unit,
     onSwitchPosition: () -> Unit,
-    secondaryKey: KeyItemC? = null,
-    tertiaryKey: KeyItemC? = null,
+    oppositeCaseKey: KeyItemC? = null,
+    numericKey: KeyItemC? = null,
     dragReturnEnabled: Boolean,
     circularDragEnabled: Boolean,
     clockwiseDragAction: CircularDragAction,
@@ -434,8 +434,8 @@ fun KeyboardKey(
                                             if (circularDragEnabled) {
                                                 val circularDragActions =
                                                     mapOf(
-                                                        CircularDragAction.OppositeCase to secondaryKey?.center?.action,
-                                                        CircularDragAction.Numeric to tertiaryKey?.center?.action,
+                                                        CircularDragAction.OppositeCase to oppositeCaseKey?.center?.action,
+                                                        CircularDragAction.Numeric to numericKey?.center?.action,
                                                     )
                                                 circularDirection(positions, keySize)?.let {
                                                     when (it) {
@@ -451,7 +451,7 @@ fun KeyboardKey(
                                             if (dragReturnEnabled) {
                                                 val swipeDirection =
                                                     swipeDirection(maxOffset.x, maxOffset.y, minSwipeLength, key.swipeType)
-                                                secondaryKey?.swipes?.get(swipeDirection)?.action
+                                                oppositeCaseKey?.swipes?.get(swipeDirection)?.action
                                             } else {
                                                 null
                                             }

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
@@ -35,6 +35,10 @@ import com.dessalines.thumbkey.db.DEFAULT_ANIMATION_HELPER_SPEED
 import com.dessalines.thumbkey.db.DEFAULT_ANIMATION_SPEED
 import com.dessalines.thumbkey.db.DEFAULT_AUTO_CAPITALIZE
 import com.dessalines.thumbkey.db.DEFAULT_BACKDROP_ENABLED
+import com.dessalines.thumbkey.db.DEFAULT_CIRCULAR_DRAG_ENABLED
+import com.dessalines.thumbkey.db.DEFAULT_CLOCKWISE_DRAG_ACTION
+import com.dessalines.thumbkey.db.DEFAULT_COUNTERCLOCKWISE_DRAG_ACTION
+import com.dessalines.thumbkey.db.DEFAULT_DRAG_RETURN_ENABLED
 import com.dessalines.thumbkey.db.DEFAULT_HIDE_LETTERS
 import com.dessalines.thumbkey.db.DEFAULT_HIDE_SYMBOLS
 import com.dessalines.thumbkey.db.DEFAULT_KEYBOARD_LAYOUT
@@ -58,6 +62,7 @@ import com.dessalines.thumbkey.keyboards.EMOJI_BACK_KEY_ITEM
 import com.dessalines.thumbkey.keyboards.KB_EN_THUMBKEY_MAIN
 import com.dessalines.thumbkey.keyboards.NUMERIC_KEY_ITEM
 import com.dessalines.thumbkey.keyboards.RETURN_KEY_ITEM
+import com.dessalines.thumbkey.utils.CircularDragAction
 import com.dessalines.thumbkey.utils.KeyAction
 import com.dessalines.thumbkey.utils.KeyboardLayout
 import com.dessalines.thumbkey.utils.KeyboardMode
@@ -98,12 +103,22 @@ fun KeyboardScreen(
                 ?: DEFAULT_KEYBOARD_LAYOUT,
         ].keyboardDefinition
 
-    val keyboard =
+    val (keyboard, secondaryKeyboard, tertiaryKeyboard) =
         when (mode) {
-            KeyboardMode.MAIN -> keyboardDefinition.modes.main
-            KeyboardMode.SHIFTED -> keyboardDefinition.modes.shifted
-            KeyboardMode.NUMERIC -> keyboardDefinition.modes.numeric
-            else -> KB_EN_THUMBKEY_MAIN
+            KeyboardMode.MAIN ->
+                Triple(
+                    keyboardDefinition.modes.main,
+                    keyboardDefinition.modes.shifted,
+                    keyboardDefinition.modes.numeric,
+                )
+            KeyboardMode.SHIFTED ->
+                Triple(
+                    keyboardDefinition.modes.shifted,
+                    keyboardDefinition.modes.main,
+                    keyboardDefinition.modes.numeric,
+                )
+            KeyboardMode.NUMERIC -> Triple(keyboardDefinition.modes.numeric, null, null)
+            else -> Triple(KB_EN_THUMBKEY_MAIN, null, null)
         }
 
     val alignment =
@@ -133,6 +148,11 @@ fun KeyboardScreen(
     val legendHeight = settings?.keySize ?: DEFAULT_KEY_SIZE
     val legendWidth = settings?.keyWidth ?: legendHeight
     val keyRadius = settings?.keyRadius ?: DEFAULT_KEY_RADIUS
+    val dragReturnEnabled = (settings?.dragReturnEnabled ?: DEFAULT_DRAG_RETURN_ENABLED).toBool()
+    val circularDragEnabled = (settings?.circularDragEnabled ?: DEFAULT_CIRCULAR_DRAG_ENABLED).toBool()
+    val clockwiseDragAction = CircularDragAction.entries[settings?.clockwiseDragAction ?: DEFAULT_CLOCKWISE_DRAG_ACTION]
+    val counterclockwiseDragAction =
+        CircularDragAction.entries[settings?.counterclockwiseDragAction ?: DEFAULT_COUNTERCLOCKWISE_DRAG_ACTION]
 
     val keyBorderWidthFloat = keyBorderWidth / 10.0f
     val keyBorderColour = MaterialTheme.colorScheme.outline
@@ -299,6 +319,10 @@ fun KeyboardScreen(
                                 },
                                 onSwitchLanguage = onSwitchLanguage,
                                 onSwitchPosition = onSwitchPosition,
+                                dragReturnEnabled = dragReturnEnabled,
+                                circularDragEnabled = circularDragEnabled,
+                                clockwiseDragAction = clockwiseDragAction,
+                                counterclockwiseDragAction = counterclockwiseDragAction,
                             )
                         }
                     }
@@ -345,9 +369,9 @@ fun KeyboardScreen(
                             },
                         ),
             ) {
-                keyboard.arr.forEach { row ->
+                keyboard.arr.forEachIndexed { i, row ->
                     Row {
-                        row.forEach { key ->
+                        row.forEachIndexed { j, key ->
                             Column {
                                 KeyboardKey(
                                     key = key,
@@ -419,6 +443,12 @@ fun KeyboardScreen(
                                     },
                                     onSwitchLanguage = onSwitchLanguage,
                                     onSwitchPosition = onSwitchPosition,
+                                    secondaryKey = secondaryKeyboard?.arr?.getOrNull(i)?.getOrNull(j),
+                                    tertiaryKey = tertiaryKeyboard?.arr?.getOrNull(i)?.getOrNull(j),
+                                    dragReturnEnabled = dragReturnEnabled,
+                                    circularDragEnabled = circularDragEnabled,
+                                    clockwiseDragAction = clockwiseDragAction,
+                                    counterclockwiseDragAction = counterclockwiseDragAction,
                                 )
                             }
                         }

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
@@ -103,22 +103,12 @@ fun KeyboardScreen(
                 ?: DEFAULT_KEYBOARD_LAYOUT,
         ].keyboardDefinition
 
-    val (keyboard, secondaryKeyboard, tertiaryKeyboard) =
+    val keyboard =
         when (mode) {
-            KeyboardMode.MAIN ->
-                Triple(
-                    keyboardDefinition.modes.main,
-                    keyboardDefinition.modes.shifted,
-                    keyboardDefinition.modes.numeric,
-                )
-            KeyboardMode.SHIFTED ->
-                Triple(
-                    keyboardDefinition.modes.shifted,
-                    keyboardDefinition.modes.main,
-                    keyboardDefinition.modes.numeric,
-                )
-            KeyboardMode.NUMERIC -> Triple(keyboardDefinition.modes.numeric, null, null)
-            else -> Triple(KB_EN_THUMBKEY_MAIN, null, null)
+            KeyboardMode.MAIN -> keyboardDefinition.modes.main
+            KeyboardMode.SHIFTED -> keyboardDefinition.modes.shifted
+            KeyboardMode.NUMERIC -> keyboardDefinition.modes.numeric
+            else -> KB_EN_THUMBKEY_MAIN
         }
 
     val alignment =
@@ -443,8 +433,17 @@ fun KeyboardScreen(
                                     },
                                     onSwitchLanguage = onSwitchLanguage,
                                     onSwitchPosition = onSwitchPosition,
-                                    secondaryKey = secondaryKeyboard?.arr?.getOrNull(i)?.getOrNull(j),
-                                    tertiaryKey = tertiaryKeyboard?.arr?.getOrNull(i)?.getOrNull(j),
+                                    oppositeCaseKey =
+                                        when (mode) {
+                                            KeyboardMode.MAIN -> keyboardDefinition.modes.shifted
+                                            KeyboardMode.SHIFTED -> keyboardDefinition.modes.main
+                                            else -> null
+                                        }?.arr?.get(i)?.get(j),
+                                    numericKey =
+                                        when (mode) {
+                                            KeyboardMode.MAIN, KeyboardMode.SHIFTED -> keyboardDefinition.modes.numeric.arr[i][j]
+                                            else -> null
+                                        },
                                     dragReturnEnabled = dragReturnEnabled,
                                     circularDragEnabled = circularDragEnabled,
                                     clockwiseDragAction = clockwiseDragAction,

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/SettingsActivity.kt
@@ -42,6 +42,10 @@ import com.dessalines.thumbkey.db.DEFAULT_ANIMATION_HELPER_SPEED
 import com.dessalines.thumbkey.db.DEFAULT_ANIMATION_SPEED
 import com.dessalines.thumbkey.db.DEFAULT_AUTO_CAPITALIZE
 import com.dessalines.thumbkey.db.DEFAULT_BACKDROP_ENABLED
+import com.dessalines.thumbkey.db.DEFAULT_CIRCULAR_DRAG_ENABLED
+import com.dessalines.thumbkey.db.DEFAULT_CLOCKWISE_DRAG_ACTION
+import com.dessalines.thumbkey.db.DEFAULT_COUNTERCLOCKWISE_DRAG_ACTION
+import com.dessalines.thumbkey.db.DEFAULT_DRAG_RETURN_ENABLED
 import com.dessalines.thumbkey.db.DEFAULT_HIDE_LETTERS
 import com.dessalines.thumbkey.db.DEFAULT_HIDE_SYMBOLS
 import com.dessalines.thumbkey.db.DEFAULT_KEYBOARD_LAYOUT
@@ -298,6 +302,10 @@ private fun resetAppSettingsToDefault(appSettingsViewModel: AppSettingsViewModel
             keyPadding = DEFAULT_KEY_PADDING,
             keyBorderWidth = DEFAULT_KEY_BORDER_WIDTH,
             keyRadius = DEFAULT_KEY_RADIUS,
+            dragReturnEnabled = DEFAULT_DRAG_RETURN_ENABLED,
+            circularDragEnabled = DEFAULT_CIRCULAR_DRAG_ENABLED,
+            clockwiseDragAction = DEFAULT_CLOCKWISE_DRAG_ACTION,
+            counterclockwiseDragAction = DEFAULT_COUNTERCLOCKWISE_DRAG_ACTION,
         ),
     )
 }

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/behavior/BehaviorActivity.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/behavior/BehaviorActivity.kt
@@ -9,10 +9,14 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.Backspace
+import androidx.compose.material.icons.automirrored.outlined.RotateLeft
+import androidx.compose.material.icons.automirrored.outlined.RotateRight
 import androidx.compose.material.icons.outlined.Abc
+import androidx.compose.material.icons.outlined.Circle
 import androidx.compose.material.icons.outlined.SpaceBar
 import androidx.compose.material.icons.outlined.SwapHoriz
 import androidx.compose.material.icons.outlined.Swipe
+import androidx.compose.material.icons.outlined.UTurnRight
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -35,6 +39,10 @@ import com.dessalines.thumbkey.R
 import com.dessalines.thumbkey.db.AppSettingsViewModel
 import com.dessalines.thumbkey.db.BehaviorUpdate
 import com.dessalines.thumbkey.db.DEFAULT_AUTO_CAPITALIZE
+import com.dessalines.thumbkey.db.DEFAULT_CIRCULAR_DRAG_ENABLED
+import com.dessalines.thumbkey.db.DEFAULT_CLOCKWISE_DRAG_ACTION
+import com.dessalines.thumbkey.db.DEFAULT_COUNTERCLOCKWISE_DRAG_ACTION
+import com.dessalines.thumbkey.db.DEFAULT_DRAG_RETURN_ENABLED
 import com.dessalines.thumbkey.db.DEFAULT_MIN_SWIPE_LENGTH
 import com.dessalines.thumbkey.db.DEFAULT_SLIDE_BACKSPACE_DEADZONE_ENABLED
 import com.dessalines.thumbkey.db.DEFAULT_SLIDE_CURSOR_MOVEMENT_MODE
@@ -44,6 +52,7 @@ import com.dessalines.thumbkey.db.DEFAULT_SLIDE_SPACEBAR_DEADZONE_ENABLED
 import com.dessalines.thumbkey.db.DEFAULT_SPACEBAR_MULTITAPS
 import com.dessalines.thumbkey.ui.components.common.TestOutTextField
 import com.dessalines.thumbkey.ui.components.settings.about.SettingsDivider
+import com.dessalines.thumbkey.utils.CircularDragAction
 import com.dessalines.thumbkey.utils.CursorAccelerationMode
 import com.dessalines.thumbkey.utils.SimpleTopAppBar
 import com.dessalines.thumbkey.utils.TAG
@@ -80,6 +89,12 @@ fun BehaviorActivity(
     var autoCapitalizeState = (settings?.autoCapitalize ?: DEFAULT_AUTO_CAPITALIZE).toBool()
     var spacebarMultiTapsState = (settings?.spacebarMultiTaps ?: DEFAULT_SPACEBAR_MULTITAPS).toBool()
 
+    var dragReturnEnabledState = (settings?.dragReturnEnabled ?: DEFAULT_DRAG_RETURN_ENABLED).toBool()
+    var circularDragEnabledState = (settings?.circularDragEnabled ?: DEFAULT_CIRCULAR_DRAG_ENABLED).toBool()
+    var clockwiseDragActionState = CircularDragAction.entries[settings?.clockwiseDragAction ?: DEFAULT_CLOCKWISE_DRAG_ACTION]
+    var counterclockwiseDragActionState =
+        CircularDragAction.entries[settings?.counterclockwiseDragAction ?: DEFAULT_COUNTERCLOCKWISE_DRAG_ACTION]
+
     val snackbarHostState = remember { SnackbarHostState() }
 
     val scrollState = rememberScrollState()
@@ -98,6 +113,10 @@ fun BehaviorActivity(
                 slideBackspaceDeadzoneEnabled = slideBackspaceDeadzoneEnabledState.toInt(),
                 autoCapitalize = autoCapitalizeState.toInt(),
                 spacebarMultiTaps = spacebarMultiTapsState.toInt(),
+                dragReturnEnabled = dragReturnEnabledState.toInt(),
+                circularDragEnabled = circularDragEnabledState.toInt(),
+                clockwiseDragAction = clockwiseDragActionState.ordinal,
+                counterclockwiseDragAction = counterclockwiseDragActionState.ordinal,
             ),
         )
     }
@@ -275,6 +294,89 @@ fun BehaviorActivity(
                             Icon(
                                 imageVector = Icons.AutoMirrored.Outlined.Backspace,
                                 contentDescription = stringResource(R.string.slide_backspace_deadzone_enable),
+                            )
+                        },
+                    )
+                    SettingsDivider()
+                    SwitchPreference(
+                        value = dragReturnEnabledState,
+                        onValueChange = {
+                            dragReturnEnabledState = it
+                            updateBehavior()
+                        },
+                        title = {
+                            Text(stringResource(R.string.drag_return_enable))
+                        },
+                        icon = {
+                            Icon(
+                                imageVector = Icons.Outlined.UTurnRight,
+                                contentDescription = stringResource(R.string.drag_return_enable),
+                            )
+                        },
+                    )
+                    SwitchPreference(
+                        value = circularDragEnabledState,
+                        onValueChange = {
+                            circularDragEnabledState = it
+                            updateBehavior()
+                        },
+                        title = {
+                            Text(stringResource(R.string.circular_drag_enable))
+                        },
+                        icon = {
+                            Icon(
+                                imageVector = Icons.Outlined.Circle,
+                                contentDescription = stringResource(R.string.circular_drag_enable),
+                            )
+                        },
+                    )
+                    ListPreference(
+                        enabled = circularDragEnabledState,
+                        type = ListPreferenceType.DROPDOWN_MENU,
+                        value = clockwiseDragActionState,
+                        onValueChange = {
+                            clockwiseDragActionState = it
+                            updateBehavior()
+                        },
+                        values = CircularDragAction.entries,
+                        valueToText = {
+                            AnnotatedString(ctx.getString(it.resId))
+                        },
+                        title = {
+                            Text(stringResource(R.string.clockwise_drag_action))
+                        },
+                        summary = {
+                            Text(stringResource(clockwiseDragActionState.resId))
+                        },
+                        icon = {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Outlined.RotateRight,
+                                contentDescription = stringResource(R.string.clockwise_drag_action),
+                            )
+                        },
+                    )
+                    ListPreference(
+                        enabled = circularDragEnabledState,
+                        type = ListPreferenceType.DROPDOWN_MENU,
+                        value = counterclockwiseDragActionState,
+                        onValueChange = {
+                            counterclockwiseDragActionState = it
+                            updateBehavior()
+                        },
+                        values = CircularDragAction.entries,
+                        valueToText = {
+                            AnnotatedString(ctx.getString(it.resId))
+                        },
+                        title = {
+                            Text(stringResource(R.string.counterclockwise_drag_action))
+                        },
+                        summary = {
+                            Text(stringResource(counterclockwiseDragActionState.resId))
+                        },
+                        icon = {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Outlined.RotateLeft,
+                                contentDescription = stringResource(R.string.counterclockwise_drag_action),
                             )
                         },
                     )

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
@@ -224,3 +224,15 @@ data class Selection(
         end += index
     }
 }
+
+enum class CircularDirection {
+    Clockwise,
+    Counterclockwise,
+}
+
+enum class CircularDragAction(
+    @StringRes val resId: Int,
+) {
+    OppositeCase(R.string.send_oppsite_case),
+    Numeric(R.string.send_numeric),
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,7 +84,7 @@
     <string name="drag_return_enable">Drag-and-Return</string>
     <string name="counterclockwise_drag_action">Counterclockwise drag action</string>
     <string name="clockwise_drag_action">Clockwise drag action</string>
-    <string name="send_oppsite_case">Send letter of opposite case</string>
-    <string name="send_numeric">Send equivalent number of numeric keyboard</string>
+    <string name="send_oppsite_case">Opposite case letter</string>
+    <string name="send_numeric">Number key</string>
     <string name="circular_drag_enable">Circular drag</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,8 +82,8 @@
     <string name="key_border_width">Key Border Width: %1$s</string>
     <string name="key_radius">Key Radius: %1$s</string>
     <string name="drag_return_enable">Drag-and-Return</string>
-    <string name="counterclockwise_drag_action">Counterclockwise circular drag</string>
-    <string name="clockwise_drag_action">Clockwise circular drag</string>
+    <string name="counterclockwise_drag_action">Counterclockwise drag action</string>
+    <string name="clockwise_drag_action">Clockwise drag action</string>
     <string name="send_oppsite_case">Send letter of opposite case</string>
     <string name="send_numeric">Send equivalent number of numeric keyboard</string>
     <string name="circular_drag_enable">Circular drag</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -81,4 +81,10 @@
     <string name="key_padding">Key Padding: %1$s</string>
     <string name="key_border_width">Key Border Width: %1$s</string>
     <string name="key_radius">Key Radius: %1$s</string>
+    <string name="drag_return_enable">Drag-and-Return</string>
+    <string name="counterclockwise_drag_action">Counterclockwise circular drag</string>
+    <string name="clockwise_drag_action">Clockwise circular drag</string>
+    <string name="send_oppsite_case">Send letter of opposite case</string>
+    <string name="send_numeric">Send equivalent number of numeric keyboard</string>
+    <string name="circular_drag_enable">Circular drag</string>
 </resources>


### PR DESCRIPTION
This implements drag-and-return and circular drag functions inspired by MessagEase.
These functions were essential to my workflow before I switched to thumb-key, so I figured I'd reimplement them here.

I'm sure some parts of the code could be improved, and I don't really like the implementation detail of having to pass the additional keys of the other keyboard layers to each key (as `secondaryKey` and `tertiaryKey`), but this seems like the easiest implementation with regard to the current architecture of thumb-key.

### Drag-and-Return

![thumb-key-drag-return](https://github.com/dessalines/thumb-key/assets/53912746/b4cf8040-0007-406e-8a85-159ccab2641c)

Lets you drag in direction of one the edges/corners of a key and back to the center in order to send the key on that edge/corner in the opposite case, so uppercase if the keyboard is currently lowercase, or lowercase if the keyboard is currently uppercase.
Note that this technically just switches between the `main` and `shifted` keyboard layout, so it will just send whatever is at the corresponding position of the equivalent keyboard.

### Circular drag

![thumb-key-circular-drag](https://github.com/dessalines/thumb-key/assets/53912746/9797fc0d-3ae2-47f9-8c21-3dda74c75459)

Lets you drag in a circle starting and ending on the same key in order to send either the center key in the opposite case (`main` vs `shifted` layout), or send the number at the corresponding position of the key (`numeric` layout).

The circle detection code is completely improvised and could probably use some improvements, but in my testing, both drag-and-returns and circular drags were detected almost flawlessly.