### PR TITLE
Fix crash when using Japanese thumb-key (fixes #858)

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
@@ -438,10 +438,12 @@ fun KeyboardScreen(
                                             KeyboardMode.MAIN -> keyboardDefinition.modes.shifted
                                             KeyboardMode.SHIFTED -> keyboardDefinition.modes.main
                                             else -> null
-                                        }?.arr?.get(i)?.get(j),
+                                        }?.arr?.getOrNull(i)?.getOrNull(j),
                                     numericKey =
                                         when (mode) {
-                                            KeyboardMode.MAIN, KeyboardMode.SHIFTED -> keyboardDefinition.modes.numeric.arr[i][j]
+                                            KeyboardMode.MAIN, KeyboardMode.SHIFTED ->
+                                                keyboardDefinition.modes.numeric.arr
+                                                    .getOrNull(i)?.getOrNull(j)
                                             else -> null
                                         },
                                     dragReturnEnabled = dragReturnEnabled,


### PR DESCRIPTION
The bug was introduced in commit 0ab4b98 (Implement Drag-and-return & Circular drag (#854)). It was caused by an assumption that the numeric mode of a layout would have at least a one-to-one relation to its main or shifted modes. In this case, the Japanese main/shifted modes have more keys than the numeric mode, which caused an index error.