### PR TITLE
Updated numeric keyboard for "italiano messagease"

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ITMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ITMessagEase.kt
@@ -585,6 +585,6 @@ val KB_IT_MESSAGEASE: KeyboardDefinition =
             KeyboardDefinitionModes(
                 main = KB_IT_MESSAGEASE_MAIN,
                 shifted = KB_IT_MESSAGEASE_SHIFTED,
-                numeric = NUMERIC_KEYBOARD,
+                numeric = KB_EN_MESSAGEASE_NUMERIC,
             ),
     )


### PR DESCRIPTION
It makes more sense for "italiano messagease" keyboard to have the numeric keyboard set with KB_EN_MESSAGEASE_NUMERIC as all symbols are correctly aligned between the main keyboard and the numeric one