### PR TITLE
Make circle threshold configurable

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/db/AppDb.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/db/AppDb.kt
@@ -56,6 +56,7 @@ const val DEFAULT_DRAG_RETURN_ENABLED = 1
 const val DEFAULT_CIRCULAR_DRAG_ENABLED = 1
 const val DEFAULT_CLOCKWISE_DRAG_ACTION = 0
 const val DEFAULT_COUNTERCLOCKWISE_DRAG_ACTION = 1
+const val DEFAULT_CIRCLE_THRESHOLD = 75
 
 @Entity
 data class AppSettings(
@@ -226,6 +227,11 @@ data class AppSettings(
         defaultValue = DEFAULT_COUNTERCLOCKWISE_DRAG_ACTION.toString(),
     )
     val counterclockwiseDragAction: Int,
+    @ColumnInfo(
+        name = "circle_threshold",
+        defaultValue = DEFAULT_CIRCLE_THRESHOLD.toString(),
+    )
+    val circleThreshold: Int,
 )
 
 data class LayoutsUpdate(
@@ -334,6 +340,8 @@ data class BehaviorUpdate(
     val clockwiseDragAction: Int,
     @ColumnInfo(name = "counterclockwise_drag_action")
     val counterclockwiseDragAction: Int,
+    @ColumnInfo(name = "circle_threshold")
+    val circleThreshold: Int,
 )
 
 @Dao
@@ -559,8 +567,17 @@ val MIGRATION_14_15 =
         }
     }
 
+val MIGRATION_15_16 =
+    object : Migration(15, 16) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL(
+                "alter table AppSettings add column circle_threshold INTEGER NOT NULL default $DEFAULT_CIRCLE_THRESHOLD",
+            )
+        }
+    }
+
 @Database(
-    version = 15,
+    version = 16,
     entities = [AppSettings::class],
     exportSchema = true,
 )
@@ -597,6 +614,7 @@ abstract class AppDB : RoomDatabase() {
                             MIGRATION_12_13,
                             MIGRATION_13_14,
                             MIGRATION_14_15,
+                            MIGRATION_15_16,
                         )
                         // Necessary because it can't insert data on creation
                         .addCallback(

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
@@ -116,6 +116,7 @@ fun KeyboardKey(
     circularDragEnabled: Boolean,
     clockwiseDragAction: CircularDragAction,
     counterclockwiseDragAction: CircularDragAction,
+    circleThreshold: Float,
 ) {
     // Necessary for swipe settings to get updated correctly
     val id =
@@ -282,7 +283,7 @@ fun KeyboardKey(
                         // Backspace key:
                         //      Swipe left and right to delete whole word
                         //      Slide gesture delete
-                        //          Wtih slide gesture deadzone to allow normal swipes
+                        //          With slide gesture deadzone to allow normal swipes
                         //          Without deadzone
                         if (key.slideType == SlideType.MOVE_CURSOR && slideEnabled) {
                             val slideSelectionOffsetTrigger = (keySize.dp.toPx() * 1.25) + minSwipeLength
@@ -439,7 +440,7 @@ fun KeyboardKey(
                                                         CircularDragAction.OppositeCase to oppositeCaseKey?.center?.action,
                                                         CircularDragAction.Numeric to numericKey?.center?.action,
                                                     )
-                                                circularDirection(positions, keySize)?.let {
+                                                circularDirection(positions, circleThreshold)?.let {
                                                     when (it) {
                                                         CircularDirection.Clockwise -> circularDragActions[clockwiseDragAction]
                                                         CircularDirection.Counterclockwise ->

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
@@ -35,6 +35,7 @@ import com.dessalines.thumbkey.db.DEFAULT_ANIMATION_HELPER_SPEED
 import com.dessalines.thumbkey.db.DEFAULT_ANIMATION_SPEED
 import com.dessalines.thumbkey.db.DEFAULT_AUTO_CAPITALIZE
 import com.dessalines.thumbkey.db.DEFAULT_BACKDROP_ENABLED
+import com.dessalines.thumbkey.db.DEFAULT_CIRCLE_THRESHOLD
 import com.dessalines.thumbkey.db.DEFAULT_CIRCULAR_DRAG_ENABLED
 import com.dessalines.thumbkey.db.DEFAULT_CLOCKWISE_DRAG_ACTION
 import com.dessalines.thumbkey.db.DEFAULT_COUNTERCLOCKWISE_DRAG_ACTION
@@ -143,6 +144,7 @@ fun KeyboardScreen(
     val clockwiseDragAction = CircularDragAction.entries[settings?.clockwiseDragAction ?: DEFAULT_CLOCKWISE_DRAG_ACTION]
     val counterclockwiseDragAction =
         CircularDragAction.entries[settings?.counterclockwiseDragAction ?: DEFAULT_COUNTERCLOCKWISE_DRAG_ACTION]
+    val circleThreshold = (settings?.circleThreshold ?: DEFAULT_CIRCLE_THRESHOLD).toFloat()
 
     val keyBorderWidthFloat = keyBorderWidth / 10.0f
     val keyBorderColour = MaterialTheme.colorScheme.outline
@@ -313,6 +315,7 @@ fun KeyboardScreen(
                                 circularDragEnabled = circularDragEnabled,
                                 clockwiseDragAction = clockwiseDragAction,
                                 counterclockwiseDragAction = counterclockwiseDragAction,
+                                circleThreshold = circleThreshold,
                             )
                         }
                     }
@@ -450,6 +453,7 @@ fun KeyboardScreen(
                                     circularDragEnabled = circularDragEnabled,
                                     clockwiseDragAction = clockwiseDragAction,
                                     counterclockwiseDragAction = counterclockwiseDragAction,
+                                    circleThreshold = circleThreshold,
                                 )
                             }
                         }

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/SettingsActivity.kt
@@ -42,6 +42,7 @@ import com.dessalines.thumbkey.db.DEFAULT_ANIMATION_HELPER_SPEED
 import com.dessalines.thumbkey.db.DEFAULT_ANIMATION_SPEED
 import com.dessalines.thumbkey.db.DEFAULT_AUTO_CAPITALIZE
 import com.dessalines.thumbkey.db.DEFAULT_BACKDROP_ENABLED
+import com.dessalines.thumbkey.db.DEFAULT_CIRCLE_THRESHOLD
 import com.dessalines.thumbkey.db.DEFAULT_CIRCULAR_DRAG_ENABLED
 import com.dessalines.thumbkey.db.DEFAULT_CLOCKWISE_DRAG_ACTION
 import com.dessalines.thumbkey.db.DEFAULT_COUNTERCLOCKWISE_DRAG_ACTION
@@ -306,6 +307,7 @@ private fun resetAppSettingsToDefault(appSettingsViewModel: AppSettingsViewModel
             circularDragEnabled = DEFAULT_CIRCULAR_DRAG_ENABLED,
             clockwiseDragAction = DEFAULT_CLOCKWISE_DRAG_ACTION,
             counterclockwiseDragAction = DEFAULT_COUNTERCLOCKWISE_DRAG_ACTION,
+            circleThreshold = DEFAULT_CIRCLE_THRESHOLD,
         ),
     )
 }

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/behavior/BehaviorActivity.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/behavior/BehaviorActivity.kt
@@ -39,6 +39,7 @@ import com.dessalines.thumbkey.R
 import com.dessalines.thumbkey.db.AppSettingsViewModel
 import com.dessalines.thumbkey.db.BehaviorUpdate
 import com.dessalines.thumbkey.db.DEFAULT_AUTO_CAPITALIZE
+import com.dessalines.thumbkey.db.DEFAULT_CIRCLE_THRESHOLD
 import com.dessalines.thumbkey.db.DEFAULT_CIRCULAR_DRAG_ENABLED
 import com.dessalines.thumbkey.db.DEFAULT_CLOCKWISE_DRAG_ACTION
 import com.dessalines.thumbkey.db.DEFAULT_COUNTERCLOCKWISE_DRAG_ACTION
@@ -95,6 +96,9 @@ fun BehaviorActivity(
     var counterclockwiseDragActionState =
         CircularDragAction.entries[settings?.counterclockwiseDragAction ?: DEFAULT_COUNTERCLOCKWISE_DRAG_ACTION]
 
+    var circleThresholdState = (settings?.circleThreshold ?: DEFAULT_CIRCLE_THRESHOLD).toFloat()
+    var circleThresholdSliderState by remember { mutableFloatStateOf(circleThresholdState) }
+
     val snackbarHostState = remember { SnackbarHostState() }
 
     val scrollState = rememberScrollState()
@@ -117,6 +121,7 @@ fun BehaviorActivity(
                 circularDragEnabled = circularDragEnabledState.toInt(),
                 clockwiseDragAction = clockwiseDragActionState.ordinal,
                 counterclockwiseDragAction = counterclockwiseDragActionState.ordinal,
+                circleThreshold = circleThresholdState.toInt(),
             ),
         )
     }
@@ -377,6 +382,33 @@ fun BehaviorActivity(
                             Icon(
                                 imageVector = Icons.AutoMirrored.Outlined.RotateLeft,
                                 contentDescription = stringResource(R.string.counterclockwise_drag_action),
+                            )
+                        },
+                    )
+                    SliderPreference(
+                        value = circleThresholdState,
+                        sliderValue = circleThresholdSliderState,
+                        onValueChange = {
+                            circleThresholdState = it
+                            updateBehavior()
+                        },
+                        onSliderValueChange = { circleThresholdSliderState = it },
+                        valueRange = 50f..300f,
+                        title = {
+                            Text(
+                                stringResource(
+                                    R.string.circle_threshold,
+                                    circleThresholdSliderState.toInt().toString(),
+                                ),
+                            )
+                        },
+                        summary = {
+                            Text(stringResource(R.string.circle_threshold_summary))
+                        },
+                        icon = {
+                            Icon(
+                                imageVector = Icons.Outlined.Circle,
+                                contentDescription = null,
                             )
                         },
                     )

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -1193,12 +1193,15 @@ fun lastColKeysToFirst(board: KeyboardC): KeyboardC {
 
 fun circularDirection(
     positions: List<Offset>,
-    keySize: Double,
+    threshold: Float,
 ): CircularDirection? {
     val center = positions.reduce(Offset::plus) / positions.count().toFloat()
     val radii = positions.map { it.getDistanceTo(center) }
     val averageRadius = radii.sum() / positions.count().toFloat()
-    val similarRadii = radii.all { it in (averageRadius - keySize)..(averageRadius + keySize) }
+    val similarRadii =
+        radii.all {
+            it in (averageRadius * (1 - (threshold / 100f))..(averageRadius * (1 + (threshold / 100f))))
+        }
     if (!similarRadii) return null
     val angleDifferences =
         positions
@@ -1215,7 +1218,7 @@ fun circularDirection(
                 }
             }
     val rotationSum = angleDifferences.sum()
-    val sumThreshold = angleDifferences.count().toDouble() * 0.9
+    val sumThreshold = angleDifferences.count().toDouble() * 0.8
     return when {
         rotationSum >= sumThreshold -> CircularDirection.Clockwise
         rotationSum <= -sumThreshold -> CircularDirection.Counterclockwise

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,4 +87,6 @@
     <string name="send_oppsite_case">Opposite case letter</string>
     <string name="send_numeric">Number key</string>
     <string name="circular_drag_enable">Circular drag</string>
+    <string name="circle_threshold">Circle Threshold: +%1$s%%</string>
+    <string name="circle_threshold_summary">Threshold to detect gestures as circlular drag instead of drag-and-return</string>
 </resources>


### PR DESCRIPTION
This makes the threshold of detecting circles vs drag-and-return gestures configurable.

I'm not completely happy with the wording of the settings (English isn't my native language), so suggestions for that are welcome.
I'm also unsure if other aspects of the gesture system should be configurable as well, but I think this setting was the most important one.