### PR TITLE
Fixes and improvements in br-fr layout

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/BRFRThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/BRFRThumbKey.kt
@@ -111,6 +111,12 @@ val KB_BR_FR_THUMBKEY_MAIN =
                         ),
                     swipes =
                         mapOf(
+                            SwipeDirection.TOP_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("ꝃ"),
+                                    action = KeyAction.CommitText("ꝃ"),
+                                    color = ColorVariant.MUTED,
+                                ),
                             SwipeDirection.TOP to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("ï"),
@@ -127,11 +133,6 @@ val KB_BR_FR_THUMBKEY_MAIN =
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("k"),
                                     action = KeyAction.CommitText("k"),
-                                ),
-                            SwipeDirection.BOTTOM to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("ꝃ"),
-                                    action = KeyAction.CommitText("ꝃ"),
                                 ),
                             SwipeDirection.BOTTOM_LEFT to
                                 KeyC(
@@ -493,6 +494,12 @@ val KB_BR_FR_THUMBKEY_SHIFTED =
                         ),
                     swipes =
                         mapOf(
+                            SwipeDirection.TOP_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("Ꝃ"),
+                                    action = KeyAction.CommitText("Ꝃ"),
+                                    color = ColorVariant.MUTED,
+                                ),
                             SwipeDirection.TOP to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("Ï"),
@@ -509,12 +516,6 @@ val KB_BR_FR_THUMBKEY_SHIFTED =
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("K"),
                                     action = KeyAction.CommitText("K"),
-                                ),
-                            SwipeDirection.BOTTOM to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("Ꝃ"),
-                                    action = KeyAction.CommitText("Ꝃ"),
-                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.BOTTOM_LEFT to
                                 KeyC(
@@ -716,6 +717,11 @@ val KB_BR_FR_THUMBKEY_SHIFTED =
                                     display = KeyDisplay.TextDisplay(","),
                                     action = KeyAction.CommitText(","),
                                     color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("Z"),
+                                    action = KeyAction.CommitText("Z"),
                                 ),
                         ),
                 ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/BRFRThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/BRFRThumbKey.kt
@@ -58,6 +58,12 @@ val KB_BR_FR_THUMBKEY_MAIN =
                                     display = KeyDisplay.TextDisplay("q"),
                                     action = KeyAction.CommitText("q"),
                                 ),
+                            SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("-"),
+                                    action = KeyAction.CommitText("-"),
+                                    color = ColorVariant.MUTED,
+                                ),
                             SwipeDirection.LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("\""),
@@ -278,6 +284,12 @@ val KB_BR_FR_THUMBKEY_MAIN =
                                     display = KeyDisplay.TextDisplay("m"),
                                     action = KeyAction.CommitText("m"),
                                 ),
+                            SwipeDirection.BOTTOM_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("!"),
+                                    action = KeyAction.CommitText("!"),
+                                    color = ColorVariant.MUTED,
+                                ),
                         ),
                 ),
                 KeyItemC(
@@ -440,6 +452,12 @@ val KB_BR_FR_THUMBKEY_SHIFTED =
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("Q"),
                                     action = KeyAction.CommitText("Q"),
+                                ),
+                            SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("-"),
+                                    action = KeyAction.CommitText("-"),
+                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.LEFT to
                                 KeyC(
@@ -666,6 +684,12 @@ val KB_BR_FR_THUMBKEY_SHIFTED =
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("M"),
                                     action = KeyAction.CommitText("M"),
+                                ),
+                            SwipeDirection.BOTTOM_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("!"),
+                                    action = KeyAction.CommitText("!"),
+                                    color = ColorVariant.MUTED,
                                 ),
                         ),
                 ),


### PR DESCRIPTION
Small improvements and fixes:
- Z was missing
- Ꝃ was muted but ꝃ was not. Both are now muted
- Ꝃ and ꝃ were too easily reachable even though they're not so useful. They were moved elsewhere
- "-" and "!" were added in the main view because we need them quite often IMO (especially the "-")