### PR TITLE
Improves symbols in main DEThumbKey keyboard.

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbKey.kt
@@ -480,6 +480,12 @@ val KB_DE_THUMBKEY_SHIFTED =
                     swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
                     swipes =
                         mapOf(
+                            SwipeDirection.BOTTOM_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay(":"),
+                                    action = KeyAction.CommitText(":"),
+                                    color = ColorVariant.MUTED,
+                                ),
                             SwipeDirection.TOP_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("G"),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbKey.kt
@@ -49,6 +49,12 @@ val KB_DE_THUMBKEY_MAIN =
                     swipeType = SwipeNWay.TWO_WAY_VERTICAL,
                     swipes =
                         mapOf(
+                            SwipeDirection.RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("!"),
+                                    action = KeyAction.CommitText("!"),
+                                    color = ColorVariant.MUTED,
+                                ),
                             SwipeDirection.BOTTOM to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("f"),
@@ -329,6 +335,12 @@ val KB_DE_THUMBKEY_SHIFTED =
                     swipeType = SwipeNWay.TWO_WAY_VERTICAL,
                     swipes =
                         mapOf(
+                            SwipeDirection.RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("!"),
+                                    action = KeyAction.CommitText("!"),
+                                    color = ColorVariant.MUTED,
+                                ),
                             SwipeDirection.BOTTOM to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("F"),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbKey.kt
@@ -72,6 +72,12 @@ val KB_DE_THUMBKEY_MAIN =
                         ),
                     swipes =
                         mapOf(
+                            SwipeDirection.LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("?"),
+                                    action = KeyAction.CommitText("?"),
+                                    color = ColorVariant.MUTED,
+                                ),
                             SwipeDirection.BOTTOM_LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("l"),
@@ -358,6 +364,12 @@ val KB_DE_THUMBKEY_SHIFTED =
                         ),
                     swipes =
                         mapOf(
+                            SwipeDirection.LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("?"),
+                                    action = KeyAction.CommitText("?"),
+                                    color = ColorVariant.MUTED,
+                                ),
                             SwipeDirection.BOTTOM_LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("L"),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbKey.kt
@@ -203,6 +203,7 @@ val KB_DE_THUMBKEY_MAIN =
                                 KeyC(
                                     display = KeyDisplay.TextDisplay(":"),
                                     action = KeyAction.CommitText(":"),
+                                    color = ColorVariant.MUTED,
                                 ),
                         ),
                 ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbKey.kt
@@ -503,6 +503,12 @@ val KB_DE_THUMBKEY_SHIFTED =
                         ),
                     swipes =
                         mapOf(
+                            SwipeDirection.TOP_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("\""),
+                                    action = KeyAction.CommitText("\""),
+                                    color = ColorVariant.MUTED,
+                                ),
                             SwipeDirection.TOP to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("B"),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbKey.kt
@@ -221,6 +221,7 @@ val KB_DE_THUMBKEY_MAIN =
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("\""),
                                     action = KeyAction.CommitText("\""),
+                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.TOP to
                                 KeyC(


### PR DESCRIPTION
PR #886 added the symbols `:` and `"` to the `DEThumbKey` keyboard. This PR changes their colours to `MUTED` and also adds these symbols to the capital letters.

In addition it adds the often used punctuations `!` and `?` to the main keyboard.