### PR TITLE
Tweak circular drag detection algorithm (fixes #894)

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
@@ -430,9 +430,10 @@ fun KeyboardKey(
                         ) {
                             hasSlideMoveCursorTriggered = false
 
+                            val finalOffsetThreshold = keySize.dp.toPx() * 0.6f // magic number found from trial and error
                             val finalOffset = positions.last()
-                            val maxOffsetBigEnough = maxOffset.getDistanceSquared() >= (finalOffset * 2f).getDistanceSquared()
-                            val finalOffsetSmallEnough = finalOffset.getDistance() <= keySize.dp.toPx() / 2
+                            val maxOffsetBigEnough = maxOffset.getDistance() >= 2 * finalOffsetThreshold
+                            val finalOffsetSmallEnough = finalOffset.getDistance() <= finalOffsetThreshold
                             action =
                                 (
                                     if (maxOffsetBigEnough && finalOffsetSmallEnough) {


### PR DESCRIPTION
This makes the algorithm for calculating circular drag less strict by:
- Making the direction calculation more straightforward
- Which in turn adds a larger margin for gesture imperfections