### PR TITLE
Fix #304 (take two): In Utils.autoCapitalizeCheck, use input type of current editor

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/common/TextFields.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/common/TextFields.kt
@@ -1,6 +1,7 @@
 package com.dessalines.thumbkey.ui.components.common
 
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
@@ -12,6 +13,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import com.dessalines.thumbkey.R
 
 @Composable
@@ -32,5 +34,6 @@ fun TestOutTextField() {
                 focusedIndicatorColor = Color.Transparent,
                 unfocusedIndicatorColor = Color.Transparent,
             ),
+        keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Sentences),
     )
 }

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -10,7 +10,6 @@ import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.text.InputType
-import android.text.TextUtils
 import android.util.Log
 import android.view.KeyEvent
 import android.view.inputmethod.EditorInfo
@@ -1004,7 +1003,7 @@ private fun autoCapitalize(
 }
 
 fun autoCapitalizeCheck(ime: IMEService): Boolean {
-    return ime.currentInputConnection.getCursorCapsMode(TextUtils.CAP_MODE_SENTENCES) > 0
+    return ime.currentInputConnection.getCursorCapsMode(ime.currentInputEditorInfo.inputType) > 0
 }
 
 /**


### PR DESCRIPTION
I checked the [documentation](https://developer.android.com/reference/android/view/inputmethod/InputConnection#getCursorCapsMode(int)) again, and it says about `reqModes`:
> [...] you can simply pass the current [`TextBoxAttribute.contentType`](https://developer.android.com/reference/android/view/inputmethod/EditorInfo#inputType) value directly in to here.

I assume that `ime.currentInputEditorInfo.inputType` is what we're looking for, in that case 😄

To make sure that this can be tested in the `TestOutTextField`, I set it to auto-capitalize sentences.

Besides the test-out text field, I've tested this in these apps, and it looks like everything is as expected:
- The built-in Messages app (only auto-capitalizes sentences when the auto-capitalize behaviour setting in Thumb-key is enabled)
- The built-in Contacts app (only auto-capitalizes every word in a name when the setting is enabled)
- JuiceSSH (no auto-capitalization, regardless of the setting)
- Termux (no auto-capitalization, regardless of the setting)

Hopefully, this really fixes #304 :smile: