### PR TITLE
Optimization of the top row keys for QwertEase layout

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENQwertEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENQwertEase.kt
@@ -609,6 +609,6 @@ val KB_EN_QWERTEASE: KeyboardDefinition =
             KeyboardDefinitionModes(
                 main = KB_EN_QWERTEASE_MAIN,
                 shifted = KB_EN_QWERTEASE_SHIFTED,
-                numeric = KB_EN_QWERTEASE_NUMERIC,
+                numeric = KB_EN_MESSAGEASE_NUMERIC,
             ),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENQwertEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENQwertEase.kt
@@ -38,9 +38,13 @@ val KB_EN_QWERTEASE_MAIN =
                                 ),
                             SwipeDirection.RIGHT to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("-"),
-                                    action = KeyAction.CommitText("-"),
-                                    color = ColorVariant.MUTED,
+                                    display = KeyDisplay.TextDisplay("☆"),
+                                    action = KeyAction.CommitText("t"),
+                                ),
+                            SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("☆"),
+                                    action = KeyAction.CommitText("t"),
                                 ),
                         ),
                 ),
@@ -52,6 +56,7 @@ val KB_EN_QWERTEASE_MAIN =
                             size = FontSizeVariant.LARGE,
                             color = ColorVariant.PRIMARY,
                         ),
+                    swipeType = SwipeNWay.TWO_WAY_VERTICAL,
                     swipes =
                         mapOf(
                             SwipeDirection.BOTTOM to
@@ -75,6 +80,22 @@ val KB_EN_QWERTEASE_MAIN =
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("y"),
                                     action = KeyAction.CommitText("y"),
+                                ),
+                                SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay(" "),
+                                    action = KeyAction.CommitText("y"),
+                                ),
+                                SwipeDirection.LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay(" "),
+                                    action = KeyAction.CommitText("y"),
+                                ),
+                                SwipeDirection.RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("-"),
+                                    action = KeyAction.CommitText("-"),
+                                    color = ColorVariant.MUTED,
                                 ),
                         ),
                 ),
@@ -306,9 +327,13 @@ val KB_EN_QWERTEASE_SHIFTED =
                                 ),
                             SwipeDirection.RIGHT to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("-"),
-                                    action = KeyAction.CommitText("-"),
-                                    color = ColorVariant.MUTED,
+                                    display = KeyDisplay.TextDisplay("★"),
+                                    action = KeyAction.CommitText("T"),
+                                ),
+                            SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("★"),
+                                    action = KeyAction.CommitText("T"),
                                 ),
                         ),
                 ),
@@ -320,6 +345,7 @@ val KB_EN_QWERTEASE_SHIFTED =
                             size = FontSizeVariant.LARGE,
                             color = ColorVariant.PRIMARY,
                         ),
+                    swipeType = SwipeNWay.TWO_WAY_VERTICAL,
                     swipes =
                         mapOf(
                             SwipeDirection.BOTTOM to
@@ -343,6 +369,22 @@ val KB_EN_QWERTEASE_SHIFTED =
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("Y"),
                                     action = KeyAction.CommitText("Y"),
+                                ),
+                            SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay(" "),
+                                    action = KeyAction.CommitText("Y"),
+                                ),
+                            SwipeDirection.LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay(" "),
+                                    action = KeyAction.CommitText("Y"),
+                                ),
+                            SwipeDirection.RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("-"),
+                                    action = KeyAction.CommitText("-"),
+                                    color = ColorVariant.MUTED,
                                 ),
                         ),
                 ),
@@ -567,6 +609,6 @@ val KB_EN_QWERTEASE: KeyboardDefinition =
             KeyboardDefinitionModes(
                 main = KB_EN_QWERTEASE_MAIN,
                 shifted = KB_EN_QWERTEASE_SHIFTED,
-                numeric = KB_EN_MESSAGEASE_NUMERIC,
+                numeric = KB_EN_QWERTEASE_NUMERIC,
             ),
     )


### PR DESCRIPTION
Added more swipe directions on top row keys for easier access especially the letter T. Added stars on it to make it obvious. ☆★

```
A   ★ |
★   T |
```