### PR TITLE
Make cursor movement detection index-based (fixes #881)

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/IMEService.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/IMEService.kt
@@ -57,7 +57,8 @@ class IMEService :
     // Lifecycle Methods
     private var lifecycleRegistry: LifecycleRegistry = LifecycleRegistry(this)
 
-    private fun handleLifecycleEvent(event: Lifecycle.Event) = lifecycleRegistry.handleLifecycleEvent(event)
+    private fun handleLifecycleEvent(event: Lifecycle.Event) =
+        lifecycleRegistry.handleLifecycleEvent(event)
 
     override val lifecycle = lifecycleRegistry
 
@@ -76,29 +77,32 @@ class IMEService :
     override fun onUpdateCursorAnchorInfo(cursorAnchorInfo: CursorAnchorInfo) {
         super.onUpdateCursorAnchorInfo(cursorAnchorInfo)
 
-        // If the cursor has moved at all vertically, or more than a small amount horizontally, the cursor has changed and multitap should be blocked.
-        // The horizontal buffer is because the cursor moves slightly based on the size of some of the characters (i.e '?') moving the cursor a little bit.
-        // It would be better to not use a magic number of 15, but I don't know what the ideal buffer is and it seems to work well, even when moving the cursor right before the multitap character
-        if (insertionMarkerBaseline != cursorAnchorInfo.insertionMarkerBaseline ||
-            abs(cursorAnchorInfo.insertionMarkerHorizontal - insertionMarkerHorizontal) > 15f
-        ) {
-            cursorMoved = true
-            insertionMarkerBaseline = cursorAnchorInfo.insertionMarkerBaseline
-            Log.d(TAG, "cursor moved")
+        cursorMoved = if (ignoreCursorMove) {
+            ignoreCursorMove = false
+            false
         } else {
-            cursorMoved = false
+            Log.d(TAG, "cursor moved")
+            cursorAnchorInfo.selectionStart != selectionStart
+                    || cursorAnchorInfo.selectionEnd != selectionEnd
         }
-        // Always update the horizontal position. This prevents the movement of the cursor by the first space tap blocking consecutive tap actions.
-        insertionMarkerHorizontal = cursorAnchorInfo.insertionMarkerHorizontal
+
+        selectionStart = cursorAnchorInfo.selectionStart
+        selectionEnd = cursorAnchorInfo.selectionEnd
     }
 
     fun didCursorMove(): Boolean {
         return cursorMoved
     }
 
+    fun ignoreNextCursorMove() {
+        // This gets reset on the next call to `onUpdateCursorAnchorInfo`
+        ignoreCursorMove = true
+    }
+
+    private var ignoreCursorMove: Boolean = false
     private var cursorMoved: Boolean = false
-    private var insertionMarkerBaseline: Float = 0f
-    private var insertionMarkerHorizontal: Float = 0f
+    private var selectionStart: Int = 0
+    private var selectionEnd: Int = 0
 
     // ViewModelStore Methods
     override val viewModelStore = ViewModelStore()
@@ -106,5 +110,6 @@ class IMEService :
     // SaveStateRegistry Methods
 
     private val savedStateRegistryController = SavedStateRegistryController.create(this)
-    override val savedStateRegistry: SavedStateRegistry = savedStateRegistryController.savedStateRegistry
+    override val savedStateRegistry: SavedStateRegistry =
+        savedStateRegistryController.savedStateRegistry
 }

--- a/app/src/main/java/com/dessalines/thumbkey/IMEService.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/IMEService.kt
@@ -17,7 +17,6 @@ import androidx.savedstate.SavedStateRegistryController
 import androidx.savedstate.SavedStateRegistryOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import com.dessalines.thumbkey.utils.TAG
-import kotlin.math.abs
 
 class IMEService :
     InputMethodService(),
@@ -57,8 +56,7 @@ class IMEService :
     // Lifecycle Methods
     private var lifecycleRegistry: LifecycleRegistry = LifecycleRegistry(this)
 
-    private fun handleLifecycleEvent(event: Lifecycle.Event) =
-        lifecycleRegistry.handleLifecycleEvent(event)
+    private fun handleLifecycleEvent(event: Lifecycle.Event) = lifecycleRegistry.handleLifecycleEvent(event)
 
     override val lifecycle = lifecycleRegistry
 
@@ -77,14 +75,15 @@ class IMEService :
     override fun onUpdateCursorAnchorInfo(cursorAnchorInfo: CursorAnchorInfo) {
         super.onUpdateCursorAnchorInfo(cursorAnchorInfo)
 
-        cursorMoved = if (ignoreCursorMove) {
-            ignoreCursorMove = false
-            false
-        } else {
-            Log.d(TAG, "cursor moved")
-            cursorAnchorInfo.selectionStart != selectionStart
-                    || cursorAnchorInfo.selectionEnd != selectionEnd
-        }
+        cursorMoved =
+            if (ignoreCursorMove) {
+                ignoreCursorMove = false
+                false
+            } else {
+                Log.d(TAG, "cursor moved")
+                cursorAnchorInfo.selectionStart != selectionStart ||
+                    cursorAnchorInfo.selectionEnd != selectionEnd
+            }
 
         selectionStart = cursorAnchorInfo.selectionStart
         selectionEnd = cursorAnchorInfo.selectionEnd

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -337,6 +337,7 @@ fun performKeyAction(
         is KeyAction.CommitText -> {
             val text = action.text
             Log.d(TAG, "committing key text: $text")
+            ime.ignoreNextCursorMove()
             ime.currentInputConnection.commitText(
                 text,
                 1,
@@ -373,6 +374,7 @@ fun performKeyAction(
             Log.d(TAG, "replacing last word")
             val text = action.text
 
+            ime.ignoreNextCursorMove()
             ime.currentInputConnection.deleteSurroundingText(action.trimCount, 0)
             ime.currentInputConnection.commitText(
                 text,


### PR DESCRIPTION
This adds a new function to the IMEService class which makes it ignore the next cursor movement. This function is called from certain parts in `performKeyAction` which would interfere with the cursor movement detection algorithm