### PR TITLE
Tweak circular drag and drag-and-return gestures (fixes #926)

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
@@ -430,10 +430,14 @@ fun KeyboardKey(
                         ) {
                             hasSlideMoveCursorTriggered = false
 
-                            val finalOffsetThreshold = keySize.dp.toPx() * 0.6f // magic number found from trial and error
+                            val finalOffsetThreshold = keySize.dp.toPx() * 0.71f // magic number found from trial and error
+                            val maxOffsetThreshold = 1.5 * finalOffsetThreshold
+
                             val finalOffset = positions.last()
-                            val maxOffsetBigEnough = maxOffset.getDistance() >= 2 * finalOffsetThreshold
                             val finalOffsetSmallEnough = finalOffset.getDistance() <= finalOffsetThreshold
+
+                            val maxOffsetDistance = maxOffset.getDistance().toDouble()
+                            val maxOffsetBigEnough = maxOffsetDistance >= maxOffsetThreshold
                             action =
                                 (
                                     if (maxOffsetBigEnough && finalOffsetSmallEnough) {
@@ -444,7 +448,7 @@ fun KeyboardKey(
                                                         CircularDragAction.OppositeCase to oppositeCaseKey?.center?.action,
                                                         CircularDragAction.Numeric to numericKey?.center?.action,
                                                     )
-                                                circularDirection(positions, keySize)?.let {
+                                                circularDirection(positions, finalOffsetThreshold)?.let {
                                                     when (it) {
                                                         CircularDirection.Clockwise -> circularDragActions[clockwiseDragAction]
                                                         CircularDirection.Counterclockwise ->

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -1195,8 +1195,8 @@ fun circularDirection(
     val center = positions.reduce(Offset::plus) / positions.count().toFloat()
     val radii = positions.map { it.getDistanceTo(center) }
     val maxRadius = radii.reduce { acc, it -> if (it > acc) it else acc }
-    // This is similar to accepting an ellipse with aspect ratio 2:1
-    val minRadius = maxRadius / 2
+    // This is similar to accepting an ellipse with aspect ratio 3:1
+    val minRadius = maxRadius / 3
     val similarRadii =
         radii.all {
             it in minRadius..maxRadius

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -1190,12 +1190,18 @@ fun lastColKeysToFirst(board: KeyboardC): KeyboardC {
 
 fun circularDirection(
     positions: List<Offset>,
-    keySize: Double,
+    circleCompletionTolerance: Float,
 ): CircularDirection? {
     val center = positions.reduce(Offset::plus) / positions.count().toFloat()
     val radii = positions.map { it.getDistanceTo(center) }
-    val averageRadius = radii.sum() / positions.count().toFloat()
-    val similarRadii = radii.all { it in (averageRadius - keySize)..(averageRadius + keySize) }
+    val maxRadius = radii.reduce { acc, it -> if (it > acc) it else acc }
+    // This is similar to accepting an ellipse with aspect ratio 2:1
+    val minRadius = maxRadius / 2
+    val similarRadii =
+        radii.all {
+            it in minRadius..maxRadius
+        }
+
     if (!similarRadii) {
         return null
     }
@@ -1214,7 +1220,9 @@ fun circularDirection(
                 )
             }.sum()
 
-    val angleThreshold = 2 * PI * (1 - keySize / (averageRadius * 1.5))
+    val averageRadius = (minRadius + maxRadius) / 2
+    // The threshold is a full circumference minus the arc with length equal to the tolerance
+    val angleThreshold = 2 * PI * (1 - circleCompletionTolerance / averageRadius)
     return when {
         spannedAngle >= angleThreshold -> CircularDirection.Clockwise
         spannedAngle <= -angleThreshold -> CircularDirection.Counterclockwise


### PR DESCRIPTION
This simplifies but also makes the circular drag detection algorithm easier to rationalize
  - As long as all positions in the gesture are more circular than an ellipse with aspect ratio 2:1 (major:minor axis), the gesture passes

Either of these gestures' final coordinate now has a larger tolerance, which hopefully fixes #926