### PR TITLE
Fix errors in CZProgrammerMessagEase

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/CZProgrammerMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/CZProgrammerMessagEase.kt
@@ -172,13 +172,13 @@ val KB_CZ_PROG_MAIN =
                             SwipeDirection.TOP_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("¨"),
-                                    action = KeyAction.ComposeLastKey("¨"),
+                                    action = KeyAction.ComposeLastKey("\""),
                                     color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.BOTTOM_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("´"),
-                                    action = KeyAction.ComposeLastKey("´"),
+                                    action = KeyAction.ComposeLastKey("'"),
                                     color = ColorVariant.MUTED,
                                 ),
                         ),
@@ -675,13 +675,13 @@ val KB_CZ_PROG_SHIFTED =
                             SwipeDirection.TOP_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("¨"),
-                                    action = KeyAction.ComposeLastKey("¨"),
+                                    action = KeyAction.ComposeLastKey("\""),
                                     color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.BOTTOM_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("´"),
-                                    action = KeyAction.ComposeLastKey("´"),
+                                    action = KeyAction.ComposeLastKey("'"),
                                     color = ColorVariant.MUTED,
                                 ),
                         ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/CZProgrammerMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/CZProgrammerMessagEase.kt
@@ -349,12 +349,6 @@ val KB_CZ_PROG_MAIN =
                                     action = KeyAction.CommitText("@"),
                                     color = ColorVariant.MUTED,
                                 ),
-                            SwipeDirection.BOTTOM to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("|"),
-                                    action = KeyAction.CommitText("|"),
-                                    color = ColorVariant.MUTED,
-                                ),
                         ),
                 ),
                 NUMERIC_KEY_ITEM,
@@ -397,6 +391,12 @@ val KB_CZ_PROG_MAIN =
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("*"),
                                     action = KeyAction.CommitText("*"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("|"),
+                                    action = KeyAction.CommitText("|"),
                                     color = ColorVariant.MUTED,
                                 ),
                         ),
@@ -859,12 +859,6 @@ val KB_CZ_PROG_SHIFTED =
                                     action = KeyAction.CommitText("@"),
                                     color = ColorVariant.MUTED,
                                 ),
-                            SwipeDirection.BOTTOM to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("|"),
-                                    action = KeyAction.CommitText("|"),
-                                    color = ColorVariant.MUTED,
-                                ),
                         ),
                 ),
                 NUMERIC_KEY_ITEM,
@@ -907,6 +901,12 @@ val KB_CZ_PROG_SHIFTED =
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("*"),
                                     action = KeyAction.CommitText("*"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("|"),
+                                    action = KeyAction.CommitText("|"),
                                     color = ColorVariant.MUTED,
                                 ),
                         ),

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -800,7 +800,7 @@ fun performKeyAction(
                             else -> textBefore
                         }
 
-                    "ˇ" -> 
+                    "ˇ" ->
                         when (textBefore) {
                             "c" -> "č"
                             "d" -> "ď"

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -799,6 +799,29 @@ fun performKeyAction(
                             "Ê" -> "Ệ"
                             else -> textBefore
                         }
+                    
+                    "ˇ" -> 
+                        when (textBefore) {
+                            "c" -> "č"
+                            "d" -> "ď"
+                            "e" -> "ě"
+                            "l" -> "ľ"
+                            "n" -> "ň"
+                            "r" -> "ř"
+                            "s" -> "š"
+                            "t" -> "ť"
+                            "z" -> "ž"
+                            "C" -> "Č"
+                            "D" -> "Ď"
+                            "E" -> "Ě"
+                            "L" -> "Ľ"
+                            "N" -> "Ň"
+                            "R" -> "Ř"
+                            "S" -> "Š"
+                            "T" -> "Ť"
+                            "Z" -> "Ž"
+                            " " -> "ˇ"
+                            else -> textBefore
 
                     else -> throw IllegalStateException("Invalid key modifier")
                 }

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -822,6 +822,7 @@ fun performKeyAction(
                             "Z" -> "Ž"
                             " " -> "ˇ"
                             else -> textBefore
+                        }
 
                     else -> throw IllegalStateException("Invalid key modifier")
                 }

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -799,7 +799,7 @@ fun performKeyAction(
                             "Ê" -> "Ệ"
                             else -> textBefore
                         }
-                    
+
                     "ˇ" -> 
                         when (textBefore) {
                             "c" -> "č"


### PR DESCRIPTION
Hi,
I fixed some errors in CZProgrammerMessagEase, i.e. keyboard crashes when ˇ typed, or missing downarrow.