### PR TITLE
Fix "latest version" links in issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -28,7 +28,7 @@ body:
       options:
         - label: I have written a short but informative title.
           required: true
-        - label: I have updated the app to **[the latest version](https://github.com/user/repo/releases/latest)**.
+        - label: I have updated the app to **[the latest version](https://github.com/dessalines/thumb-key/releases/latest)**.
           required: true
         - label: I have checked through the app settings for my feature.
           required: true

--- a/.github/ISSUE_TEMPLATE/issue_report.yml
+++ b/.github/ISSUE_TEMPLATE/issue_report.yml
@@ -81,7 +81,7 @@ body:
       options:
         - label: I have written a short but informative title.
           required: true
-        - label: I have updated the app to **[the latest version](https://github.com/user/repo/releases/latest)**.
+        - label: I have updated the app to **[the latest version](https://github.com/dessalines/thumb-key/releases/latest)**.
           required: true
         - label: >-
             I have searched the existing issues and this is a new one, **NOT** a 


### PR DESCRIPTION
When the new issue forms were implemented, nobody made the acknowledgment of "I have updated the app to the latest version" actually link to the `/dessalines/thumb-key` releases page (it was left at `/user/repo`, which 404s). This pull request fixes that.