### PR TITLE
MessageEase layouts: use numerics from MessageEase too

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/CZProgrammerMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/CZProgrammerMessagEase.kt
@@ -1030,6 +1030,6 @@ val KB_CZ_PROG: KeyboardDefinition =
             KeyboardDefinitionModes(
                 main = KB_CZ_PROG_MAIN,
                 shifted = KB_CZ_PROG_SHIFTED,
-                numeric = NUMERIC_KEYBOARD,
+                numeric = KB_EN_MESSAGEASE_NUMERIC,
             ),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEase.kt
@@ -752,6 +752,6 @@ val KB_DE_MESSAGEASE: KeyboardDefinition =
             KeyboardDefinitionModes(
                 main = KB_DE_MESSAGEASE_MAIN,
                 shifted = KB_DE_MESSAGEASE_SHIFTED,
-                numeric = NUMERIC_KEYBOARD,
+                numeric = KB_EN_MESSAGEASE_NUMERIC,
             ),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEaseSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEaseSymbols.kt
@@ -950,6 +950,6 @@ val KB_DE_MESSAGEASE_SYMBOLS: KeyboardDefinition =
             KeyboardDefinitionModes(
                 main = KB_DE_MESSAGEASE_SYMBOLS_MAIN,
                 shifted = KB_DE_MESSAGEASE_SYMBOLS_SHIFTED,
-                numeric = NUMERIC_KEYBOARD,
+                numeric = KB_EN_MESSAGEASE_NUMERIC,
             ),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENEOMessagEaseSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENEOMessagEaseSymbols.kt
@@ -1094,7 +1094,7 @@ val KB_ENEO_MESSAGEASE_SYMBOLS: KeyboardDefinition =
             KeyboardDefinitionModes(
                 main = KB_ENEO_MESSAGEASE_SYMBOLS_MAIN,
                 shifted = KB_ENEO_MESSAGEASE_SYMBOLS_SHIFTED,
-                numeric = NUMERIC_KEYBOARD,
+                numeric = KB_EN_MESSAGEASE_NUMERIC,
             ),
         settings =
             KeyboardDefinitionSettings(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENNOMessagEaseSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENNOMessagEaseSymbols.kt
@@ -924,6 +924,6 @@ val KB_EN_NO_MESSAGEASE_SYMBOLS: KeyboardDefinition =
             KeyboardDefinitionModes(
                 main = KB_EN_NO_MESSAGEASE_SYMBOLS_MAIN,
                 shifted = KB_EN_NO_MESSAGEASE_SYMBOLS_SHIFTED,
-                numeric = NUMERIC_KEYBOARD,
+                numeric = KB_EN_MESSAGEASE_NUMERIC,
             ),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ESCAMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ESCAMessagEase.kt
@@ -680,6 +680,6 @@ val KB_ES_CA_MESSAGEASE: KeyboardDefinition =
             KeyboardDefinitionModes(
                 main = KB_ES_CA_MESSAGEASE_MAIN,
                 shifted = KB_ES_CA_MESSAGEASE_SHIFTED,
-                numeric = NUMERIC_KEYBOARD,
+                numeric = KB_EN_MESSAGEASE_NUMERIC,
             ),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FIEEMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FIEEMessagEase.kt
@@ -963,7 +963,7 @@ val KB_FI_EE_MESSAGEASE_SYMBOLS: KeyboardDefinition =
             KeyboardDefinitionModes(
                 main = KB_FI_EE_MESSAGEASE_SYMBOLS_MAIN,
                 shifted = KB_FI_EE_MESSAGEASE_SYMBOLS_SHIFTED,
-                numeric = NUMERIC_KEYBOARD,
+                numeric = KB_EN_MESSAGEASE_NUMERIC,
             ),
         settings =
             KeyboardDefinitionSettings(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FIMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FIMessagEase.kt
@@ -744,6 +744,6 @@ val KB_FI_MESSAGEASE: KeyboardDefinition =
             KeyboardDefinitionModes(
                 main = KB_FI_MESSAGEASE_MAIN,
                 shifted = KB_FI_MESSAGEASE_SHIFTED,
-                numeric = NUMERIC_KEYBOARD,
+                numeric = KB_EN_MESSAGEASE_NUMERIC,
             ),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/RUMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/RUMessagEase.kt
@@ -577,6 +577,6 @@ val KB_RU_MESSAGEASE: KeyboardDefinition =
             KeyboardDefinitionModes(
                 main = KB_RU_MESSAGEASE_MAIN,
                 shifted = KB_RU_MESSAGEASE_SHIFTED,
-                numeric = NUMERIC_KEYBOARD,
+                numeric = KB_EN_MESSAGEASE_NUMERIC,
             ),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/SLMessagEaseSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/SLMessagEaseSymbols.kt
@@ -938,6 +938,6 @@ val KB_SL_MESSAGEASE_SYMBOLS: KeyboardDefinition =
             KeyboardDefinitionModes(
                 main = KB_SL_MESSAGEASE_SYMBOLS_MAIN,
                 shifted = KB_SL_MESSAGEASE_SYMBOLS_SHIFTED,
-                numeric = NUMERIC_KEYBOARD,
+                numeric = KB_EN_MESSAGEASE_NUMERIC,
             ),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/SVMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/SVMessagEase.kt
@@ -744,6 +744,6 @@ val KB_SV_MESSAGEASE: KeyboardDefinition =
             KeyboardDefinitionModes(
                 main = KB_SV_MESSAGEASE_MAIN,
                 shifted = KB_SV_MESSAGEASE_SHIFTED,
-                numeric = NUMERIC_KEYBOARD,
+                numeric = KB_EN_MESSAGEASE_NUMERIC,
             ),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/UKRUMessagEaseSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/UKRUMessagEaseSymbols.kt
@@ -940,6 +940,6 @@ val KB_UK_RU_MESSAGEASE_SYMBOLS: KeyboardDefinition =
             KeyboardDefinitionModes(
                 main = KB_UK_RU_MESSAGEASE_SYMBOLS_MAIN,
                 shifted = KB_UK_RU_MESSAGEASE_SYMBOLS_SHIFTED,
-                numeric = NUMERIC_KEYBOARD,
+                numeric = KB_EN_MESSAGEASE_NUMERIC,
             ),
     )


### PR DESCRIPTION
Default numerics are too different from messagease layout, in messagease app numerics for English and other layouts are usually the same, so just reuse KB_EN_MESSAGEASE_NUMERIC.

I've just found all layouts with `messagease` in naming and with NUMERIC_KEYBOARD usage, and replaced it.