### PR TITLE
Farsi/Persian Spacebar Multi-taps

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/CommonKeys.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/CommonKeys.kt
@@ -616,4 +616,19 @@ val SPACEBAR_FRENCH_TYPESPLIT_BOTTOM_KEY_ITEM =
             ),
     )
 
+val SPACEBAR_FARSI_KEY_ITEM =
+    SPACEBAR_KEY_ITEM.copy(
+        nextTapActions =
+            listOf(
+                KeyAction.ReplaceLastText("، ", trimCount = 1),
+                KeyAction.ReplaceLastText(". "),
+                KeyAction.ReplaceLastText("؟ "),
+                KeyAction.ReplaceLastText("! "),
+                KeyAction.ReplaceLastText(": "),
+                KeyAction.ReplaceLastText("؛ "),
+            ),
+    )
+
+val SPACEBAR_FARSI_SKINNY_KEY_ITEM = SPACEBAR_FARSI_KEY_ITEM.copy(widthMultiplier = 1)
+
 val SPACEBAR_ZERO_KEY_ITEM = SPACEBAR_KEY_ITEM.copy(longPress = KeyAction.CommitText("0"))

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FAThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FAThumbKey.kt
@@ -303,7 +303,7 @@ val KB_FA_THUMBKEY_MAIN =
                 BACKSPACE_KEY_ITEM,
             ),
             listOf(
-                SPACEBAR_KEY_ITEM,
+                SPACEBAR_FARSI_KEY_ITEM,
                 RETURN_KEY_ITEM,
             ),
         ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FarsiNumeric.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FarsiNumeric.kt
@@ -355,7 +355,7 @@ val FARSI_NUMERIC_KEYBOARD =
                         ),
                     widthMultiplier = 2,
                 ),
-                SPACEBAR_SKINNY_KEY_ITEM,
+                SPACEBAR_FARSI_SKINNY_KEY_ITEM,
                 RETURN_KEY_ITEM,
             ),
         ),


### PR DESCRIPTION
Farsi and some other RTL languages like Arabic uses different symbols for comma, semicolon and question mark but current spacebar multi-taps symbols uses default symbols, so I changed them to use correct symbols.
I'm not sure it's appropriate to define `SPACEBAR_FARSI_KEY_ITEM` and `SPACEBAR_FARSI_SKINNY_KEY_ITEM` in `CommonKeys.kt`  and if they should be defined in `FAThumbKey.kt` and `FarsiNumeric.kt`, but I thought they can be used in future Farsi layouts and some other RTL languages like Arabic this way. 