### PR TITLE
European Thumb-Key layout

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/EuropeThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/EuropeThumbKey.kt
@@ -1,0 +1,830 @@
+package com.dessalines.thumbkey.keyboards
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowDropDown
+import androidx.compose.material.icons.outlined.ArrowDropUp
+import androidx.compose.material.icons.outlined.Copyright
+import androidx.compose.material.icons.outlined.KeyboardCapslock
+import com.dessalines.thumbkey.utils.ColorVariant
+import com.dessalines.thumbkey.utils.FontSizeVariant
+import com.dessalines.thumbkey.utils.KeyAction
+import com.dessalines.thumbkey.utils.KeyC
+import com.dessalines.thumbkey.utils.KeyDisplay
+import com.dessalines.thumbkey.utils.KeyItemC
+import com.dessalines.thumbkey.utils.KeyboardC
+import com.dessalines.thumbkey.utils.KeyboardDefinition
+import com.dessalines.thumbkey.utils.KeyboardDefinitionModes
+import com.dessalines.thumbkey.utils.KeyboardDefinitionSettings
+import com.dessalines.thumbkey.utils.SwipeDirection
+import com.dessalines.thumbkey.utils.SwipeNWay
+import com.dessalines.thumbkey.utils.autoCapitalizeI
+import com.dessalines.thumbkey.utils.autoCapitalizeIApostrophe
+
+val KB_EUROPE_THUMBKEY_MAIN =
+    KeyboardC(
+        listOf(
+            listOf(
+                KeyItemC(
+                    center =
+                        KeyC(
+                            action = KeyAction.CommitText("s"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
+                    swipes =
+                        mapOf(
+                            SwipeDirection.TOP_LEFT to
+                                KeyC(
+                                    action = KeyAction.CommitText("«"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.TOP to
+                                KeyC(
+                                    action = KeyAction.CommitText("§"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.TOP_RIGHT to
+                                KeyC(
+                                    action = KeyAction.CommitText("»"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.LEFT to
+                                KeyC(
+                                    action = KeyAction.CommitText("¿"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.RIGHT to
+                                KeyC(
+                                    action = KeyAction.CommitText("?"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.BOTTOM_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("◌̄"),
+                                    action = KeyAction.CommitText("\u0304"),
+                                ),
+                            SwipeDirection.BOTTOM_RIGHT to
+                                KeyC(
+                                    action = KeyAction.CommitText("p"),
+                                ),
+                        ),
+                ),
+                KeyItemC(
+                    center =
+                        KeyC(
+                            action = KeyAction.CommitText("l"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
+                    swipes =
+                        mapOf(
+                            SwipeDirection.LEFT to
+                                KeyC(
+                                    action = KeyAction.CommitText("¡"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.RIGHT to
+                                KeyC(
+                                    action = KeyAction.CommitText("!"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.TOP to
+                                KeyC(
+                                    action = KeyAction.CommitText("ł"),
+                                ),
+                            SwipeDirection.BOTTOM to
+                                KeyC(
+                                    action = KeyAction.CommitText("v"),
+                                ),
+                        ),
+                ),
+                KeyItemC(
+                    center =
+                        KeyC(
+                            action = KeyAction.CommitText("i"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
+                    swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
+                    swipes =
+                        mapOf(
+                            SwipeDirection.TOP_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("◌̃"),
+                                    action = KeyAction.CommitText("\u0303"),
+                                ),
+                            SwipeDirection.TOP_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("◌̆"),
+                                    action = KeyAction.CommitText("\u0306"),
+                                ),
+                            SwipeDirection.BOTTOM_LEFT to
+                                KeyC(
+                                    action = KeyAction.CommitText("m"),
+                                ),
+                            SwipeDirection.BOTTOM_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("◌̌"),
+                                    action = KeyAction.CommitText("\u030c"),
+                                ),
+                        ),
+                ),
+                EMOJI_KEY_ITEM,
+            ),
+            listOf(
+                KeyItemC(
+                    center =
+                        KeyC(
+                            action = KeyAction.CommitText("t"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
+                    swipes =
+                        mapOf(
+                            SwipeDirection.TOP_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("◌̓"),
+                                    action = KeyAction.CommitText("\u0313"),
+                                ),
+                            SwipeDirection.TOP to
+                                KeyC(
+                                    // PER MILLE SIGN
+                                    display = KeyDisplay.TextDisplay("‰"),
+                                    action = KeyAction.CommitText("\u2030"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.TOP_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("◌̦"),
+                                    action = KeyAction.CommitText("\u0326"),
+                                ),
+                            SwipeDirection.LEFT to
+                                KeyC(
+                                    // DAGGER
+                                    display = KeyDisplay.TextDisplay("†"),
+                                    action = KeyAction.CommitText("\u2020"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.RIGHT to
+                                KeyC(
+                                    action = KeyAction.CommitText("h"),
+                                ),
+                            SwipeDirection.BOTTOM_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("◌̏"),
+                                    action = KeyAction.CommitText("\u030f"),
+                                ),
+                            SwipeDirection.BOTTOM to
+                                KeyC(
+                                    // PLUS-MINUS SIGN
+                                    display = KeyDisplay.TextDisplay("±"),
+                                    action = KeyAction.CommitText("\u00b1"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.BOTTOM_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("◌̇"),
+                                    action = KeyAction.CommitText("\u0307"),
+                                ),
+                        ),
+                ),
+                KeyItemC(
+                    center =
+                        KeyC(
+                            action = KeyAction.CommitText("r"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
+                    swipes =
+                        mapOf(
+                            SwipeDirection.TOP_LEFT to
+                                KeyC(
+                                    action = KeyAction.CommitText("y"),
+                                ),
+                            SwipeDirection.TOP to
+                                KeyC(
+                                    action = KeyAction.CommitText("q"),
+                                ),
+                            SwipeDirection.TOP_RIGHT to
+                                KeyC(
+                                    action = KeyAction.CommitText("w"),
+                                ),
+                            SwipeDirection.RIGHT to
+                                KeyC(
+                                    action = KeyAction.CommitText("k"),
+                                ),
+                            SwipeDirection.BOTTOM_RIGHT to
+                                KeyC(
+                                    action = KeyAction.CommitText("b"),
+                                ),
+                            SwipeDirection.BOTTOM to
+                                KeyC(
+                                    action = KeyAction.CommitText("j"),
+                                ),
+                            SwipeDirection.BOTTOM_LEFT to
+                                KeyC(
+                                    action = KeyAction.CommitText("z"),
+                                ),
+                            SwipeDirection.LEFT to
+                                KeyC(
+                                    action = KeyAction.CommitText("f"),
+                                ),
+                        ),
+                ),
+                KeyItemC(
+                    center =
+                        KeyC(
+                            action = KeyAction.CommitText("a"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
+                    swipes =
+                        mapOf(
+                            SwipeDirection.TOP_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("◌̊"),
+                                    action = KeyAction.CommitText("\u030a"),
+                                ),
+                            SwipeDirection.TOP_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("◌̨"),
+                                    action = KeyAction.CommitText("\u0328"),
+                                ),
+                            SwipeDirection.LEFT to
+                                KeyC(
+                                    action = KeyAction.CommitText("u"),
+                                ),
+                            SwipeDirection.TOP to
+                                KeyC(
+                                    display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
+                                    action = KeyAction.ToggleShiftMode(true),
+                                    swipeReturnAction = KeyAction.ToggleCurrentWordCapitalization(true),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.BOTTOM to
+                                KeyC(
+                                    action = KeyAction.ToggleShiftMode(false),
+                                    swipeReturnAction = KeyAction.ToggleCurrentWordCapitalization(false),
+                                ),
+                            SwipeDirection.BOTTOM_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("◌̒"),
+                                    action = KeyAction.CommitText("\u0312"),
+                                ),
+                            SwipeDirection.RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("◌̈"),
+                                    action = KeyAction.CommitText("\u0308"),
+                                ),
+                            SwipeDirection.BOTTOM_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("◌̧"),
+                                    action = KeyAction.CommitText("\u0327"),
+                                ),
+                        ),
+                ),
+                NUMERIC_KEY_ITEM,
+            ),
+            listOf(
+                KeyItemC(
+                    center =
+                        KeyC(
+                            action = KeyAction.CommitText("n"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
+                    swipes =
+                        mapOf(
+                            SwipeDirection.TOP_LEFT to
+                                KeyC(
+                                    // U+00DE
+                                    action = KeyAction.CommitText("þ"),
+                                ),
+                            SwipeDirection.TOP to
+                                KeyC(
+                                    // DEGREE SIGN
+                                    display = KeyDisplay.TextDisplay("°"),
+                                    action = KeyAction.CommitText("\u00b0"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.TOP_RIGHT to
+                                KeyC(
+                                    action = KeyAction.CommitText("c"),
+                                ),
+                            SwipeDirection.BOTTOM_LEFT to
+                                KeyC(
+                                    // U+0152
+                                    action = KeyAction.CommitText("œ"),
+                                ),
+                            SwipeDirection.BOTTOM_RIGHT to
+                                KeyC(
+                                    // U+00D0
+                                    action = KeyAction.CommitText("ð"),
+                                ),
+                        ),
+                ),
+                KeyItemC(
+                    center =
+                        KeyC(
+                            action = KeyAction.CommitText("o"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
+                    swipes =
+                        mapOf(
+                            SwipeDirection.TOP_LEFT to
+                                KeyC(
+                                    action = KeyAction.CommitText("đ"),
+                                ),
+                            SwipeDirection.TOP to
+                                KeyC(
+                                    action = KeyAction.CommitText("g"),
+                                ),
+                            SwipeDirection.TOP_RIGHT to
+                                KeyC(
+                                    action = KeyAction.CommitText("ø"),
+                                ),
+                            SwipeDirection.RIGHT to
+                                KeyC(
+                                    action = KeyAction.CommitText("x"),
+                                ),
+                            SwipeDirection.LEFT to
+                                KeyC(
+                                    action = KeyAction.CommitText("æ"),
+                                ),
+                            SwipeDirection.BOTTOM_LEFT to
+                                KeyC(
+                                    action = KeyAction.CommitText("'"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.BOTTOM to
+                                KeyC(
+                                    action = KeyAction.CommitText("."),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.BOTTOM_RIGHT to
+                                KeyC(
+                                    action = KeyAction.CommitText("-"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                        ),
+                ),
+                KeyItemC(
+                    center =
+                        KeyC(
+                            action = KeyAction.CommitText("e"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
+                    swipes =
+                        mapOf(
+                            SwipeDirection.TOP_LEFT to
+                                KeyC(
+                                    action = KeyAction.CommitText("d"),
+                                ),
+                            SwipeDirection.TOP_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("◌̀"),
+                                    action = KeyAction.CommitText("\u0300"),
+                                ),
+                            SwipeDirection.LEFT to
+                                KeyC(
+                                    action = KeyAction.CommitText("ß"),
+                                ),
+                            SwipeDirection.RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("◌̂"),
+                                    action = KeyAction.CommitText("\u0302"),
+                                ),
+                            SwipeDirection.BOTTOM_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("◌̋"),
+                                    action = KeyAction.CommitText("\u030b"),
+                                ),
+                            SwipeDirection.BOTTOM_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("◌́"),
+                                    action = KeyAction.CommitText("\u0301"),
+                                ),
+                        ),
+                ),
+                BACKSPACE_KEY_ITEM,
+            ),
+            listOf(
+                SPACEBAR_KEY_ITEM,
+                RETURN_KEY_ITEM,
+            ),
+        ),
+    )
+
+val KB_EUROPE_THUMBKEY_SHIFTED =
+    KeyboardC(
+        listOf(
+            listOf(
+                KeyItemC(
+                    center =
+                        KeyC(
+                            action = KeyAction.CommitText("S"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
+                    swipes =
+                        mapOf(
+                            SwipeDirection.TOP_LEFT to
+                                KeyC(
+                                    action = KeyAction.CommitText("«"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.TOP to
+                                KeyC(
+                                    action = KeyAction.CommitText("§"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.TOP_RIGHT to
+                                KeyC(
+                                    action = KeyAction.CommitText("»"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.LEFT to
+                                KeyC(
+                                    action = KeyAction.CommitText("¿"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.RIGHT to
+                                KeyC(
+                                    action = KeyAction.CommitText("?"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.BOTTOM_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("◌̄"),
+                                    action = KeyAction.CommitText("\u0304"),
+                                ),
+                            SwipeDirection.BOTTOM_RIGHT to
+                                KeyC(
+                                    action = KeyAction.CommitText("P"),
+                                ),
+                        ),
+                ),
+                KeyItemC(
+                    center =
+                        KeyC(
+                            action = KeyAction.CommitText("L"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
+                    swipes =
+                        mapOf(
+                            SwipeDirection.LEFT to
+                                KeyC(
+                                    action = KeyAction.CommitText("¡"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.RIGHT to
+                                KeyC(
+                                    action = KeyAction.CommitText("!"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.TOP to
+                                KeyC(
+                                    action = KeyAction.CommitText("Ł"),
+                                ),
+                            SwipeDirection.BOTTOM to
+                                KeyC(
+                                    action = KeyAction.CommitText("V"),
+                                ),
+                        ),
+                ),
+                KeyItemC(
+                    center =
+                        KeyC(
+                            action = KeyAction.CommitText("I"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
+                    swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
+                    swipes =
+                        mapOf(
+                            SwipeDirection.TOP_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("◌̃"),
+                                    action = KeyAction.CommitText("\u0303"),
+                                ),
+                            SwipeDirection.TOP_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("◌̆"),
+                                    action = KeyAction.CommitText("\u0306"),
+                                ),
+                            SwipeDirection.BOTTOM_LEFT to
+                                KeyC(
+                                    action = KeyAction.CommitText("M"),
+                                ),
+                            SwipeDirection.BOTTOM_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("◌̌"),
+                                    action = KeyAction.CommitText("\u030c"),
+                                ),
+                        ),
+                ),
+                EMOJI_KEY_ITEM,
+            ),
+            listOf(
+                KeyItemC(
+                    center =
+                        KeyC(
+                            action = KeyAction.CommitText("T"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
+                    swipes =
+                        mapOf(
+                            SwipeDirection.TOP_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("◌̓"),
+                                    action = KeyAction.CommitText("\u0313"),
+                                ),
+                            SwipeDirection.TOP to
+                                KeyC(
+                                    // PER MILLE SIGN
+                                    display = KeyDisplay.TextDisplay("‰"),
+                                    action = KeyAction.CommitText("\u2030"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.TOP_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("◌̦"),
+                                    action = KeyAction.CommitText("\u0326"),
+                                ),
+                            SwipeDirection.LEFT to
+                                KeyC(
+                                    // DOUBLE DAGGER
+                                    display = KeyDisplay.TextDisplay("‡"),
+                                    action = KeyAction.CommitText("\u2021"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.RIGHT to
+                                KeyC(
+                                    action = KeyAction.CommitText("H"),
+                                ),
+                            SwipeDirection.BOTTOM_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("◌̏"),
+                                    action = KeyAction.CommitText("\u030f"),
+                                ),
+                            SwipeDirection.BOTTOM to
+                                KeyC(
+                                    // PLUS-MINUS SIGN
+                                    display = KeyDisplay.TextDisplay("±"),
+                                    action = KeyAction.CommitText("\u00b1"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.BOTTOM_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("◌̇"),
+                                    action = KeyAction.CommitText("\u0307"),
+                                ),
+                        ),
+                ),
+                KeyItemC(
+                    center =
+                        KeyC(
+                            action = KeyAction.CommitText("R"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
+                    swipes =
+                        mapOf(
+                            SwipeDirection.TOP_LEFT to
+                                KeyC(
+                                    action = KeyAction.CommitText("Y"),
+                                ),
+                            SwipeDirection.TOP to
+                                KeyC(
+                                    action = KeyAction.CommitText("Q"),
+                                ),
+                            SwipeDirection.TOP_RIGHT to
+                                KeyC(
+                                    action = KeyAction.CommitText("W"),
+                                ),
+                            SwipeDirection.RIGHT to
+                                KeyC(
+                                    action = KeyAction.CommitText("K"),
+                                ),
+                            SwipeDirection.BOTTOM_RIGHT to
+                                KeyC(
+                                    action = KeyAction.CommitText("B"),
+                                ),
+                            SwipeDirection.BOTTOM to
+                                KeyC(
+                                    action = KeyAction.CommitText("J"),
+                                ),
+                            SwipeDirection.BOTTOM_LEFT to
+                                KeyC(
+                                    action = KeyAction.CommitText("Z"),
+                                ),
+                            SwipeDirection.LEFT to
+                                KeyC(
+                                    action = KeyAction.CommitText("F"),
+                                ),
+                        ),
+                ),
+                KeyItemC(
+                    center =
+                        KeyC(
+                            action = KeyAction.CommitText("A"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
+                    swipes =
+                        mapOf(
+                            SwipeDirection.TOP_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("◌̊"),
+                                    action = KeyAction.CommitText("\u030a"),
+                                ),
+                            SwipeDirection.TOP_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("◌̨"),
+                                    action = KeyAction.CommitText("\u0328"),
+                                ),
+                            SwipeDirection.LEFT to
+                                KeyC(
+                                    action = KeyAction.CommitText("U"),
+                                ),
+                            SwipeDirection.TOP to
+                                KeyC(
+                                    display = KeyDisplay.IconDisplay(Icons.Outlined.KeyboardCapslock),
+                                    capsModeDisplay = KeyDisplay.IconDisplay(Icons.Outlined.Copyright),
+                                    action = KeyAction.ToggleCapsLock,
+                                    swipeReturnAction = KeyAction.ToggleCurrentWordCapitalization(true),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
+                                    action = KeyAction.ToggleShiftMode(false),
+                                    swipeReturnAction = KeyAction.ToggleCurrentWordCapitalization(false),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.BOTTOM_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("◌̒"),
+                                    action = KeyAction.CommitText("\u0312"),
+                                ),
+                            SwipeDirection.RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("◌̈"),
+                                    action = KeyAction.CommitText("\u0308"),
+                                ),
+                            SwipeDirection.BOTTOM_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("◌̧"),
+                                    action = KeyAction.CommitText("\u0327"),
+                                ),
+                        ),
+                ),
+                NUMERIC_KEY_ITEM,
+            ),
+            listOf(
+                KeyItemC(
+                    center =
+                        KeyC(
+                            action = KeyAction.CommitText("N"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
+                    swipes =
+                        mapOf(
+                            SwipeDirection.TOP_LEFT to
+                                KeyC(
+                                    action = KeyAction.CommitText("Þ"),
+                                ),
+                            SwipeDirection.TOP to
+                                KeyC(
+                                    // DEGREE SIGN
+                                    display = KeyDisplay.TextDisplay("°"),
+                                    action = KeyAction.CommitText("\u00b0"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.TOP_RIGHT to
+                                KeyC(
+                                    action = KeyAction.CommitText("C"),
+                                ),
+                            SwipeDirection.BOTTOM_LEFT to
+                                KeyC(
+                                    action = KeyAction.CommitText("Œ"),
+                                ),
+                            SwipeDirection.BOTTOM_RIGHT to
+                                KeyC(
+                                    action = KeyAction.CommitText("Ð"),
+                                ),
+                        ),
+                ),
+                KeyItemC(
+                    center =
+                        KeyC(
+                            action = KeyAction.CommitText("O"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
+                    swipes =
+                        mapOf(
+                            SwipeDirection.TOP_LEFT to
+                                KeyC(
+                                    action = KeyAction.CommitText("Đ"),
+                                ),
+                            SwipeDirection.TOP to
+                                KeyC(
+                                    action = KeyAction.CommitText("G"),
+                                ),
+                            SwipeDirection.TOP_RIGHT to
+                                KeyC(
+                                    action = KeyAction.CommitText("Ø"),
+                                ),
+                            SwipeDirection.RIGHT to
+                                KeyC(
+                                    action = KeyAction.CommitText("X"),
+                                ),
+                            SwipeDirection.LEFT to
+                                KeyC(
+                                    action = KeyAction.CommitText("Æ"),
+                                ),
+                            SwipeDirection.BOTTOM_LEFT to
+                                KeyC(
+                                    action = KeyAction.CommitText("'"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.BOTTOM to
+                                KeyC(
+                                    action = KeyAction.CommitText("."),
+                                    color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.BOTTOM_RIGHT to
+                                KeyC(
+                                    action = KeyAction.CommitText("-"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                        ),
+                ),
+                KeyItemC(
+                    center =
+                        KeyC(
+                            action = KeyAction.CommitText("E"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
+                    swipes =
+                        mapOf(
+                            SwipeDirection.TOP_LEFT to
+                                KeyC(
+                                    action = KeyAction.CommitText("D"),
+                                ),
+                            SwipeDirection.TOP_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("◌̀"),
+                                    action = KeyAction.CommitText("\u0300"),
+                                ),
+                            SwipeDirection.LEFT to
+                                KeyC(
+                                    action = KeyAction.CommitText("ẞ"),
+                                ),
+                            SwipeDirection.RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("◌̂"),
+                                    action = KeyAction.CommitText("\u0302"),
+                                ),
+                            SwipeDirection.BOTTOM_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("◌̋"),
+                                    action = KeyAction.CommitText("\u030b"),
+                                ),
+                            SwipeDirection.BOTTOM_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("◌́"),
+                                    action = KeyAction.CommitText("\u0301"),
+                                ),
+                        ),
+                ),
+                BACKSPACE_KEY_ITEM,
+            ),
+            listOf(
+                SPACEBAR_KEY_ITEM,
+                RETURN_KEY_ITEM,
+            ),
+        ),
+    )
+
+val KB_EUROPE_THUMBKEY: KeyboardDefinition =
+    KeyboardDefinition(
+        title = "European thumb-key",
+        modes =
+            KeyboardDefinitionModes(
+                main = KB_EUROPE_THUMBKEY_MAIN,
+                shifted = KB_EUROPE_THUMBKEY_SHIFTED,
+                numeric = NUMERIC_KEYBOARD,
+            ),
+        settings =
+            KeyboardDefinitionSettings(
+                autoCapitalizers = arrayOf(::autoCapitalizeI, ::autoCapitalizeIApostrophe),
+            ),
+    )

--- a/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
@@ -69,6 +69,7 @@ import com.dessalines.thumbkey.keyboards.KB_ES_EO_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_ES_MESSAGEASE
 import com.dessalines.thumbkey.keyboards.KB_ES_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_ES_TYPESPLIT
+import com.dessalines.thumbkey.keyboards.KB_EUROPE_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_EU_ES_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_EU_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_FA_THUMBKEY
@@ -276,4 +277,5 @@ enum class KeyboardLayout(
     FAThumbKeySamsung(KB_FA_THUMBKEY_SAMSUNG),
     DEENAEThumbkey(KB_DE_EN_AE_THUMBKEY),
     SKThumbKeyV3(KB_SK_THUMBKEY_V3),
+    EuropeThumbkey(KB_EUROPE_THUMBKEY),
 }


### PR DESCRIPTION
> 640K ought to be enough for anyone.

This layout ought to be enough for anyone... as long as they are typing a message in a European language with script based on the Latin alphabet.

The MAIN GOAL of the layout is to be able to input EVERY LETTER used by European languages without EVER having to switch to another layout.

LETTER FREQUENCY SOURCE

The Python script uses that data[1] I found on Wikipedia to calculate the combined letter frequency for a bunch of European languages. I then used the result to compose a layout that will be suboptimal for EVERY language, but will NEVER require switching to input a character... as long as you stay in Europe, that is.

[1] https://en.wikipedia.org/wiki/Letter_frequency

Apart from the base letters found in the original Latin alphabet, plenty of European languages also use accented versions of the base letters. It would not be possible to construct a single layout if not for a nifty trick that @Berengar pointed out - Unicode combining characters. As it turns out, about 20 of them are enough to cover all of Europe using Latin alphabet.

There are a few symbols which look like they should be a base letter plus a combining character--the most obvious ones being Ł and Ø--but for which I could not figure out a way of synthesising. So I put them as base letters in the layout.

LAYOUT MAP

Characters in keys are listed in the following order:

    +-------+
    | 1 2 3 |
    | 4 5 6 |
    | 7 8 9 |
    +-------+

ASCII letters are given as themselves and - (hyphen) stands for "empty position". Other symbols are given as their Unicode codepoints.

Top left key (S):

    U+00AB LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
    U+00A7 SECTION SIGN
    U+00BB RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK

    U+00BF INVERTED QUESTION MARK
    S
    U+003F QUESTION MARK

    U+0304 COMBINING MACRON
    -
    P

Top key (L):

    -
    -
    Ł

    U+00A1 INVERTED EXCLAMATION MARK
    L
    U+0021 EXCLAMATION MARK

    -
    V
    -

Top right key (I):

    U+0303 COMBINING TILDE
    -
    U+0306 COMBINING BREVE

    -
    I
    -

    M
    -
    U+030C COMBINING CARON (HACEK)

Middle left key (T):

    U+0313 COMBINING COMMA ABOVE
    U+2030 PER MILLE SIGN
    U+0326 COMBINING COMMA BELOW

    U+2021 / U+2020 DOUBLE DAGGER / DAGGER
    T
    H

    U+030F COMBINING DOUBLE GRAVE ACCENT
    -
    U+0307 COMBINING DOT ABOVE

Middle right key (A):

    U+030A COMBINING RING ABOVE
    -
    U+0328 COMBINING OGONEK

    U
    A
    U+0308 COMBINING DIAERESIS

    U+0312 COMBINING TURNED COMMA ABOVE (CEDILLA ABOVE)
    -
    U+0327 COMBINING CEDILLA

Bottom left key (N):

    U+00DE / U+00FE LATIN CAPITAL/SMALL LETTER THORN
    U+00B0 DEGREE SIGN
    C

    -
    N
    -

    U+0152 / U+0153 LATIN CAPITAL/SMALL LIGATURE OE
    -
    U+00D0 / U+00F0 LATIN CAPITAL/SMALL LETTER ETH

Bottom key (O):

    U+0110 / U+0111 LATIN CAPITAL/SMALL LETTER D WITH STROKE
    G
    U+00D8 / U+00F8 LATIN CAPITAL/SMALL LETTER O WITH STROKE

    U+00C6 / U+00E6 LATIN CAPITAL/SMALL LETTER AE
    O
    X

    -
    U+002E FULL STOP
    U+002D HYPHEN-MINUS

Bottom right key (E):

    D
    -
    U+0300 COMBINING GRAVE ACCENT

    U+1E9E / U+00DF LATIN CAPITAL/SMALL LETTER SHARP S
    E
    U+0302 COMBINING CIRCUMFLEX ACCENT (HAT)

    U+030B COMBINING DOUBLE ACUTE ACCENT
    -
    U+0301 COMBINING ACUTE ACCENT

PUNCTUATION MARKS

Why did Spanish and French receive "special treatment", with their « and », ? and ¿, and ! and ¡ being included in the base layout?

Let me restate the main goal of the layout: to be able to input EVERY LETTER used by European languages without EVER having to switch to another layout.

Having accomplished that, and still having free space left on some of the keys, I thought about including important punctuation marks. Other Thumb-Key layouts go for the most frequently used charactcers like a comma, a full stop, exclamation mark, etc.

However, all of these "typical" characters are either easily obtainable by repeated taps on the Space key, or by switching to the numeric keyboard. (Since both Space-taps and the numeric keyboard stay the same no matter which layout one uses the muscle memory is retained, which fits the goal of the European layout.)

After some deliberation, I decided to include the French quotation marks and Spanish question and exclamation marks. Why? Because they are not available on the numeric keyboard and users from these countries would still have to switch to another layout to get them.

FRENCH QUOTATION MARKS

One could ask, why support French quoting style, and not other styles used throughout Europe? Thumb-Key is a keyboard made for tiny touch screens of smartphones, and I would expect the most frequent use of it to be in texting. From my experience, the English quoting style won.

Take the ,,quote'' style used in Poland, for example. When you are typesetting a book, then by all means - go for the proper style. But in my experience no one cares when texting, and the easily accessible " is all that is used.

The French quoting style is unique enough to warrant inclusion, in my personal, subjective, opinion. Also, « and » are distinct enough to allow an extra level of depths in quoting without any ambiguity. Do I expect this to be a frequent use case, though? No, not really.

PUNCTUATION PAIRS

The characters that "come together" reside on left and right sides of a key, in a single row:

    LEFT                            RIGHT                   COMMENT
    U+0313 COMMA ABOVE              U+0326 COMMA BELOW      Top of T key
    U+0312 CEDILLA ABOVE            U+0327 CEDILLA          Bot of A key
    U+00BF ¿                        U+003F ?                Mid of S key
    U+00A1 ¡                        U+0021 !                Mid of L key

I have also considered applying this rule to the following "pairs" of characters:

 - U+0300 GRAVE ACCENT and U+0301 ACUTE ACCENT
 - U+030F DOUBLE GRAVE ACCENT and U+030B DOUBLE ACUTE ACCENT
 - U+030C CARON (HACEK) and U+0302 CIRCUMFLEX ACCENT

However, if I wanted to do this I would not be able to always keep the accents on the same key as the letter they modify -- and I considered keeping accents near their letters to be more important than keeping the arbitrary "pairs" together.

The layout is unambiguous enough as it is right now, so I do not expect much confusion once users get accustomed to it.