### PR TITLE
Show emoji key while in Shift mode in Programmer Wide layout

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyProgrammerWide.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyProgrammerWide.kt
@@ -427,7 +427,7 @@ val KB_EN_THUMBKEY_PROGRAMMING_WIDE_SHIFTED =
     KeyboardC(
         listOf(
             listOf(
-                EMOJI_BACK_KEY_ITEM,
+                EMOJI_KEY_ITEM,
                 KeyItemC(
                     center =
                         KeyC(


### PR DESCRIPTION
In the "english thumb-key programming wide" layout, the `EMOJI_BACK_KEY_ITEM` key is used in place of `EMOJI_KEY_ITEM` when shifted, as defined in [the layout file](https://github.com/dessalines/thumb-key/blob/8096df7e332228f05338fd4e9a5ebb82b7f33c5a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyProgrammerWide.kt#L430). This means that the emoji key doesn't show up in Shift mode like it does in other keyboard layouts. 

Apart from [CommonKeys.kt](https://github.com/dessalines/thumb-key/blob/8096df7e332228f05338fd4e9a5ebb82b7f33c5a/app/src/main/java/com/dessalines/thumbkey/keyboards/CommonKeys.kt#L149), the Programmer Wide layout is the only other file in the `thumbkey/keyboards` directory containing `EMOJI_BACK_KEY_ITEM`.

This pull request replaces `EMOJI_BACK_KEY_ITEM` with `EMOJI_KEY_ITEM`, as seen in other keyboard layouts.