### PR TITLE
Added üÜ and ßẞ to DEMessagEaseNordic.kt, shifted ßẞ correctly in german keyboards

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEase.kt
@@ -646,8 +646,8 @@ val KB_DE_MESSAGEASE_SHIFTED =
                                 ),
                             SwipeDirection.BOTTOM to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("ß"),
-                                    action = KeyAction.CommitText("ß"),
+                                    display = KeyDisplay.TextDisplay("ẞ"),
+                                    action = KeyAction.CommitText("ẞ"),
                                 ),
                             SwipeDirection.RIGHT to
                                 KeyC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEaseNordic.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEaseNordic.kt
@@ -169,8 +169,8 @@ val KB_DE_NORDIC_MESSAGEASE_MAIN =
                         mapOf(
                             SwipeDirection.TOP to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("æ"),
-                                    action = KeyAction.CommitText("æ"),
+                                    display = KeyDisplay.TextDisplay("ü"),
+                                    action = KeyAction.CommitText("ü"),
                                 ),
                             SwipeDirection.TOP_LEFT to
                                 KeyC(
@@ -366,6 +366,11 @@ val KB_DE_NORDIC_MESSAGEASE_MAIN =
                                     display = KeyDisplay.TextDisplay("ø"),
                                     action = KeyAction.CommitText("ø"),
                                 ),
+                            SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("ß"),
+                                    action = KeyAction.CommitText("ß"),
+                                ),
                             SwipeDirection.BOTTOM_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.IconDisplay(Icons.AutoMirrored.Outlined.KeyboardTab),
@@ -394,6 +399,11 @@ val KB_DE_NORDIC_MESSAGEASE_MAIN =
                                     display = KeyDisplay.TextDisplay("\""),
                                     action = KeyAction.CommitText("\""),
                                     color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("æ"),
+                                    action = KeyAction.CommitText("æ"),
                                 ),
                             SwipeDirection.BOTTOM_LEFT to
                                 KeyC(
@@ -634,8 +644,8 @@ val KB_DE_NORDIC_MESSAGEASE_SHIFTED =
                         mapOf(
                             SwipeDirection.TOP to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("Æ"),
-                                    action = KeyAction.CommitText("Æ"),
+                                    display = KeyDisplay.TextDisplay("Ü"),
+                                    action = KeyAction.CommitText("Ü"),
                                 ),
                             SwipeDirection.TOP_LEFT to
                                 KeyC(
@@ -834,6 +844,11 @@ val KB_DE_NORDIC_MESSAGEASE_SHIFTED =
                                     display = KeyDisplay.TextDisplay("Ø"),
                                     action = KeyAction.CommitText("Ø"),
                                 ),
+                            SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("ẞ"),
+                                    action = KeyAction.CommitText("ẞ"),
+                                ),
                             SwipeDirection.BOTTOM_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.IconDisplay(Icons.AutoMirrored.Outlined.KeyboardTab),
@@ -862,6 +877,11 @@ val KB_DE_NORDIC_MESSAGEASE_SHIFTED =
                                     display = KeyDisplay.TextDisplay("\""),
                                     action = KeyAction.CommitText("\""),
                                     color = ColorVariant.MUTED,
+                                ),
+                            SwipeDirection.LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("Æ"),
+                                    action = KeyAction.CommitText("Æ"),
                                 ),
                             SwipeDirection.BOTTOM_LEFT to
                                 KeyC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbKey.kt
@@ -577,8 +577,8 @@ val KB_DE_THUMBKEY_SHIFTED =
                                 ),
                             SwipeDirection.LEFT to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("ß"),
-                                    action = KeyAction.CommitText("ß"),
+                                    display = KeyDisplay.TextDisplay("ẞ"),
+                                    action = KeyAction.CommitText("ẞ"),
                                 ),
                         ),
                 ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbKeyMultiLingual.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbKeyMultiLingual.kt
@@ -846,8 +846,8 @@ val KB_DE_THUMBKEY_MULTILINGUAL_SHIFTED =
                                 ),
                             SwipeDirection.LEFT to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("ß"),
-                                    action = KeyAction.CommitText("ß"),
+                                    display = KeyDisplay.TextDisplay("ẞ"),
+                                    action = KeyAction.CommitText("ẞ"),
                                 ),
                         ),
                 ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbkeySymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbkeySymbols.kt
@@ -415,7 +415,7 @@ val KB_DE_THUMBKEY_SYMBOLS_MAIN =
                             SwipeDirection.LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("ß"),
-                                    action = KeyAction.CommitText("ß,"),
+                                    action = KeyAction.CommitText("ß"),
                                     color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.BOTTOM_LEFT to

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbkeySymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbkeySymbols.kt
@@ -415,7 +415,7 @@ val KB_DE_THUMBKEY_SYMBOLS_MAIN =
                             SwipeDirection.LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("ß"),
-                                    action = KeyAction.CommitText("ß"),
+                                    action = KeyAction.CommitText("ß,"),
                                     color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.BOTTOM_LEFT to


### PR DESCRIPTION
1. Implemented own suggestion from https://github.com/dessalines/thumb-key/issues/1027
2. changed ß (small) to ẞ (big) in shifted layers of all german keyboards
yes, there is a big version of the letter https://de.wikipedia.org/wiki/Gro%C3%9Fes_%C3%9F

Fixes https://github.com/dessalines/thumb-key/issues/1027