### PR TITLE
add hyphen `-` to the first layer of FRThumbKeyV2.kt

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FRThumbKeyV2.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FRThumbKeyV2.kt
@@ -141,7 +141,13 @@ val KB_FR_THUMBKEY_V2_MAIN =
                             color = ColorVariant.PRIMARY,
                         ),
                     swipes =
-                        mapOf(
+                        mapOf(                            
+                                SwipeDirection.LEFT to
+                                    KeyC(
+                                        display = KeyDisplay.TextDisplay("-"),
+                                        action = KeyAction.CommitText("-"),
+                                        color = ColorVariant.MUTED,
+                                    ),
                             SwipeDirection.RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("v"),
@@ -504,6 +510,12 @@ val KB_FR_THUMBKEY_V2_SHIFTED =
                         ),
                     swipes =
                         mapOf(
+                            SwipeDirection.LEFT to
+                                    KeyC(
+                                        display = KeyDisplay.TextDisplay("-"),
+                                        action = KeyAction.CommitText("-"),
+                                        color = ColorVariant.MUTED,
+                                    ),
                             SwipeDirection.RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("V"),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FRThumbKeyV2.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FRThumbKeyV2.kt
@@ -141,13 +141,13 @@ val KB_FR_THUMBKEY_V2_MAIN =
                             color = ColorVariant.PRIMARY,
                         ),
                     swipes =
-                        mapOf(                            
-                                SwipeDirection.LEFT to
-                                    KeyC(
-                                        display = KeyDisplay.TextDisplay("-"),
-                                        action = KeyAction.CommitText("-"),
-                                        color = ColorVariant.MUTED,
-                                    ),
+                        mapOf(
+                            SwipeDirection.LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("-"),
+                                    action = KeyAction.CommitText("-"),
+                                    color = ColorVariant.MUTED,
+                                ),
                             SwipeDirection.RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("v"),
@@ -511,11 +511,11 @@ val KB_FR_THUMBKEY_V2_SHIFTED =
                     swipes =
                         mapOf(
                             SwipeDirection.LEFT to
-                                    KeyC(
-                                        display = KeyDisplay.TextDisplay("-"),
-                                        action = KeyAction.CommitText("-"),
-                                        color = ColorVariant.MUTED,
-                                    ),
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("-"),
+                                    action = KeyAction.CommitText("-"),
+                                    color = ColorVariant.MUTED,
+                                ),
                             SwipeDirection.RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("V"),


### PR DESCRIPTION
Trait d'union - Hyphen is a common character in french:

grand-mère, couvre-lit, quatre-vingts
Jean-Luc, Marie-Lise
c'est-à-dire, vis-à-vis

etc...
so it makes sense to have it on the first layer, as all the other french layers does.