### PR TITLE
Added ES thumb-key symbols layout

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ESThumbKeySymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ESThumbKeySymbols.kt
@@ -23,442 +23,442 @@ val KB_ES_THUMBKEY_SYMBOLS_MAIN =
             listOf(
                 KeyItemC(
                     center =
-                    KeyC(
-                        display = KeyDisplay.TextDisplay("n"),
-                        action = KeyAction.CommitText("n"),
-                        size = FontSizeVariant.LARGE,
-                        color = ColorVariant.PRIMARY,
-                    ),
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("n"),
+                            action = KeyAction.CommitText("n"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
                     swipes =
-                    mapOf(
-                        SwipeDirection.TOP_RIGHT to
+                        mapOf(
+                            SwipeDirection.TOP_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("ª"),
                                     action = KeyAction.CommitText("ª"),
                                 ),
-                        SwipeDirection.LEFT to
+                            SwipeDirection.LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("ñ"),
                                     action = KeyAction.CommitText("ñ"),
                                 ),
-                        SwipeDirection.BOTTOM_LEFT to
+                            SwipeDirection.BOTTOM_LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("$"),
                                     action = KeyAction.CommitText("$"),
                                 ),
-                        SwipeDirection.BOTTOM_RIGHT to
+                            SwipeDirection.BOTTOM_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("b"),
                                     action = KeyAction.CommitText("b"),
                                 ),
-                    ),
+                        ),
                 ),
                 KeyItemC(
                     center =
-                    KeyC(
-                        display = KeyDisplay.TextDisplay("l"),
-                        action = KeyAction.CommitText("l"),
-                        size = FontSizeVariant.LARGE,
-                        color = ColorVariant.PRIMARY,
-                    ),
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("l"),
+                            action = KeyAction.CommitText("l"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
                     swipeType = SwipeNWay.FOUR_WAY_CROSS,
                     swipes =
-                    mapOf(
-                        SwipeDirection.TOP_LEFT to
+                        mapOf(
+                            SwipeDirection.TOP_LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("`"),
                                     action = KeyAction.CommitText("`"),
                                 ),
-                        SwipeDirection.TOP to
+                            SwipeDirection.TOP to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("^"),
                                     action = KeyAction.CommitText("^"),
                                 ),
-                        SwipeDirection.TOP_RIGHT to
+                            SwipeDirection.TOP_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("´"),
                                     action = KeyAction.CommitText("´"),
                                 ),
-                        SwipeDirection.LEFT to
+                            SwipeDirection.LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("+"),
                                     action = KeyAction.CommitText("+"),
                                 ),
-                        SwipeDirection.RIGHT to
+                            SwipeDirection.RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("!"),
                                     action = KeyAction.CommitText("!"),
                                 ),
-                        SwipeDirection.BOTTOM_LEFT to
+                            SwipeDirection.BOTTOM_LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("/"),
                                     action = KeyAction.CommitText("/"),
                                 ),
-                        SwipeDirection.BOTTOM to
+                            SwipeDirection.BOTTOM to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("v"),
                                     action = KeyAction.CommitText("v"),
                                 ),
-                        SwipeDirection.BOTTOM_RIGHT to
+                            SwipeDirection.BOTTOM_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("\\"),
                                     action = KeyAction.CommitText("\\"),
                                 ),
-                    ),
+                        ),
                 ),
                 KeyItemC(
                     center =
-                    KeyC(
-                        display = KeyDisplay.TextDisplay("o"),
-                        action = KeyAction.CommitText("o"),
-                        size = FontSizeVariant.LARGE,
-                        color = ColorVariant.PRIMARY,
-                    ),
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("o"),
+                            action = KeyAction.CommitText("o"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
                     swipes =
-                    mapOf(
-                        SwipeDirection.TOP_RIGHT to
+                        mapOf(
+                            SwipeDirection.TOP_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("€"),
                                     action = KeyAction.CommitText("€"),
                                 ),
-                        SwipeDirection.TOP to
+                            SwipeDirection.TOP to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("="),
                                     action = KeyAction.CommitText("="),
                                 ),
-                        SwipeDirection.TOP_LEFT to
+                            SwipeDirection.TOP_LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("£"),
                                     action = KeyAction.CommitText("£"),
                                 ),
-                        SwipeDirection.LEFT to
+                            SwipeDirection.LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("?"),
                                     action = KeyAction.CommitText("?"),
                                 ),
-                        SwipeDirection.RIGHT to
+                            SwipeDirection.RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("ó"),
                                     action = KeyAction.CommitText("ó"),
                                 ),
-                        SwipeDirection.BOTTOM_LEFT to
+                            SwipeDirection.BOTTOM_LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("u"),
                                     action = KeyAction.CommitText("u"),
                                 ),
-                        SwipeDirection.BOTTOM to
+                            SwipeDirection.BOTTOM to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("ü"),
                                     action = KeyAction.CommitText("ü"),
                                 ),
-                        SwipeDirection.BOTTOM_RIGHT to
+                            SwipeDirection.BOTTOM_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("ú"),
                                     action = KeyAction.CommitText("ú"),
                                 ),
-                    ),
+                        ),
                 ),
                 EMOJI_KEY_ITEM,
             ),
             listOf(
                 KeyItemC(
                     center =
-                    KeyC(
-                        display = KeyDisplay.TextDisplay("r"),
-                        action = KeyAction.CommitText("r"),
-                        size = FontSizeVariant.LARGE,
-                        color = ColorVariant.PRIMARY,
-                    ),
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("r"),
+                            action = KeyAction.CommitText("r"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
                     swipeType = SwipeNWay.TWO_WAY_HORIZONTAL,
                     swipes =
-                    mapOf(
-                        SwipeDirection.TOP_LEFT to
+                        mapOf(
+                            SwipeDirection.TOP_LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("{"),
                                     action = KeyAction.CommitText("{"),
                                 ),
-                        SwipeDirection.TOP_RIGHT to
+                            SwipeDirection.TOP_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("%"),
                                     action = KeyAction.CommitText("%"),
                                 ),
-                        SwipeDirection.RIGHT to
+                            SwipeDirection.RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("p"),
                                     action = KeyAction.CommitText("p"),
                                 ),
-                        SwipeDirection.BOTTOM_LEFT to
+                            SwipeDirection.BOTTOM_LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("["),
                                     action = KeyAction.CommitText("["),
                                 ),
-                        SwipeDirection.BOTTOM to
+                            SwipeDirection.BOTTOM to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("("),
                                     action = KeyAction.CommitText("("),
                                 ),
-                        SwipeDirection.BOTTOM_RIGHT to
+                            SwipeDirection.BOTTOM_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("_"),
                                     action = KeyAction.CommitText("_"),
                                 ),
-                    ),
+                        ),
                 ),
                 KeyItemC(
                     center =
-                    KeyC(
-                        display = KeyDisplay.TextDisplay("d"),
-                        action = KeyAction.CommitText("d"),
-                        size = FontSizeVariant.LARGE,
-                        color = ColorVariant.PRIMARY,
-                    ),
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("d"),
+                            action = KeyAction.CommitText("d"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
                     swipes =
-                    mapOf(
-                        SwipeDirection.TOP_LEFT to
+                        mapOf(
+                            SwipeDirection.TOP_LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("j"),
                                     action = KeyAction.CommitText("j"),
                                 ),
-                        SwipeDirection.TOP to
+                            SwipeDirection.TOP to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("k"),
                                     action = KeyAction.CommitText("k"),
                                 ),
-                        SwipeDirection.TOP_RIGHT to
+                            SwipeDirection.TOP_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("h"),
                                     action = KeyAction.CommitText("h"),
                                 ),
-                        SwipeDirection.LEFT to
+                            SwipeDirection.LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("z"),
                                     action = KeyAction.CommitText("z"),
                                 ),
-                        SwipeDirection.RIGHT to
+                            SwipeDirection.RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("q"),
                                     action = KeyAction.CommitText("q"),
                                 ),
-                        SwipeDirection.BOTTOM_LEFT to
+                            SwipeDirection.BOTTOM_LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("f"),
                                     action = KeyAction.CommitText("f"),
                                 ),
-                        SwipeDirection.BOTTOM to
+                            SwipeDirection.BOTTOM to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("x"),
                                     action = KeyAction.CommitText("x"),
                                 ),
-                        SwipeDirection.BOTTOM_RIGHT to
+                            SwipeDirection.BOTTOM_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("y"),
                                     action = KeyAction.CommitText("y"),
                                 ),
-                    ),
+                        ),
                 ),
                 KeyItemC(
                     center =
-                    KeyC(
-                        display = KeyDisplay.TextDisplay("a"),
-                        action = KeyAction.CommitText("a"),
-                        size = FontSizeVariant.LARGE,
-                        color = ColorVariant.PRIMARY,
-                    ),
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("a"),
+                            action = KeyAction.CommitText("a"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
                     swipeType = SwipeNWay.FOUR_WAY_CROSS,
                     swipes =
-                    mapOf(
-                        SwipeDirection.TOP_LEFT to
+                        mapOf(
+                            SwipeDirection.TOP_LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("|"),
                                     action = KeyAction.CommitText("|"),
                                 ),
-                        SwipeDirection.TOP to
+                            SwipeDirection.TOP to
                                 KeyC(
                                     display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
                                     action = KeyAction.ToggleShiftMode(true),
                                     swipeReturnAction = KeyAction.ToggleCurrentWordCapitalization(true),
                                     color = ColorVariant.MUTED,
                                 ),
-                        SwipeDirection.TOP_RIGHT to
+                            SwipeDirection.TOP_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("}"),
                                     action = KeyAction.CommitText("}"),
                                 ),
-                        SwipeDirection.LEFT to
+                            SwipeDirection.LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("t"),
                                     action = KeyAction.CommitText("t"),
                                 ),
-                        SwipeDirection.RIGHT to
+                            SwipeDirection.RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("á"),
                                     action = KeyAction.CommitText("á"),
                                 ),
-                        SwipeDirection.BOTTOM_LEFT to
+                            SwipeDirection.BOTTOM_LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("@"),
                                     action = KeyAction.CommitText("@"),
                                 ),
-                        SwipeDirection.BOTTOM to
+                            SwipeDirection.BOTTOM to
                                 KeyC(
                                     action = KeyAction.ToggleShiftMode(false),
                                     swipeReturnAction = KeyAction.ToggleCurrentWordCapitalization(false),
                                 ),
-                        SwipeDirection.BOTTOM to
+                            SwipeDirection.BOTTOM to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay(")"),
                                     action = KeyAction.CommitText(")"),
                                 ),
-                        SwipeDirection.BOTTOM_RIGHT to
+                            SwipeDirection.BOTTOM_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("]"),
                                     action = KeyAction.CommitText("]"),
                                 ),
-                    ),
+                        ),
                 ),
                 NUMERIC_KEY_ITEM,
             ),
             listOf(
                 KeyItemC(
                     center =
-                    KeyC(
-                        display = KeyDisplay.TextDisplay("s"),
-                        action = KeyAction.CommitText("s"),
-                        size = FontSizeVariant.LARGE,
-                        color = ColorVariant.PRIMARY,
-                    ),
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("s"),
+                            action = KeyAction.CommitText("s"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
                     swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
                     swipes =
-                    mapOf(
-                        SwipeDirection.TOP_LEFT to
+                        mapOf(
+                            SwipeDirection.TOP_LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("~"),
                                     action = KeyAction.CommitText("~"),
                                 ),
-                        SwipeDirection.TOP_RIGHT to
+                            SwipeDirection.TOP_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("m"),
                                     action = KeyAction.CommitText("m"),
                                 ),
-                        SwipeDirection.BOTTOM_LEFT to
+                            SwipeDirection.BOTTOM_LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("<"),
                                     action = KeyAction.CommitText("<"),
                                 ),
-                        SwipeDirection.BOTTOM_RIGHT to
+                            SwipeDirection.BOTTOM_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay(":"),
                                     action = KeyAction.CommitText(":"),
                                 ),
-                    ),
+                        ),
                 ),
                 KeyItemC(
                     center =
-                    KeyC(
-                        display = KeyDisplay.TextDisplay("i"),
-                        action = KeyAction.CommitText("i"),
-                        size = FontSizeVariant.LARGE,
-                        color = ColorVariant.PRIMARY,
-                    ),
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("i"),
+                            action = KeyAction.CommitText("i"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
                     swipes =
-                    mapOf(
-                        SwipeDirection.TOP_LEFT to
+                        mapOf(
+                            SwipeDirection.TOP_LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("\""),
                                     action = KeyAction.CommitText("\""),
                                 ),
-                        SwipeDirection.TOP to
+                            SwipeDirection.TOP to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("g"),
                                     action = KeyAction.CommitText("g"),
                                 ),
-                        SwipeDirection.TOP_RIGHT to
+                            SwipeDirection.TOP_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("'"),
                                     action = KeyAction.CommitText("'"),
                                     color = ColorVariant.MUTED,
                                 ),
-                        SwipeDirection.LEFT to
+                            SwipeDirection.LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("w"),
                                     action = KeyAction.CommitText("w"),
                                 ),
-                        SwipeDirection.RIGHT to
+                            SwipeDirection.RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("í"),
                                     action = KeyAction.CommitText("í"),
                                 ),
-                        SwipeDirection.BOTTOM to
+                            SwipeDirection.BOTTOM to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("."),
                                     action = KeyAction.CommitText("."),
                                     color = ColorVariant.MUTED,
                                 ),
-                        SwipeDirection.BOTTOM_LEFT to
+                            SwipeDirection.BOTTOM_LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("*"),
                                     action = KeyAction.CommitText("*"),
                                     color = ColorVariant.MUTED,
                                 ),
-                        SwipeDirection.BOTTOM_RIGHT to
+                            SwipeDirection.BOTTOM_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("-"),
                                     action = KeyAction.CommitText("-"),
                                     color = ColorVariant.MUTED,
                                 ),
-                    ),
+                        ),
                 ),
                 KeyItemC(
                     center =
-                    KeyC(
-                        display = KeyDisplay.TextDisplay("e"),
-                        action = KeyAction.CommitText("e"),
-                        size = FontSizeVariant.LARGE,
-                        color = ColorVariant.PRIMARY,
-                    ),
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("e"),
+                            action = KeyAction.CommitText("e"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
                     swipes =
-                    mapOf(
-                        SwipeDirection.TOP_LEFT to
+                        mapOf(
+                            SwipeDirection.TOP_LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("c"),
                                     action = KeyAction.CommitText("c"),
                                 ),
-                        SwipeDirection.TOP to
+                            SwipeDirection.TOP to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("&"),
                                     action = KeyAction.CommitText("&"),
                                 ),
-                        SwipeDirection.TOP_RIGHT to
+                            SwipeDirection.TOP_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("°"),
                                     action = KeyAction.CommitText("°"),
                                 ),
-                        SwipeDirection.LEFT to
+                            SwipeDirection.LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("#"),
                                     action = KeyAction.CommitText("#"),
                                 ),
-                        SwipeDirection.RIGHT to
+                            SwipeDirection.RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("é"),
                                     action = KeyAction.CommitText("é"),
                                 ),
-                        SwipeDirection.BOTTOM_LEFT to
+                            SwipeDirection.BOTTOM_LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay(";"),
                                     action = KeyAction.CommitText(";"),
                                 ),
-                        SwipeDirection.BOTTOM to
+                            SwipeDirection.BOTTOM to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay(","),
                                     action = KeyAction.CommitText(","),
                                 ),
-                        SwipeDirection.BOTTOM_RIGHT to
+                            SwipeDirection.BOTTOM_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay(">"),
                                     action = KeyAction.CommitText(">"),
                                 ),
-                    ),
+                        ),
                 ),
                 BACKSPACE_KEY_ITEM,
             ),
@@ -475,173 +475,173 @@ val KB_ES_THUMBKEY_SYMBOLS_SHIFTED =
             listOf(
                 KeyItemC(
                     center =
-                    KeyC(
-                        display = KeyDisplay.TextDisplay("N"),
-                        action = KeyAction.CommitText("N"),
-                        size = FontSizeVariant.LARGE,
-                        color = ColorVariant.PRIMARY,
-                    ),
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("N"),
+                            action = KeyAction.CommitText("N"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
                     swipes =
-                    mapOf(
-                        SwipeDirection.LEFT to
+                        mapOf(
+                            SwipeDirection.LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("Ñ"),
                                     action = KeyAction.CommitText("Ñ"),
                                 ),
-                        SwipeDirection.BOTTOM_RIGHT to
+                            SwipeDirection.BOTTOM_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("B"),
                                     action = KeyAction.CommitText("B"),
                                 ),
-                    ),
+                        ),
                 ),
                 KeyItemC(
                     center =
-                    KeyC(
-                        display = KeyDisplay.TextDisplay("L"),
-                        action = KeyAction.CommitText("L"),
-                        size = FontSizeVariant.LARGE,
-                        color = ColorVariant.PRIMARY,
-                    ),
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("L"),
+                            action = KeyAction.CommitText("L"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
                     swipeType = SwipeNWay.FOUR_WAY_CROSS,
                     swipes =
-                    mapOf(
-                        SwipeDirection.RIGHT to
+                        mapOf(
+                            SwipeDirection.RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("¡"),
                                     action = KeyAction.CommitText("¡"),
                                     color = ColorVariant.MUTED,
                                 ),
-                        SwipeDirection.BOTTOM to
+                            SwipeDirection.BOTTOM to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("V"),
                                     action = KeyAction.CommitText("V"),
                                 ),
-                    ),
+                        ),
                 ),
                 KeyItemC(
                     center =
-                    KeyC(
-                        display = KeyDisplay.TextDisplay("O"),
-                        action = KeyAction.CommitText("O"),
-                        size = FontSizeVariant.LARGE,
-                        color = ColorVariant.PRIMARY,
-                    ),
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("O"),
+                            action = KeyAction.CommitText("O"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
                     swipes =
-                    mapOf(
-                        SwipeDirection.LEFT to
+                        mapOf(
+                            SwipeDirection.LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("¿"),
                                     action = KeyAction.CommitText("¿"),
                                     color = ColorVariant.MUTED,
                                 ),
-                        SwipeDirection.RIGHT to
+                            SwipeDirection.RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("Ó"),
                                     action = KeyAction.CommitText("Ó"),
                                 ),
-                        SwipeDirection.BOTTOM_LEFT to
+                            SwipeDirection.BOTTOM_LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("U"),
                                     action = KeyAction.CommitText("U"),
                                 ),
-                        SwipeDirection.BOTTOM to
+                            SwipeDirection.BOTTOM to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("Ü"),
                                     action = KeyAction.CommitText("Ü"),
                                 ),
-                        SwipeDirection.BOTTOM_RIGHT to
+                            SwipeDirection.BOTTOM_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("Ú"),
                                     action = KeyAction.CommitText("Ú"),
                                 ),
-                    ),
+                        ),
                 ),
                 EMOJI_KEY_ITEM,
             ),
             listOf(
                 KeyItemC(
                     center =
-                    KeyC(
-                        display = KeyDisplay.TextDisplay("R"),
-                        action = KeyAction.CommitText("R"),
-                        size = FontSizeVariant.LARGE,
-                        color = ColorVariant.PRIMARY,
-                    ),
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("R"),
+                            action = KeyAction.CommitText("R"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
                     swipeType = SwipeNWay.TWO_WAY_HORIZONTAL,
                     swipes =
-                    mapOf(
-                        SwipeDirection.RIGHT to
+                        mapOf(
+                            SwipeDirection.RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("P"),
                                     action = KeyAction.CommitText("P"),
                                 ),
-                    ),
+                        ),
                 ),
                 KeyItemC(
                     center =
-                    KeyC(
-                        display = KeyDisplay.TextDisplay("D"),
-                        action = KeyAction.CommitText("D"),
-                        size = FontSizeVariant.LARGE,
-                        color = ColorVariant.PRIMARY,
-                    ),
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("D"),
+                            action = KeyAction.CommitText("D"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
                     swipes =
-                    mapOf(
-                        SwipeDirection.TOP_LEFT to
+                        mapOf(
+                            SwipeDirection.TOP_LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("J"),
                                     action = KeyAction.CommitText("J"),
                                 ),
-                        SwipeDirection.TOP to
+                            SwipeDirection.TOP to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("K"),
                                     action = KeyAction.CommitText("K"),
                                 ),
-                        SwipeDirection.TOP_RIGHT to
+                            SwipeDirection.TOP_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("H"),
                                     action = KeyAction.CommitText("H"),
                                 ),
-                        SwipeDirection.LEFT to
+                            SwipeDirection.LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("Z"),
                                     action = KeyAction.CommitText("Z"),
                                 ),
-                        SwipeDirection.RIGHT to
+                            SwipeDirection.RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("Q"),
                                     action = KeyAction.CommitText("Q"),
                                 ),
-                        SwipeDirection.BOTTOM_LEFT to
+                            SwipeDirection.BOTTOM_LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("F"),
                                     action = KeyAction.CommitText("F"),
                                 ),
-                        SwipeDirection.BOTTOM to
+                            SwipeDirection.BOTTOM to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("X"),
                                     action = KeyAction.CommitText("X"),
                                 ),
-                        SwipeDirection.BOTTOM_RIGHT to
+                            SwipeDirection.BOTTOM_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("Y"),
                                     action = KeyAction.CommitText("Y"),
                                 ),
-                    ),
+                        ),
                 ),
                 KeyItemC(
                     center =
-                    KeyC(
-                        display = KeyDisplay.TextDisplay("A"),
-                        action = KeyAction.CommitText("A"),
-                        size = FontSizeVariant.LARGE,
-                        color = ColorVariant.PRIMARY,
-                    ),
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("A"),
+                            action = KeyAction.CommitText("A"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
                     swipeType = SwipeNWay.FOUR_WAY_CROSS,
                     swipes =
-                    mapOf(
-                        SwipeDirection.TOP to
+                        mapOf(
+                            SwipeDirection.TOP to
                                 KeyC(
                                     display = KeyDisplay.IconDisplay(Icons.Outlined.KeyboardCapslock),
                                     capsModeDisplay = KeyDisplay.IconDisplay(Icons.Outlined.Copyright),
@@ -649,118 +649,118 @@ val KB_ES_THUMBKEY_SYMBOLS_SHIFTED =
                                     swipeReturnAction = KeyAction.ToggleCurrentWordCapitalization(true),
                                     color = ColorVariant.MUTED,
                                 ),
-                        SwipeDirection.LEFT to
+                            SwipeDirection.LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("T"),
                                     action = KeyAction.CommitText("T"),
                                 ),
-                        SwipeDirection.RIGHT to
+                            SwipeDirection.RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("Á"),
                                     action = KeyAction.CommitText("Á"),
                                 ),
-                        SwipeDirection.BOTTOM to
+                            SwipeDirection.BOTTOM to
                                 KeyC(
                                     display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
                                     action = KeyAction.ToggleShiftMode(false),
                                     swipeReturnAction = KeyAction.ToggleCurrentWordCapitalization(false),
                                     color = ColorVariant.MUTED,
                                 ),
-                    ),
+                        ),
                 ),
                 NUMERIC_KEY_ITEM,
             ),
             listOf(
                 KeyItemC(
                     center =
-                    KeyC(
-                        display = KeyDisplay.TextDisplay("S"),
-                        action = KeyAction.CommitText("S"),
-                        size = FontSizeVariant.LARGE,
-                        color = ColorVariant.PRIMARY,
-                    ),
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("S"),
+                            action = KeyAction.CommitText("S"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
                     swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
                     swipes =
-                    mapOf(
-                        SwipeDirection.TOP_RIGHT to
+                        mapOf(
+                            SwipeDirection.TOP_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("M"),
                                     action = KeyAction.CommitText("M"),
                                 ),
-                    ),
+                        ),
                 ),
                 KeyItemC(
                     center =
-                    KeyC(
-                        display = KeyDisplay.TextDisplay("I"),
-                        action = KeyAction.CommitText("I"),
-                        size = FontSizeVariant.LARGE,
-                        color = ColorVariant.PRIMARY,
-                    ),
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("I"),
+                            action = KeyAction.CommitText("I"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
                     swipes =
-                    mapOf(
-                        SwipeDirection.TOP to
+                        mapOf(
+                            SwipeDirection.TOP to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("G"),
                                     action = KeyAction.CommitText("G"),
                                 ),
-                        SwipeDirection.TOP_RIGHT to
+                            SwipeDirection.TOP_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("'"),
                                     action = KeyAction.CommitText("'"),
                                     color = ColorVariant.MUTED,
                                 ),
-                        SwipeDirection.LEFT to
+                            SwipeDirection.LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("W"),
                                     action = KeyAction.CommitText("W"),
                                 ),
-                        SwipeDirection.RIGHT to
+                            SwipeDirection.RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("Í"),
                                     action = KeyAction.CommitText("Í"),
                                 ),
-                        SwipeDirection.BOTTOM_LEFT to
+                            SwipeDirection.BOTTOM_LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("*"),
                                     action = KeyAction.CommitText("*"),
                                     color = ColorVariant.MUTED,
                                 ),
-                        SwipeDirection.BOTTOM to
+                            SwipeDirection.BOTTOM to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("."),
                                     action = KeyAction.CommitText("."),
                                     color = ColorVariant.MUTED,
                                 ),
-                        SwipeDirection.BOTTOM_RIGHT to
+                            SwipeDirection.BOTTOM_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("-"),
                                     action = KeyAction.CommitText("-"),
                                     color = ColorVariant.MUTED,
                                 ),
-                    ),
+                        ),
                 ),
                 KeyItemC(
                     center =
-                    KeyC(
-                        display = KeyDisplay.TextDisplay("E"),
-                        action = KeyAction.CommitText("E"),
-                        size = FontSizeVariant.LARGE,
-                        color = ColorVariant.PRIMARY,
-                    ),
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("E"),
+                            action = KeyAction.CommitText("E"),
+                            size = FontSizeVariant.LARGE,
+                            color = ColorVariant.PRIMARY,
+                        ),
                     swipes =
-                    mapOf(
-                        SwipeDirection.TOP_LEFT to
+                        mapOf(
+                            SwipeDirection.TOP_LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("C"),
                                     action = KeyAction.CommitText("C"),
                                 ),
-                        SwipeDirection.RIGHT to
+                            SwipeDirection.RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("É"),
                                     action = KeyAction.CommitText("É"),
                                 ),
-                    ),
+                        ),
                 ),
                 BACKSPACE_KEY_ITEM,
             ),
@@ -775,9 +775,9 @@ val KB_ES_THUMBKEY_SYMBOLS: KeyboardDefinition =
     KeyboardDefinition(
         title = "español thumb-key symbols",
         modes =
-        KeyboardDefinitionModes(
-            main = KB_ES_THUMBKEY_SYMBOLS_MAIN,
-            shifted = KB_ES_THUMBKEY_SYMBOLS_SHIFTED,
-            numeric = NUMERIC_KEYBOARD,
-        ),
+            KeyboardDefinitionModes(
+                main = KB_ES_THUMBKEY_SYMBOLS_MAIN,
+                shifted = KB_ES_THUMBKEY_SYMBOLS_SHIFTED,
+                numeric = NUMERIC_KEYBOARD,
+            ),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ESThumbKeySymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ESThumbKeySymbols.kt
@@ -1,0 +1,783 @@
+package com.dessalines.thumbkey.keyboards
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowDropDown
+import androidx.compose.material.icons.outlined.ArrowDropUp
+import androidx.compose.material.icons.outlined.Copyright
+import androidx.compose.material.icons.outlined.KeyboardCapslock
+import com.dessalines.thumbkey.utils.ColorVariant
+import com.dessalines.thumbkey.utils.FontSizeVariant
+import com.dessalines.thumbkey.utils.KeyAction
+import com.dessalines.thumbkey.utils.KeyC
+import com.dessalines.thumbkey.utils.KeyDisplay
+import com.dessalines.thumbkey.utils.KeyItemC
+import com.dessalines.thumbkey.utils.KeyboardC
+import com.dessalines.thumbkey.utils.KeyboardDefinition
+import com.dessalines.thumbkey.utils.KeyboardDefinitionModes
+import com.dessalines.thumbkey.utils.SwipeDirection
+import com.dessalines.thumbkey.utils.SwipeNWay
+
+val KB_ES_THUMBKEY_SYMBOLS_MAIN =
+    KeyboardC(
+        listOf(
+            listOf(
+                KeyItemC(
+                    center =
+                    KeyC(
+                        display = KeyDisplay.TextDisplay("n"),
+                        action = KeyAction.CommitText("n"),
+                        size = FontSizeVariant.LARGE,
+                        color = ColorVariant.PRIMARY,
+                    ),
+                    swipes =
+                    mapOf(
+                        SwipeDirection.TOP_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("ª"),
+                                    action = KeyAction.CommitText("ª"),
+                                ),
+                        SwipeDirection.LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("ñ"),
+                                    action = KeyAction.CommitText("ñ"),
+                                ),
+                        SwipeDirection.BOTTOM_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("$"),
+                                    action = KeyAction.CommitText("$"),
+                                ),
+                        SwipeDirection.BOTTOM_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("b"),
+                                    action = KeyAction.CommitText("b"),
+                                ),
+                    ),
+                ),
+                KeyItemC(
+                    center =
+                    KeyC(
+                        display = KeyDisplay.TextDisplay("l"),
+                        action = KeyAction.CommitText("l"),
+                        size = FontSizeVariant.LARGE,
+                        color = ColorVariant.PRIMARY,
+                    ),
+                    swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                    swipes =
+                    mapOf(
+                        SwipeDirection.TOP_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("`"),
+                                    action = KeyAction.CommitText("`"),
+                                ),
+                        SwipeDirection.TOP to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("^"),
+                                    action = KeyAction.CommitText("^"),
+                                ),
+                        SwipeDirection.TOP_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("´"),
+                                    action = KeyAction.CommitText("´"),
+                                ),
+                        SwipeDirection.LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("+"),
+                                    action = KeyAction.CommitText("+"),
+                                ),
+                        SwipeDirection.RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("!"),
+                                    action = KeyAction.CommitText("!"),
+                                ),
+                        SwipeDirection.BOTTOM_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("/"),
+                                    action = KeyAction.CommitText("/"),
+                                ),
+                        SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("v"),
+                                    action = KeyAction.CommitText("v"),
+                                ),
+                        SwipeDirection.BOTTOM_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("\\"),
+                                    action = KeyAction.CommitText("\\"),
+                                ),
+                    ),
+                ),
+                KeyItemC(
+                    center =
+                    KeyC(
+                        display = KeyDisplay.TextDisplay("o"),
+                        action = KeyAction.CommitText("o"),
+                        size = FontSizeVariant.LARGE,
+                        color = ColorVariant.PRIMARY,
+                    ),
+                    swipes =
+                    mapOf(
+                        SwipeDirection.TOP_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("€"),
+                                    action = KeyAction.CommitText("€"),
+                                ),
+                        SwipeDirection.TOP to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("="),
+                                    action = KeyAction.CommitText("="),
+                                ),
+                        SwipeDirection.TOP_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("£"),
+                                    action = KeyAction.CommitText("£"),
+                                ),
+                        SwipeDirection.LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("?"),
+                                    action = KeyAction.CommitText("?"),
+                                ),
+                        SwipeDirection.RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("ó"),
+                                    action = KeyAction.CommitText("ó"),
+                                ),
+                        SwipeDirection.BOTTOM_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("u"),
+                                    action = KeyAction.CommitText("u"),
+                                ),
+                        SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("ü"),
+                                    action = KeyAction.CommitText("ü"),
+                                ),
+                        SwipeDirection.BOTTOM_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("ú"),
+                                    action = KeyAction.CommitText("ú"),
+                                ),
+                    ),
+                ),
+                EMOJI_KEY_ITEM,
+            ),
+            listOf(
+                KeyItemC(
+                    center =
+                    KeyC(
+                        display = KeyDisplay.TextDisplay("r"),
+                        action = KeyAction.CommitText("r"),
+                        size = FontSizeVariant.LARGE,
+                        color = ColorVariant.PRIMARY,
+                    ),
+                    swipeType = SwipeNWay.TWO_WAY_HORIZONTAL,
+                    swipes =
+                    mapOf(
+                        SwipeDirection.TOP_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("{"),
+                                    action = KeyAction.CommitText("{"),
+                                ),
+                        SwipeDirection.TOP_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("%"),
+                                    action = KeyAction.CommitText("%"),
+                                ),
+                        SwipeDirection.RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("p"),
+                                    action = KeyAction.CommitText("p"),
+                                ),
+                        SwipeDirection.BOTTOM_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("["),
+                                    action = KeyAction.CommitText("["),
+                                ),
+                        SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("("),
+                                    action = KeyAction.CommitText("("),
+                                ),
+                        SwipeDirection.BOTTOM_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("_"),
+                                    action = KeyAction.CommitText("_"),
+                                ),
+                    ),
+                ),
+                KeyItemC(
+                    center =
+                    KeyC(
+                        display = KeyDisplay.TextDisplay("d"),
+                        action = KeyAction.CommitText("d"),
+                        size = FontSizeVariant.LARGE,
+                        color = ColorVariant.PRIMARY,
+                    ),
+                    swipes =
+                    mapOf(
+                        SwipeDirection.TOP_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("j"),
+                                    action = KeyAction.CommitText("j"),
+                                ),
+                        SwipeDirection.TOP to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("k"),
+                                    action = KeyAction.CommitText("k"),
+                                ),
+                        SwipeDirection.TOP_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("h"),
+                                    action = KeyAction.CommitText("h"),
+                                ),
+                        SwipeDirection.LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("z"),
+                                    action = KeyAction.CommitText("z"),
+                                ),
+                        SwipeDirection.RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("q"),
+                                    action = KeyAction.CommitText("q"),
+                                ),
+                        SwipeDirection.BOTTOM_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("f"),
+                                    action = KeyAction.CommitText("f"),
+                                ),
+                        SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("x"),
+                                    action = KeyAction.CommitText("x"),
+                                ),
+                        SwipeDirection.BOTTOM_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("y"),
+                                    action = KeyAction.CommitText("y"),
+                                ),
+                    ),
+                ),
+                KeyItemC(
+                    center =
+                    KeyC(
+                        display = KeyDisplay.TextDisplay("a"),
+                        action = KeyAction.CommitText("a"),
+                        size = FontSizeVariant.LARGE,
+                        color = ColorVariant.PRIMARY,
+                    ),
+                    swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                    swipes =
+                    mapOf(
+                        SwipeDirection.TOP_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("|"),
+                                    action = KeyAction.CommitText("|"),
+                                ),
+                        SwipeDirection.TOP to
+                                KeyC(
+                                    display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
+                                    action = KeyAction.ToggleShiftMode(true),
+                                    swipeReturnAction = KeyAction.ToggleCurrentWordCapitalization(true),
+                                    color = ColorVariant.MUTED,
+                                ),
+                        SwipeDirection.TOP_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("}"),
+                                    action = KeyAction.CommitText("}"),
+                                ),
+                        SwipeDirection.LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("t"),
+                                    action = KeyAction.CommitText("t"),
+                                ),
+                        SwipeDirection.RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("á"),
+                                    action = KeyAction.CommitText("á"),
+                                ),
+                        SwipeDirection.BOTTOM_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("@"),
+                                    action = KeyAction.CommitText("@"),
+                                ),
+                        SwipeDirection.BOTTOM to
+                                KeyC(
+                                    action = KeyAction.ToggleShiftMode(false),
+                                    swipeReturnAction = KeyAction.ToggleCurrentWordCapitalization(false),
+                                ),
+                        SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay(")"),
+                                    action = KeyAction.CommitText(")"),
+                                ),
+                        SwipeDirection.BOTTOM_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("]"),
+                                    action = KeyAction.CommitText("]"),
+                                ),
+                    ),
+                ),
+                NUMERIC_KEY_ITEM,
+            ),
+            listOf(
+                KeyItemC(
+                    center =
+                    KeyC(
+                        display = KeyDisplay.TextDisplay("s"),
+                        action = KeyAction.CommitText("s"),
+                        size = FontSizeVariant.LARGE,
+                        color = ColorVariant.PRIMARY,
+                    ),
+                    swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
+                    swipes =
+                    mapOf(
+                        SwipeDirection.TOP_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("~"),
+                                    action = KeyAction.CommitText("~"),
+                                ),
+                        SwipeDirection.TOP_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("m"),
+                                    action = KeyAction.CommitText("m"),
+                                ),
+                        SwipeDirection.BOTTOM_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("<"),
+                                    action = KeyAction.CommitText("<"),
+                                ),
+                        SwipeDirection.BOTTOM_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay(":"),
+                                    action = KeyAction.CommitText(":"),
+                                ),
+                    ),
+                ),
+                KeyItemC(
+                    center =
+                    KeyC(
+                        display = KeyDisplay.TextDisplay("i"),
+                        action = KeyAction.CommitText("i"),
+                        size = FontSizeVariant.LARGE,
+                        color = ColorVariant.PRIMARY,
+                    ),
+                    swipes =
+                    mapOf(
+                        SwipeDirection.TOP_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("\""),
+                                    action = KeyAction.CommitText("\""),
+                                ),
+                        SwipeDirection.TOP to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("g"),
+                                    action = KeyAction.CommitText("g"),
+                                ),
+                        SwipeDirection.TOP_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("'"),
+                                    action = KeyAction.CommitText("'"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                        SwipeDirection.LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("w"),
+                                    action = KeyAction.CommitText("w"),
+                                ),
+                        SwipeDirection.RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("í"),
+                                    action = KeyAction.CommitText("í"),
+                                ),
+                        SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("."),
+                                    action = KeyAction.CommitText("."),
+                                    color = ColorVariant.MUTED,
+                                ),
+                        SwipeDirection.BOTTOM_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("*"),
+                                    action = KeyAction.CommitText("*"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                        SwipeDirection.BOTTOM_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("-"),
+                                    action = KeyAction.CommitText("-"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                    ),
+                ),
+                KeyItemC(
+                    center =
+                    KeyC(
+                        display = KeyDisplay.TextDisplay("e"),
+                        action = KeyAction.CommitText("e"),
+                        size = FontSizeVariant.LARGE,
+                        color = ColorVariant.PRIMARY,
+                    ),
+                    swipes =
+                    mapOf(
+                        SwipeDirection.TOP_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("c"),
+                                    action = KeyAction.CommitText("c"),
+                                ),
+                        SwipeDirection.TOP to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("&"),
+                                    action = KeyAction.CommitText("&"),
+                                ),
+                        SwipeDirection.TOP_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("°"),
+                                    action = KeyAction.CommitText("°"),
+                                ),
+                        SwipeDirection.LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("#"),
+                                    action = KeyAction.CommitText("#"),
+                                ),
+                        SwipeDirection.RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("é"),
+                                    action = KeyAction.CommitText("é"),
+                                ),
+                        SwipeDirection.BOTTOM_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay(";"),
+                                    action = KeyAction.CommitText(";"),
+                                ),
+                        SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay(","),
+                                    action = KeyAction.CommitText(","),
+                                ),
+                        SwipeDirection.BOTTOM_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay(">"),
+                                    action = KeyAction.CommitText(">"),
+                                ),
+                    ),
+                ),
+                BACKSPACE_KEY_ITEM,
+            ),
+            listOf(
+                SPACEBAR_KEY_ITEM,
+                RETURN_KEY_ITEM,
+            ),
+        ),
+    )
+
+val KB_ES_THUMBKEY_SYMBOLS_SHIFTED =
+    KeyboardC(
+        listOf(
+            listOf(
+                KeyItemC(
+                    center =
+                    KeyC(
+                        display = KeyDisplay.TextDisplay("N"),
+                        action = KeyAction.CommitText("N"),
+                        size = FontSizeVariant.LARGE,
+                        color = ColorVariant.PRIMARY,
+                    ),
+                    swipes =
+                    mapOf(
+                        SwipeDirection.LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("Ñ"),
+                                    action = KeyAction.CommitText("Ñ"),
+                                ),
+                        SwipeDirection.BOTTOM_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("B"),
+                                    action = KeyAction.CommitText("B"),
+                                ),
+                    ),
+                ),
+                KeyItemC(
+                    center =
+                    KeyC(
+                        display = KeyDisplay.TextDisplay("L"),
+                        action = KeyAction.CommitText("L"),
+                        size = FontSizeVariant.LARGE,
+                        color = ColorVariant.PRIMARY,
+                    ),
+                    swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                    swipes =
+                    mapOf(
+                        SwipeDirection.RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("¡"),
+                                    action = KeyAction.CommitText("¡"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                        SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("V"),
+                                    action = KeyAction.CommitText("V"),
+                                ),
+                    ),
+                ),
+                KeyItemC(
+                    center =
+                    KeyC(
+                        display = KeyDisplay.TextDisplay("O"),
+                        action = KeyAction.CommitText("O"),
+                        size = FontSizeVariant.LARGE,
+                        color = ColorVariant.PRIMARY,
+                    ),
+                    swipes =
+                    mapOf(
+                        SwipeDirection.LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("¿"),
+                                    action = KeyAction.CommitText("¿"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                        SwipeDirection.RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("Ó"),
+                                    action = KeyAction.CommitText("Ó"),
+                                ),
+                        SwipeDirection.BOTTOM_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("U"),
+                                    action = KeyAction.CommitText("U"),
+                                ),
+                        SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("Ü"),
+                                    action = KeyAction.CommitText("Ü"),
+                                ),
+                        SwipeDirection.BOTTOM_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("Ú"),
+                                    action = KeyAction.CommitText("Ú"),
+                                ),
+                    ),
+                ),
+                EMOJI_KEY_ITEM,
+            ),
+            listOf(
+                KeyItemC(
+                    center =
+                    KeyC(
+                        display = KeyDisplay.TextDisplay("R"),
+                        action = KeyAction.CommitText("R"),
+                        size = FontSizeVariant.LARGE,
+                        color = ColorVariant.PRIMARY,
+                    ),
+                    swipeType = SwipeNWay.TWO_WAY_HORIZONTAL,
+                    swipes =
+                    mapOf(
+                        SwipeDirection.RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("P"),
+                                    action = KeyAction.CommitText("P"),
+                                ),
+                    ),
+                ),
+                KeyItemC(
+                    center =
+                    KeyC(
+                        display = KeyDisplay.TextDisplay("D"),
+                        action = KeyAction.CommitText("D"),
+                        size = FontSizeVariant.LARGE,
+                        color = ColorVariant.PRIMARY,
+                    ),
+                    swipes =
+                    mapOf(
+                        SwipeDirection.TOP_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("J"),
+                                    action = KeyAction.CommitText("J"),
+                                ),
+                        SwipeDirection.TOP to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("K"),
+                                    action = KeyAction.CommitText("K"),
+                                ),
+                        SwipeDirection.TOP_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("H"),
+                                    action = KeyAction.CommitText("H"),
+                                ),
+                        SwipeDirection.LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("Z"),
+                                    action = KeyAction.CommitText("Z"),
+                                ),
+                        SwipeDirection.RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("Q"),
+                                    action = KeyAction.CommitText("Q"),
+                                ),
+                        SwipeDirection.BOTTOM_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("F"),
+                                    action = KeyAction.CommitText("F"),
+                                ),
+                        SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("X"),
+                                    action = KeyAction.CommitText("X"),
+                                ),
+                        SwipeDirection.BOTTOM_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("Y"),
+                                    action = KeyAction.CommitText("Y"),
+                                ),
+                    ),
+                ),
+                KeyItemC(
+                    center =
+                    KeyC(
+                        display = KeyDisplay.TextDisplay("A"),
+                        action = KeyAction.CommitText("A"),
+                        size = FontSizeVariant.LARGE,
+                        color = ColorVariant.PRIMARY,
+                    ),
+                    swipeType = SwipeNWay.FOUR_WAY_CROSS,
+                    swipes =
+                    mapOf(
+                        SwipeDirection.TOP to
+                                KeyC(
+                                    display = KeyDisplay.IconDisplay(Icons.Outlined.KeyboardCapslock),
+                                    capsModeDisplay = KeyDisplay.IconDisplay(Icons.Outlined.Copyright),
+                                    action = KeyAction.ToggleCapsLock,
+                                    swipeReturnAction = KeyAction.ToggleCurrentWordCapitalization(true),
+                                    color = ColorVariant.MUTED,
+                                ),
+                        SwipeDirection.LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("T"),
+                                    action = KeyAction.CommitText("T"),
+                                ),
+                        SwipeDirection.RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("Á"),
+                                    action = KeyAction.CommitText("Á"),
+                                ),
+                        SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
+                                    action = KeyAction.ToggleShiftMode(false),
+                                    swipeReturnAction = KeyAction.ToggleCurrentWordCapitalization(false),
+                                    color = ColorVariant.MUTED,
+                                ),
+                    ),
+                ),
+                NUMERIC_KEY_ITEM,
+            ),
+            listOf(
+                KeyItemC(
+                    center =
+                    KeyC(
+                        display = KeyDisplay.TextDisplay("S"),
+                        action = KeyAction.CommitText("S"),
+                        size = FontSizeVariant.LARGE,
+                        color = ColorVariant.PRIMARY,
+                    ),
+                    swipeType = SwipeNWay.FOUR_WAY_DIAGONAL,
+                    swipes =
+                    mapOf(
+                        SwipeDirection.TOP_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("M"),
+                                    action = KeyAction.CommitText("M"),
+                                ),
+                    ),
+                ),
+                KeyItemC(
+                    center =
+                    KeyC(
+                        display = KeyDisplay.TextDisplay("I"),
+                        action = KeyAction.CommitText("I"),
+                        size = FontSizeVariant.LARGE,
+                        color = ColorVariant.PRIMARY,
+                    ),
+                    swipes =
+                    mapOf(
+                        SwipeDirection.TOP to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("G"),
+                                    action = KeyAction.CommitText("G"),
+                                ),
+                        SwipeDirection.TOP_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("'"),
+                                    action = KeyAction.CommitText("'"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                        SwipeDirection.LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("W"),
+                                    action = KeyAction.CommitText("W"),
+                                ),
+                        SwipeDirection.RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("Í"),
+                                    action = KeyAction.CommitText("Í"),
+                                ),
+                        SwipeDirection.BOTTOM_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("*"),
+                                    action = KeyAction.CommitText("*"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                        SwipeDirection.BOTTOM to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("."),
+                                    action = KeyAction.CommitText("."),
+                                    color = ColorVariant.MUTED,
+                                ),
+                        SwipeDirection.BOTTOM_RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("-"),
+                                    action = KeyAction.CommitText("-"),
+                                    color = ColorVariant.MUTED,
+                                ),
+                    ),
+                ),
+                KeyItemC(
+                    center =
+                    KeyC(
+                        display = KeyDisplay.TextDisplay("E"),
+                        action = KeyAction.CommitText("E"),
+                        size = FontSizeVariant.LARGE,
+                        color = ColorVariant.PRIMARY,
+                    ),
+                    swipes =
+                    mapOf(
+                        SwipeDirection.TOP_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("C"),
+                                    action = KeyAction.CommitText("C"),
+                                ),
+                        SwipeDirection.RIGHT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("É"),
+                                    action = KeyAction.CommitText("É"),
+                                ),
+                    ),
+                ),
+                BACKSPACE_KEY_ITEM,
+            ),
+            listOf(
+                SPACEBAR_KEY_ITEM,
+                RETURN_KEY_ITEM,
+            ),
+        ),
+    )
+
+val KB_ES_THUMBKEY_SYMBOLS: KeyboardDefinition =
+    KeyboardDefinition(
+        title = "español thumb-key symbols",
+        modes =
+        KeyboardDefinitionModes(
+            main = KB_ES_THUMBKEY_SYMBOLS_MAIN,
+            shifted = KB_ES_THUMBKEY_SYMBOLS_SHIFTED,
+            numeric = NUMERIC_KEYBOARD,
+        ),
+    )

--- a/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
@@ -141,6 +141,7 @@ import com.dessalines.thumbkey.keyboards.KB_UK_MESSAGEASE_SYMBOLS
 import com.dessalines.thumbkey.keyboards.KB_UK_RU_MESSAGEASE_SYMBOLS
 import com.dessalines.thumbkey.keyboards.KB_UK_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_VN_THUMBKEY
+import com.dessalines.thumbkey.keyboards.KB_ES_THUMBKEY_SYMBOLS
 
 // Make sure new keyboards are added AT THE END of this list, and have a higher index.
 // DO NOT put them in the middle of the list!
@@ -288,4 +289,5 @@ enum class KeyboardLayout(
     ENMessagEaseWriter(KB_EN_MESSAGEASE_WRITER),
     RUMessagEaseWriter(KB_RU_MESSAGEASE_WRITER),
     ENSVThumbKeyProgramming(KB_EN_SV_THUMBKEY_PROGRAMMING),
+    ESThumbKeySymbols(KB_ES_THUMBKEY_SYMBOLS),
 }

--- a/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
@@ -71,6 +71,7 @@ import com.dessalines.thumbkey.keyboards.KB_ES_CA_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_ES_EO_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_ES_MESSAGEASE
 import com.dessalines.thumbkey.keyboards.KB_ES_THUMBKEY
+import com.dessalines.thumbkey.keyboards.KB_ES_THUMBKEY_SYMBOLS
 import com.dessalines.thumbkey.keyboards.KB_ES_TYPESPLIT
 import com.dessalines.thumbkey.keyboards.KB_EUROPE_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_EU_ES_THUMBKEY
@@ -141,7 +142,6 @@ import com.dessalines.thumbkey.keyboards.KB_UK_MESSAGEASE_SYMBOLS
 import com.dessalines.thumbkey.keyboards.KB_UK_RU_MESSAGEASE_SYMBOLS
 import com.dessalines.thumbkey.keyboards.KB_UK_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_VN_THUMBKEY
-import com.dessalines.thumbkey.keyboards.KB_ES_THUMBKEY_SYMBOLS
 
 // Make sure new keyboards are added AT THE END of this list, and have a higher index.
 // DO NOT put them in the middle of the list!


### PR DESCRIPTION
I tried to stick as loyal as possible to the current Spanish Thumb-Key layout, just added the "ª" symbol and moved parenthesis to keep every letter in the same place.

![imagen](https://github.com/user-attachments/assets/e5fab73b-6ef6-4da6-9354-f638279b599c)
