### PR TITLE
Add compose keys (caron, breve), quote sign toggle

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyCompose.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyCompose.kt
@@ -278,10 +278,10 @@ val KB_EN_THUMBKEY_COMPOSE_MAIN =
                                     action = KeyAction.CommitText("f"),
                                 ),
                             SwipeDirection.TOP_LEFT to
-                                    KeyC(
-                                        display = KeyDisplay.TextDisplay(" "),
-                                        action = KeyAction.CommitText("f"),
-                                    ),
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay(" "),
+                                    action = KeyAction.CommitText("f"),
+                                ),
                             SwipeDirection.TOP_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("'"),
@@ -432,17 +432,17 @@ val KB_EN_THUMBKEY_COMPOSE_SHIFTED =
                                     action = KeyAction.CommitText("M"),
                                 ),
                             SwipeDirection.TOP_RIGHT to
-                                    KeyC(
-                                        display = KeyDisplay.TextDisplay("ˇ"),
-                                        action = KeyAction.ComposeLastKey("ˇ"),
-                                        color = ColorVariant.MUTED,
-                                    ),
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("ˇ"),
+                                    action = KeyAction.ComposeLastKey("ˇ"),
+                                    color = ColorVariant.MUTED,
+                                ),
                             SwipeDirection.BOTTOM_RIGHT to
-                                    KeyC(
-                                        display = KeyDisplay.TextDisplay("˘"),
-                                        action = KeyAction.ComposeLastKey("˘"),
-                                        color = ColorVariant.MUTED,
-                                    ),
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay("˘"),
+                                    action = KeyAction.ComposeLastKey("˘"),
+                                    color = ColorVariant.MUTED,
+                                ),
                             SwipeDirection.TOP_LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("'"),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyCompose.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyCompose.kt
@@ -250,7 +250,7 @@ val KB_EN_THUMBKEY_COMPOSE_MAIN =
                                 ),
                             SwipeDirection.BOTTOM_LEFT to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("¿¡"),
+                                    display = KeyDisplay.TextDisplay("¿¡ßç"),
                                     action = KeyAction.ComposeLastKey("!"),
                                     color = ColorVariant.MUTED,
                                 ),
@@ -281,7 +281,6 @@ val KB_EN_THUMBKEY_COMPOSE_MAIN =
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("'"),
                                     action = KeyAction.CommitText("'"),
-                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.RIGHT to
                                 KeyC(
@@ -292,19 +291,16 @@ val KB_EN_THUMBKEY_COMPOSE_MAIN =
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("-"),
                                     action = KeyAction.CommitText("-"),
-                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.BOTTOM to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("."),
                                     action = KeyAction.CommitText("."),
-                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.BOTTOM_LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("*"),
                                     action = KeyAction.CommitText("*"),
-                                    color = ColorVariant.MUTED,
                                 ),
                         ),
                 ),
@@ -568,7 +564,7 @@ val KB_EN_THUMBKEY_COMPOSE_SHIFTED =
                                 ),
                             SwipeDirection.BOTTOM_LEFT to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay("¿¡"),
+                                    display = KeyDisplay.TextDisplay("¿¡ßÇ"),
                                     action = KeyAction.ComposeLastKey("!"),
                                     color = ColorVariant.MUTED,
                                 ),
@@ -599,7 +595,6 @@ val KB_EN_THUMBKEY_COMPOSE_SHIFTED =
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("'"),
                                     action = KeyAction.CommitText("'"),
-                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.RIGHT to
                                 KeyC(
@@ -610,19 +605,16 @@ val KB_EN_THUMBKEY_COMPOSE_SHIFTED =
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("-"),
                                     action = KeyAction.CommitText("-"),
-                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.BOTTOM to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("."),
                                     action = KeyAction.CommitText("."),
-                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.BOTTOM_LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("*"),
                                     action = KeyAction.CommitText("*"),
-                                    color = ColorVariant.MUTED,
                                 ),
                         ),
                 ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyCompose.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyCompose.kt
@@ -117,13 +117,15 @@ val KB_EN_THUMBKEY_COMPOSE_MAIN =
                                 ),
                             SwipeDirection.TOP_RIGHT to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay(""),
-                                    action = KeyAction.CommitText("m"),
+                                    display = KeyDisplay.TextDisplay("ˇ"),
+                                    action = KeyAction.ComposeLastKey("ˇ"),
+                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.BOTTOM_RIGHT to
                                 KeyC(
-                                    display = KeyDisplay.TextDisplay(""),
-                                    action = KeyAction.CommitText("m"),
+                                    display = KeyDisplay.TextDisplay("˘"),
+                                    action = KeyAction.ComposeLastKey("˘"),
+                                    color = ColorVariant.MUTED,
                                 ),
                             SwipeDirection.BOTTOM_LEFT to
                                 KeyC(
@@ -429,15 +431,17 @@ val KB_EN_THUMBKEY_COMPOSE_SHIFTED =
                                     action = KeyAction.CommitText("M"),
                                 ),
                             SwipeDirection.TOP_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay(""),
-                                    action = KeyAction.CommitText("M"),
-                                ),
+                                    KeyC(
+                                        display = KeyDisplay.TextDisplay("ˇ"),
+                                        action = KeyAction.ComposeLastKey("ˇ"),
+                                        color = ColorVariant.MUTED,
+                                    ),
                             SwipeDirection.BOTTOM_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay(""),
-                                    action = KeyAction.CommitText("M"),
-                                ),
+                                    KeyC(
+                                        display = KeyDisplay.TextDisplay("˘"),
+                                        action = KeyAction.ComposeLastKey("˘"),
+                                        color = ColorVariant.MUTED,
+                                    ),
                             SwipeDirection.TOP_LEFT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("'"),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyCompose.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyCompose.kt
@@ -277,6 +277,11 @@ val KB_EN_THUMBKEY_COMPOSE_MAIN =
                                     display = KeyDisplay.TextDisplay("f"),
                                     action = KeyAction.CommitText("f"),
                                 ),
+                            SwipeDirection.TOP_LEFT to
+                                    KeyC(
+                                        display = KeyDisplay.TextDisplay(" "),
+                                        action = KeyAction.CommitText("f"),
+                                    ),
                             SwipeDirection.TOP_RIGHT to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("'"),
@@ -589,6 +594,11 @@ val KB_EN_THUMBKEY_COMPOSE_SHIFTED =
                             SwipeDirection.TOP to
                                 KeyC(
                                     display = KeyDisplay.TextDisplay("F"),
+                                    action = KeyAction.CommitText("F"),
+                                ),
+                            SwipeDirection.TOP_LEFT to
+                                KeyC(
+                                    display = KeyDisplay.TextDisplay(" "),
                                     action = KeyAction.CommitText("F"),
                                 ),
                             SwipeDirection.TOP_RIGHT to

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -417,6 +417,7 @@ fun performKeyAction(
                             "y" -> "ÿ"
                             "Y" -> "Ÿ"
                             " " -> "\""
+                            "'" -> "\""
                             else -> textBefore
                         }
 
@@ -472,6 +473,7 @@ fun performKeyAction(
                             "Z" -> "Ź"
                             "'" -> "”"
                             " " -> "'"
+                            "\"" -> "'"
                             else -> textBefore
                         }
 


### PR DESCRIPTION
Summary of all changes:
- Add caron and breve compose keys to en-thumbkey-composed layout.
- Enable toggling of single and double quote sign using the compose key action.
- Also includes some small cosmetic changes (show compose keys as muted, real keys as normal).
- Increased swipe area for "f" key by adding unused adjacent swipe direction (to reduce chance for typos).

Fixes #1073.
