### PR TITLE
Automatically calculate swipe zones

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/BGMessagEasePhoneticSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/BGMessagEasePhoneticSymbols.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_BG_MESSAGEASE_PHONETIC_SYMBOLS_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/BGThumbKeySymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/BGThumbKeySymbols.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 // Adds more punctuation options to the main screen to reduce switches to the numeric keyboard
 val KB_BG_THUMBKEY_SYMBOLS_MAIN =

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/BRFRThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/BRFRThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_BR_FR_THUMBKEY_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/BYThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/BYThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_BY_THUMBKEY_MAIN =
     KeyboardC(
@@ -22,12 +21,10 @@ val KB_BY_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("р", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("х"),
                 ),
                 KeyItemC(
                     center = KeyC("а", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("ж"),
                 ),
                 EMOJI_KEY_ITEM,
@@ -35,7 +32,6 @@ val KB_BY_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("н", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("м"),
                     bottom = KeyC("л"),
                 ),
@@ -52,7 +48,6 @@ val KB_BY_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("е", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("ф"),
                     top =
                         KeyC(
@@ -115,12 +110,10 @@ val KB_BY_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("Р", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("Х"),
                 ),
                 KeyItemC(
                     center = KeyC("А", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("Ж"),
                 ),
                 EMOJI_KEY_ITEM,
@@ -128,7 +121,6 @@ val KB_BY_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("Н", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("М"),
                     bottom = KeyC("Л"),
                 ),
@@ -145,7 +137,6 @@ val KB_BY_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("Е", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("Ф"),
                     top =
                         KeyC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/BYThumbKeySymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/BYThumbKeySymbols.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_BY_THUMBKEY_SYMBOLS_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/CAThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/CAThumbKey.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_CA_THUMBKEY_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/CZProgrammerMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/CZProgrammerMessagEase.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_CZ_MESSAGEASE_PROGRAMMING_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/CommonKeys.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/CommonKeys.kt
@@ -10,12 +10,10 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 fun textEditKeyItem(center: KeyC) =
     KeyItemC(
         backgroundColor = SURFACE_VARIANT,
-        swipeType = EIGHT_WAY,
         center = center,
         top =
             KeyC(
@@ -58,7 +56,6 @@ fun textEditKeyItem(center: KeyC) =
 fun specialActionKeyItem(center: KeyC) =
     KeyItemC(
         backgroundColor = SURFACE_VARIANT,
-        swipeType = EIGHT_WAY,
         center = center,
         top =
             KeyC(
@@ -155,7 +152,6 @@ val BACKSPACE_KEY_ITEM =
                 size = LARGE,
                 color = SECONDARY,
             ),
-        swipeType = TWO_WAY_HORIZONTAL,
         slideType = SlideType.DELETE,
         left =
             KeyC(
@@ -176,7 +172,6 @@ val BACKSPACE_WIDE_KEY_ITEM = BACKSPACE_KEY_ITEM.copy(widthMultiplier = 3)
 val SPACEBAR_KEY_ITEM =
     KeyItemC(
         center = KeyC(" "),
-        swipeType = FOUR_WAY_CROSS,
         slideType = SlideType.MOVE_CURSOR,
         left =
             KeyC(
@@ -218,7 +213,6 @@ val SPACEBAR_DOUBLE_KEY_ITEM = SPACEBAR_KEY_ITEM.copy(widthMultiplier = 2)
 val SPACEBAR_PROGRAMMING_KEY_ITEM =
     KeyItemC(
         center = KeyC(" "),
-        swipeType = FOUR_WAY_CROSS,
         slideType = SlideType.MOVE_CURSOR,
         left =
             KeyC(
@@ -284,7 +278,6 @@ val RETURN_KEY_ITEM =
 val SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM =
     KeyItemC(
         center = KeyC(" "),
-        swipeType = FOUR_WAY_CROSS,
         slideType = SlideType.MOVE_CURSOR,
         left =
             KeyC(
@@ -323,7 +316,6 @@ val SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM =
     )
 val SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM =
     SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM.copy(
-        swipeType = EIGHT_WAY,
         left =
             KeyC(
                 action =
@@ -426,7 +418,6 @@ val BACKSPACE_TYPESPLIT_KEY_ITEM =
                 size = LARGE,
                 color = SECONDARY,
             ),
-        swipeType = FOUR_WAY_CROSS,
         slideType = SlideType.DELETE,
         left =
             KeyC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DAThumbKeyV2.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DAThumbKeyV2.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_DA_THUMBKEY_MAIN =
     KeyboardC(
@@ -16,18 +15,15 @@ val KB_DA_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("v"),
                     topLeft = KeyC("w"),
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("f"),
                 ),
                 KeyItemC(
                     center = KeyC("i", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("h"),
                     topRight = KeyC("y"),
                 ),
@@ -36,7 +32,6 @@ val KB_DA_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("m"),
                 ),
                 KeyItemC(
@@ -52,7 +47,6 @@ val KB_DA_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("u"),
                     top =
                         KeyC(
@@ -72,7 +66,6 @@ val KB_DA_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("g"),
                     bottomLeft = KeyC("z"),
                 ),
@@ -87,7 +80,6 @@ val KB_DA_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("o"),
                 ),
                 BACKSPACE_KEY_ITEM,
@@ -105,18 +97,15 @@ val KB_DA_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("V"),
                     topLeft = KeyC("W"),
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("F"),
                 ),
                 KeyItemC(
                     center = KeyC("I", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("H"),
                     topRight = KeyC("Y"),
                 ),
@@ -125,7 +114,6 @@ val KB_DA_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("M"),
                 ),
                 KeyItemC(
@@ -141,7 +129,6 @@ val KB_DA_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("U"),
                     bottom =
                         KeyC(
@@ -164,7 +151,6 @@ val KB_DA_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("G"),
                     bottomLeft = KeyC("Z"),
                 ),
@@ -179,7 +165,6 @@ val KB_DA_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("O"),
                 ),
                 BACKSPACE_KEY_ITEM,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEENAEThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEENAEThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_DE_THUMBKEY_AE_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEase.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_DE_MESSAGEASE_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEaseNordic.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEaseNordic.kt
@@ -9,7 +9,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_DE_NORDIC_MESSAGEASE_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEaseSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEaseSymbols.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_DE_MESSAGEASE_SYMBOLS_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_DE_THUMBKEY_MAIN =
     KeyboardC(
@@ -16,12 +15,10 @@ val KB_DE_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("c"),
                 ),
                 KeyItemC(
                     center = KeyC("d", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("!", color = MUTED),
                     bottom = KeyC("f"),
                 ),
@@ -36,7 +33,6 @@ val KB_DE_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("m"),
                 ),
                 KeyItemC(
@@ -52,7 +48,6 @@ val KB_DE_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("i", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("o"),
                     right = KeyC("ö"),
                     top =
@@ -73,7 +68,6 @@ val KB_DE_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("g"),
                     bottomRight = KeyC(":", color = MUTED),
                 ),
@@ -90,7 +84,6 @@ val KB_DE_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("u"),
                     topRight = KeyC("ü"),
                 ),
@@ -109,12 +102,10 @@ val KB_DE_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("C"),
                 ),
                 KeyItemC(
                     center = KeyC("D", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     right = KeyC("!", color = MUTED),
                     bottom = KeyC("F"),
                 ),
@@ -129,7 +120,6 @@ val KB_DE_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("M"),
                 ),
                 KeyItemC(
@@ -145,7 +135,6 @@ val KB_DE_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("I", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("O"),
                     right = KeyC("Ö"),
                     bottom =
@@ -168,7 +157,6 @@ val KB_DE_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC(":", color = MUTED),
                     topRight = KeyC("G"),
                 ),
@@ -185,7 +173,6 @@ val KB_DE_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("U"),
                     topRight = KeyC("Ü"),
                 ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbKeyMultiLingual.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbKeyMultiLingual.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_DE_THUMBKEY_MULTILINGUAL_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbkeySymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbkeySymbols.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_DE_THUMBKEY_SYMBOLS_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DETypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DETypeSplit.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_DE_TYPESPLIT_MAIN =
     KeyboardC(
@@ -14,7 +13,6 @@ val KB_DE_TYPESPLIT_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("q"),
                     left =
                         KeyC(
@@ -29,7 +27,6 @@ val KB_DE_TYPESPLIT_MAIN =
                 EMOJI_KEY_ITEM_ALT,
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("z"),
                     left =
                         KeyC(
@@ -41,7 +38,6 @@ val KB_DE_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("i", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -55,7 +51,6 @@ val KB_DE_TYPESPLIT_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom =
                         KeyC(
                             display = null,
@@ -65,7 +60,6 @@ val KB_DE_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("ß", color = MUTED),
                     top =
                         KeyC(
@@ -76,7 +70,6 @@ val KB_DE_TYPESPLIT_MAIN =
                 SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("d", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("f"),
                     left =
                         KeyC(
@@ -87,7 +80,6 @@ val KB_DE_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("h", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -101,7 +93,6 @@ val KB_DE_TYPESPLIT_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("c", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("x"),
                     left =
                         KeyC(
@@ -112,7 +103,6 @@ val KB_DE_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("b", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("v"),
                 ),
                 SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
@@ -121,7 +111,6 @@ val KB_DE_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("m", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("?", color = MUTED),
                     left = KeyC("!", color = MUTED),
                     bottom = KeyC(":", color = MUTED),
@@ -142,7 +131,6 @@ val KB_DE_TYPESPLIT_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("Q"),
                     left =
                         KeyC(
@@ -157,7 +145,6 @@ val KB_DE_TYPESPLIT_SHIFTED =
                 EMOJI_KEY_ITEM_ALT,
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("Z"),
                     left =
                         KeyC(
@@ -169,7 +156,6 @@ val KB_DE_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("I", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -183,7 +169,6 @@ val KB_DE_TYPESPLIT_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom =
                         KeyC(
                             display = null,
@@ -193,7 +178,6 @@ val KB_DE_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("ẞ", color = MUTED),
                     top =
                         KeyC(
@@ -204,7 +188,6 @@ val KB_DE_TYPESPLIT_SHIFTED =
                 SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("D", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("F"),
                     left =
                         KeyC(
@@ -215,7 +198,6 @@ val KB_DE_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("H", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -229,7 +211,6 @@ val KB_DE_TYPESPLIT_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("C", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("X"),
                     left =
                         KeyC(
@@ -240,7 +221,6 @@ val KB_DE_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("B", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("V"),
                 ),
                 SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
@@ -249,7 +229,6 @@ val KB_DE_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("M", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("?", color = MUTED),
                     left = KeyC("!", color = MUTED),
                     bottom = KeyC(":", color = MUTED),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENCZThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENCZThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_CZ_THUMBKEY_MAIN =
     KeyboardC(
@@ -16,19 +15,16 @@ val KB_EN_CZ_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("w"),
                     topRight = KeyC("š"),
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("g"),
                     top = KeyC("ř"),
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("u"),
                     topRight = KeyC("ó"),
                     bottomRight = KeyC("ů"),
@@ -39,7 +35,6 @@ val KB_EN_CZ_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("m"),
                     top = KeyC("ň"),
                 ),
@@ -56,7 +51,6 @@ val KB_EN_CZ_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("l"),
                     right = KeyC("á"),
                     top =
@@ -114,19 +108,16 @@ val KB_EN_CZ_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("W"),
                     topRight = KeyC("Š"),
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("G"),
                     top = KeyC("Ř"),
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("U"),
                     topRight = KeyC("Ó"),
                     bottomRight = KeyC("Ů"),
@@ -137,7 +128,6 @@ val KB_EN_CZ_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("M"),
                     top = KeyC("Ň"),
                 ),
@@ -154,7 +144,6 @@ val KB_EN_CZ_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("L"),
                     right = KeyC("Á"),
                     top =
@@ -195,7 +184,6 @@ val KB_EN_CZ_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     topLeft = KeyC("D"),
                     top = KeyC("É"),
                     right = KeyC("Ď"),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENColumnar.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENColumnar.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_COLUMNAR_MAIN =
     KeyboardC(
@@ -16,19 +15,16 @@ val KB_EN_COLUMNAR_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("q"),
                     bottom = KeyC("z"),
                 ),
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("w"),
                     bottom = KeyC("x"),
                 ),
                 KeyItemC(
                     center = KeyC("d", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("e"),
                     bottom = KeyC("c"),
                 ),
@@ -37,19 +33,16 @@ val KB_EN_COLUMNAR_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("f", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("r"),
                     bottom = KeyC("v"),
                 ),
                 KeyItemC(
                     center = KeyC("g", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("t"),
                     bottom = KeyC("b"),
                 ),
                 KeyItemC(
                     center = KeyC("h", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left =
                         KeyC(
                             ToggleShiftMode(false),
@@ -76,19 +69,16 @@ val KB_EN_COLUMNAR_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("j", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("u"),
                     bottom = KeyC("m"),
                 ),
                 KeyItemC(
                     center = KeyC("k", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("i"),
                     bottom = KeyC(","),
                 ),
                 KeyItemC(
                     center = KeyC("l", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("o"),
                     bottom = KeyC("p"),
                 ),
@@ -107,19 +97,16 @@ val KB_EN_COLUMNAR_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("Q"),
                     bottom = KeyC("Z"),
                 ),
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("W"),
                     bottom = KeyC("X"),
                 ),
                 KeyItemC(
                     center = KeyC("D", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("E"),
                     bottom = KeyC("C"),
                 ),
@@ -128,19 +115,16 @@ val KB_EN_COLUMNAR_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("F", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("R"),
                     bottom = KeyC("V"),
                 ),
                 KeyItemC(
                     center = KeyC("G", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("T"),
                     bottom = KeyC("B"),
                 ),
                 KeyItemC(
                     center = KeyC("H", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left =
                         KeyC(
                             display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
@@ -170,19 +154,16 @@ val KB_EN_COLUMNAR_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("J", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("U"),
                     bottom = KeyC("M"),
                 ),
                 KeyItemC(
                     center = KeyC("K", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("I"),
                     bottom = KeyC("."),
                 ),
                 KeyItemC(
                     center = KeyC("L", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("O"),
                     bottom = KeyC("P"),
                 ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENColumnarQuick.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENColumnarQuick.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_COLUMNAR_QUICK_MAIN =
     KeyboardC(
@@ -16,19 +15,16 @@ val KB_EN_COLUMNAR_QUICK_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("q"),
                     bottom = KeyC("z"),
                 ),
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("w"),
                     bottom = KeyC("x"),
                 ),
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("d"),
                     bottom = KeyC("c"),
                 ),
@@ -37,19 +33,16 @@ val KB_EN_COLUMNAR_QUICK_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("f"),
                     bottom = KeyC("v"),
                 ),
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("g"),
                     bottom = KeyC("b"),
                 ),
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left =
                         KeyC(
                             ToggleShiftMode(false),
@@ -76,19 +69,16 @@ val KB_EN_COLUMNAR_QUICK_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("u", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("j"),
                     bottom = KeyC("m"),
                 ),
                 KeyItemC(
                     center = KeyC("i", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("k"),
                     bottom = KeyC(","),
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("l"),
                     bottom = KeyC("p"),
                 ),
@@ -107,19 +97,16 @@ val KB_EN_COLUMNAR_QUICK_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("Q"),
                     bottom = KeyC("Z"),
                 ),
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("W"),
                     bottom = KeyC("X"),
                 ),
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("D"),
                     bottom = KeyC("C"),
                 ),
@@ -128,19 +115,16 @@ val KB_EN_COLUMNAR_QUICK_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("F"),
                     bottom = KeyC("V"),
                 ),
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("G"),
                     bottom = KeyC("B"),
                 ),
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left =
                         KeyC(
                             display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
@@ -170,19 +154,16 @@ val KB_EN_COLUMNAR_QUICK_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("U", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("J"),
                     bottom = KeyC("M"),
                 ),
                 KeyItemC(
                     center = KeyC("I", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("K"),
                     bottom = KeyC("."),
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("L"),
                     bottom = KeyC("P"),
                 ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDAThumbKeySymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDAThumbKeySymbols.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 // Same as 'english symbols thumb-key', with additional Danish letters
 val KB_EN_DA_THUMBKEY_SYMBOLS_MAIN =
@@ -17,7 +16,6 @@ val KB_EN_DA_THUMBKEY_SYMBOLS_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("w"),
                     bottomLeft = KeyC("$", color = MUTED),
                 ),
@@ -90,7 +88,6 @@ val KB_EN_DA_THUMBKEY_SYMBOLS_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("c"),
                     topLeft = KeyC("~", color = MUTED),
                     bottomRight = KeyC(":", color = MUTED),
@@ -132,7 +129,6 @@ val KB_EN_DA_THUMBKEY_SYMBOLS_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("W"),
                     bottomLeft = KeyC("$", color = MUTED),
                 ),
@@ -208,7 +204,6 @@ val KB_EN_DA_THUMBKEY_SYMBOLS_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("C"),
                     topLeft = KeyC("~", color = MUTED),
                     bottomRight = KeyC(":", color = MUTED),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDENLThumbkey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDENLThumbkey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_DE_NL_THUMBKEY_MAIN =
     KeyboardC(
@@ -16,13 +15,11 @@ val KB_EN_DE_NL_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("w"),
                     topRight = KeyC("ß", color = MUTED),
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("g"),
                 ),
                 KeyItemC(
@@ -37,7 +34,6 @@ val KB_EN_DE_NL_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("m"),
                 ),
                 KeyItemC(
@@ -53,7 +49,6 @@ val KB_EN_DE_NL_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("l"),
                     top =
                         KeyC(
@@ -69,7 +64,6 @@ val KB_EN_DE_NL_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("c"),
                     right = KeyC("ç", color = MUTED),
                     bottomRight = KeyC(":", color = MUTED),
@@ -88,7 +82,6 @@ val KB_EN_DE_NL_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("d"),
                     top = KeyC("è", color = MUTED),
                     topRight = KeyC("é", color = MUTED),
@@ -113,17 +106,14 @@ val KB_EN_DE_NL_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("W"),
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("G"),
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("&", color = MUTED),
                     bottomLeft = KeyC("U"),
                     topLeft = KeyC("Ü", color = MUTED),
@@ -134,7 +124,6 @@ val KB_EN_DE_NL_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("M"),
                 ),
                 KeyItemC(
@@ -150,7 +139,6 @@ val KB_EN_DE_NL_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("L"),
                     right = KeyC("Ä", color = MUTED),
                     bottom =
@@ -174,7 +162,6 @@ val KB_EN_DE_NL_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("C"),
                     right = KeyC("Ç", color = MUTED),
                     bottomRight = KeyC(":", color = MUTED),
@@ -193,7 +180,6 @@ val KB_EN_DE_NL_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("D"),
                     top = KeyC("È", color = MUTED),
                     topRight = KeyC("É", color = MUTED),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDEThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDEThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_DE_THUMBKEY_MAIN =
     KeyboardC(
@@ -21,7 +20,6 @@ val KB_EN_DE_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("h", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("f"),
                 ),
                 KeyItemC(
@@ -34,7 +32,6 @@ val KB_EN_DE_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("c"),
                 ),
                 KeyItemC(
@@ -71,7 +68,6 @@ val KB_EN_DE_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("g"),
                 ),
                 KeyItemC(
@@ -85,7 +81,6 @@ val KB_EN_DE_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("d"),
                 ),
                 BACKSPACE_KEY_ITEM,
@@ -108,7 +103,6 @@ val KB_EN_DE_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("H", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("F"),
                 ),
                 KeyItemC(
@@ -121,7 +115,6 @@ val KB_EN_DE_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("C"),
                 ),
                 KeyItemC(
@@ -161,7 +154,6 @@ val KB_EN_DE_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("G"),
                 ),
                 KeyItemC(
@@ -175,7 +167,6 @@ val KB_EN_DE_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("D"),
                 ),
                 BACKSPACE_KEY_ITEM,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDEThumbKeyV2.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDEThumbKeyV2.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_DE_THUMBKEY_V2_MAIN =
     KeyboardC(
@@ -16,13 +15,11 @@ val KB_EN_DE_THUMBKEY_V2_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("w"),
                     topRight = KeyC("ß"),
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("g"),
                 ),
                 KeyItemC(
@@ -36,7 +33,6 @@ val KB_EN_DE_THUMBKEY_V2_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("m"),
                 ),
                 KeyItemC(
@@ -52,7 +48,6 @@ val KB_EN_DE_THUMBKEY_V2_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("l"),
                     top =
                         KeyC(
@@ -68,7 +63,6 @@ val KB_EN_DE_THUMBKEY_V2_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("c"),
                 ),
                 KeyItemC(
@@ -82,7 +76,6 @@ val KB_EN_DE_THUMBKEY_V2_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("d"),
                 ),
                 BACKSPACE_KEY_ITEM,
@@ -100,17 +93,14 @@ val KB_EN_DE_THUMBKEY_V2_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("W"),
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("G"),
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("U"),
                     topLeft = KeyC("Ü"),
                     bottom = KeyC("Ö"),
@@ -120,7 +110,6 @@ val KB_EN_DE_THUMBKEY_V2_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("M"),
                 ),
                 KeyItemC(
@@ -136,7 +125,6 @@ val KB_EN_DE_THUMBKEY_V2_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("L"),
                     right = KeyC("Ä"),
                     bottom =
@@ -160,7 +148,6 @@ val KB_EN_DE_THUMBKEY_V2_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("C"),
                 ),
                 KeyItemC(
@@ -174,7 +161,6 @@ val KB_EN_DE_THUMBKEY_V2_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("D"),
                 ),
                 BACKSPACE_KEY_ITEM,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDoubleSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDoubleSymbols.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_DOUBLE_SYMBOLS_MAIN =
     KeyboardC(
@@ -16,7 +15,6 @@ val KB_EN_DOUBLE_SYMBOLS_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("w"),
                     bottomLeft = KeyC("$", color = MUTED),
                 ),
@@ -40,7 +38,6 @@ val KB_EN_DOUBLE_SYMBOLS_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("w"),
                     bottomLeft = KeyC("$", color = MUTED),
                 ),
@@ -150,7 +147,6 @@ val KB_EN_DOUBLE_SYMBOLS_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("c"),
                     topLeft = KeyC("~", color = MUTED),
                     bottomRight = KeyC(":", color = MUTED),
@@ -178,7 +174,6 @@ val KB_EN_DOUBLE_SYMBOLS_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("c"),
                     topLeft = KeyC("~", color = MUTED),
                     bottomRight = KeyC(":", color = MUTED),
@@ -221,7 +216,6 @@ val KB_EN_DOUBLE_SYMBOLS_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("W"),
                     bottomLeft = KeyC("$", color = MUTED),
                 ),
@@ -245,7 +239,6 @@ val KB_EN_DOUBLE_SYMBOLS_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("W"),
                     bottomLeft = KeyC("$", color = MUTED),
                 ),
@@ -361,7 +354,6 @@ val KB_EN_DOUBLE_SYMBOLS_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("C"),
                     topLeft = KeyC("~", color = MUTED),
                     bottomRight = KeyC(":", color = MUTED),
@@ -389,7 +381,6 @@ val KB_EN_DOUBLE_SYMBOLS_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("C"),
                     topLeft = KeyC("~", color = MUTED),
                     bottomRight = KeyC(":", color = MUTED),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENEEThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENEEThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_EE_THUMBKEY_MAIN =
     KeyboardC(
@@ -16,18 +15,15 @@ val KB_EN_EE_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("š"),
                     bottomRight = KeyC("w"),
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("g"),
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("u"),
                     topLeft = KeyC("õ"),
                     topRight = KeyC("ö"),
@@ -38,7 +34,6 @@ val KB_EN_EE_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("m"),
                 ),
                 KeyItemC(
@@ -54,7 +49,6 @@ val KB_EN_EE_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("l"),
                     top =
                         KeyC(
@@ -75,7 +69,6 @@ val KB_EN_EE_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("c"),
                 ),
                 KeyItemC(
@@ -90,7 +83,6 @@ val KB_EN_EE_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("d"),
                 ),
                 BACKSPACE_KEY_ITEM,
@@ -108,18 +100,15 @@ val KB_EN_EE_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("Š"),
                     bottomRight = KeyC("W"),
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("G"),
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("U"),
                     topLeft = KeyC("Õ"),
                     topRight = KeyC("Ö"),
@@ -130,7 +119,6 @@ val KB_EN_EE_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("M"),
                 ),
                 KeyItemC(
@@ -146,7 +134,6 @@ val KB_EN_EE_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("L"),
                     bottom =
                         KeyC(
@@ -170,7 +157,6 @@ val KB_EN_EE_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("C"),
                 ),
                 KeyItemC(
@@ -185,7 +171,6 @@ val KB_EN_EE_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("D"),
                 ),
                 BACKSPACE_KEY_ITEM,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENEOMessagEaseSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENEOMessagEaseSymbols.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_EO_MESSAGEASE_SYMBOLS_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENEOThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENEOThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_EO_THUMBKEY_MAIN =
     KeyboardC(
@@ -16,7 +15,6 @@ val KB_EN_EO_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("k"),
                     top = KeyC("m"),
                     left = KeyC("'"),
@@ -24,7 +22,6 @@ val KB_EN_EO_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("ŝ"),
                     top = KeyC("p"),
                     left = KeyC("ϗ"),
@@ -32,7 +29,6 @@ val KB_EN_EO_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("ĥ"),
                     top = KeyC("h"),
                     left = KeyC("#"),
@@ -43,7 +39,6 @@ val KB_EN_EO_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("ĵ"),
                     top = KeyC("j"),
                     left = KeyC("."),
@@ -51,7 +46,6 @@ val KB_EN_EO_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("v"),
                     top = KeyC("f"),
                     left = KeyC("?"),
@@ -59,7 +53,6 @@ val KB_EN_EO_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("d"),
                     left = KeyC("("),
                     right = KeyC(")"),
@@ -76,7 +69,6 @@ val KB_EN_EO_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("ĉ"),
                     top = KeyC("c"),
                     left = KeyC("b"),
@@ -84,7 +76,6 @@ val KB_EN_EO_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("l", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("ĝ"),
                     top = KeyC("g"),
                     left = KeyC("y"),
@@ -92,7 +83,6 @@ val KB_EN_EO_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("i", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("ŭ"),
                     top = KeyC("u"),
                     left = KeyC("x"),
@@ -113,7 +103,6 @@ val KB_EN_EO_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("K"),
                     top = KeyC("M"),
                     left = KeyC("'"),
@@ -121,7 +110,6 @@ val KB_EN_EO_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("Ŝ"),
                     top = KeyC("P"),
                     left = KeyC("ϗ"),
@@ -129,7 +117,6 @@ val KB_EN_EO_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("Ĥ"),
                     top = KeyC("H"),
                     left = KeyC("#"),
@@ -140,7 +127,6 @@ val KB_EN_EO_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("Ĵ"),
                     top = KeyC("J"),
                     left = KeyC("."),
@@ -148,7 +134,6 @@ val KB_EN_EO_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("V"),
                     top = KeyC("F"),
                     left = KeyC("?"),
@@ -156,7 +141,6 @@ val KB_EN_EO_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("D"),
                     left = KeyC("("),
                     right = KeyC(")"),
@@ -173,7 +157,6 @@ val KB_EN_EO_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("Ĉ"),
                     top = KeyC("C"),
                     left = KeyC("B"),
@@ -181,7 +164,6 @@ val KB_EN_EO_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("L", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("Ĝ"),
                     top = KeyC("G"),
                     left = KeyC("Y"),
@@ -189,7 +171,6 @@ val KB_EN_EO_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("I", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("Ŭ"),
                     top = KeyC("U"),
                     left = KeyC("X"),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENESCAThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENESCAThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_ES_CA_THUMBKEY_MAIN =
     KeyboardC(
@@ -16,7 +15,6 @@ val KB_EN_ES_CA_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("w"),
                 ),
                 KeyItemC(
@@ -40,7 +38,6 @@ val KB_EN_ES_CA_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("m"),
                     left = KeyC("ñ"),
                 ),
@@ -79,7 +76,6 @@ val KB_EN_ES_CA_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("c"),
                     bottomRight = KeyC("ç"),
                 ),
@@ -115,7 +111,6 @@ val KB_EN_ES_CA_HUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("W"),
                 ),
                 KeyItemC(
@@ -139,7 +134,6 @@ val KB_EN_ES_CA_HUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("M"),
                     left = KeyC("Ñ"),
                 ),
@@ -181,7 +175,6 @@ val KB_EN_ES_CA_HUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("C"),
                     bottomRight = KeyC("Ç"),
                 ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENFRMessagEaseSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENFRMessagEaseSymbols.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 // Layout for English and French
 // ┌───────┬───────┬───────┐
@@ -51,7 +50,6 @@ val KB_EN_FR_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("!", color = MUTED),
                     bottom = KeyC("l"),
                 ),
@@ -87,7 +85,6 @@ val KB_EN_FR_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top =
                         KeyC(
                             display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
@@ -150,7 +147,6 @@ val KB_EN_FR_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("!", color = MUTED),
                     bottom = KeyC("L"),
                 ),
@@ -186,7 +182,6 @@ val KB_EN_FR_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top =
                         KeyC(
                             display = KeyDisplay.IconDisplay(Icons.Outlined.KeyboardCapslock),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENHRMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENHRMessagEase.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_HR_MESSAGEASE_MAIN =
     KeyboardC(
@@ -22,12 +21,10 @@ val KB_EN_HR_MESSAGEASE_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("l"),
                 ),
                 KeyItemC(
                     center = KeyC("i", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("x"),
                 ),
                 EMOJI_KEY_ITEM,
@@ -52,7 +49,6 @@ val KB_EN_HR_MESSAGEASE_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("m"),
                     top =
                         KeyC(
@@ -86,7 +82,6 @@ val KB_EN_HR_MESSAGEASE_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("f"),
                 ),
                 BACKSPACE_KEY_ITEM,
@@ -110,12 +105,10 @@ val KB_EN_HR_MESSAGEASE_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("L"),
                 ),
                 KeyItemC(
                     center = KeyC("I", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("X"),
                 ),
                 EMOJI_KEY_ITEM,
@@ -140,7 +133,6 @@ val KB_EN_HR_MESSAGEASE_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("M"),
                     bottom =
                         KeyC(
@@ -177,7 +169,6 @@ val KB_EN_HR_MESSAGEASE_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("F"),
                 ),
                 BACKSPACE_KEY_ITEM,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENITThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENITThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_IT_THUMBKEY_MAIN =
     KeyboardC(
@@ -16,17 +15,14 @@ val KB_EN_IT_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("w"),
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("g"),
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("ò"),
                     bottomRight = KeyC("ù"),
                     bottomLeft = KeyC("u"),
@@ -36,12 +32,10 @@ val KB_EN_IT_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("m"),
                 ),
                 KeyItemC(
                     center = KeyC("h", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     topLeft = KeyC("j"),
                     top = KeyC("q"),
                     topRight = KeyC("b"),
@@ -53,7 +47,6 @@ val KB_EN_IT_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     left = KeyC("l"),
                     top =
                         KeyC(
@@ -74,12 +67,10 @@ val KB_EN_IT_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("c"),
                 ),
                 KeyItemC(
                     center = KeyC("i", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     topLeft = KeyC("ì"),
                     top = KeyC("f"),
                     topRight = KeyC("'", color = MUTED),
@@ -90,7 +81,6 @@ val KB_EN_IT_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("d"),
                     topRight = KeyC("è"),
                     bottomRight = KeyC("é"),
@@ -110,17 +100,14 @@ val KB_EN_IT_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("W"),
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("G"),
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("Ò"),
                     bottomRight = KeyC("Ù"),
                     bottomLeft = KeyC("U"),
@@ -130,12 +117,10 @@ val KB_EN_IT_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("M"),
                 ),
                 KeyItemC(
                     center = KeyC("H", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     topLeft = KeyC("J"),
                     top = KeyC("Q"),
                     topRight = KeyC("B"),
@@ -147,7 +132,6 @@ val KB_EN_IT_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     left = KeyC("L"),
                     bottom =
                         KeyC(
@@ -171,12 +155,10 @@ val KB_EN_IT_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("C"),
                 ),
                 KeyItemC(
                     center = KeyC("I", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     topLeft = KeyC("Ì"),
                     top = KeyC("F"),
                     topRight = KeyC("'", color = MUTED),
@@ -187,7 +169,6 @@ val KB_EN_IT_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("D"),
                     topRight = KeyC("È"),
                     bottomRight = KeyC("É"),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENLAThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENLAThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_LA_THUMBKEY_MAIN =
     KeyboardC(
@@ -16,19 +15,16 @@ val KB_EN_LA_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     bottomRight = KeyC("w"),
                     top = KeyC("ī"),
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("g"),
                     top = KeyC("ȳ"),
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     bottomLeft = KeyC("u"),
                     bottom = KeyC("ū"),
                     top = KeyC("ō"),
@@ -38,7 +34,6 @@ val KB_EN_LA_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("m"),
                 ),
                 KeyItemC(
@@ -54,7 +49,6 @@ val KB_EN_LA_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("l"),
                     top =
                         KeyC(
@@ -75,7 +69,6 @@ val KB_EN_LA_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("c"),
                 ),
                 KeyItemC(
@@ -89,7 +82,6 @@ val KB_EN_LA_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     topLeft = KeyC("d"),
                     top = KeyC("ē"),
                 ),
@@ -108,19 +100,16 @@ val KB_EN_LA_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     bottomRight = KeyC("W"),
                     top = KeyC("Ī"),
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("G"),
                     top = KeyC("Ȳ"),
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     bottomLeft = KeyC("U"),
                     bottom = KeyC("Ū"),
                     top = KeyC("Ō"),
@@ -130,7 +119,6 @@ val KB_EN_LA_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("M"),
                 ),
                 KeyItemC(
@@ -146,7 +134,6 @@ val KB_EN_LA_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("L"),
                     bottom =
                         KeyC(
@@ -170,7 +157,6 @@ val KB_EN_LA_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("C"),
                 ),
                 KeyItemC(
@@ -184,7 +170,6 @@ val KB_EN_LA_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     topLeft = KeyC("D"),
                     top = KeyC("Ē"),
                 ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMIThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMIThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_MI_THUMBKEY_MAIN =
     KeyboardC(
@@ -16,17 +15,14 @@ val KB_EN_MI_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("w"),
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("g"),
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     right = KeyC("ō"),
                     bottom = KeyC("ū"),
                     bottomLeft = KeyC("u"),
@@ -36,7 +32,6 @@ val KB_EN_MI_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("m"),
                 ),
                 KeyItemC(
@@ -52,7 +47,6 @@ val KB_EN_MI_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("l"),
                     right = KeyC("ā"),
                     top =
@@ -73,12 +67,10 @@ val KB_EN_MI_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("c"),
                 ),
                 KeyItemC(
                     center = KeyC("i", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     top = KeyC("f"),
                     topRight = KeyC("'", color = MUTED),
                     right = KeyC("z"),
@@ -89,7 +81,6 @@ val KB_EN_MI_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     right = KeyC("ē"),
                     topLeft = KeyC("d"),
                 ),
@@ -108,17 +99,14 @@ val KB_EN_MI_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("W"),
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("G"),
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     right = KeyC("Ō"),
                     bottom = KeyC("Ū"),
                     bottomLeft = KeyC("U"),
@@ -128,7 +116,6 @@ val KB_EN_MI_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("M"),
                 ),
                 KeyItemC(
@@ -144,7 +131,6 @@ val KB_EN_MI_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("L"),
                     right = KeyC("Ā"),
                     bottom =
@@ -168,7 +154,6 @@ val KB_EN_MI_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("C"),
                 ),
                 KeyItemC(
@@ -183,7 +168,6 @@ val KB_EN_MI_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("D"),
                     right = KeyC("Ē"),
                 ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMIThumbKeySymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMIThumbKeySymbols.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 // Adds more punctuation options to the main screen to reduce switches to the numeric keyboard
 val KB_EN_MI_THUMBKEY_SYMBOLS_MAIN =
@@ -17,7 +16,6 @@ val KB_EN_MI_THUMBKEY_SYMBOLS_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("w"),
                     bottomLeft = KeyC("$", color = MUTED),
                 ),
@@ -34,7 +32,6 @@ val KB_EN_MI_THUMBKEY_SYMBOLS_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     topLeft = KeyC("ū"),
                     top = KeyC("ā"),
                     right = KeyC("ō"),
@@ -92,7 +89,6 @@ val KB_EN_MI_THUMBKEY_SYMBOLS_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("c"),
                     topLeft = KeyC("~", color = MUTED),
                     bottomRight = KeyC(":", color = MUTED),
@@ -111,7 +107,6 @@ val KB_EN_MI_THUMBKEY_SYMBOLS_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     topLeft = KeyC("d"),
                     top = KeyC("&", color = MUTED),
                     topRight = KeyC("°", color = MUTED),
@@ -136,7 +131,6 @@ val KB_EN_MI_THUMBKEY_SYMBOLS_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("W"),
                     bottomLeft = KeyC("$", color = MUTED),
                 ),
@@ -213,7 +207,6 @@ val KB_EN_MI_THUMBKEY_SYMBOLS_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("C"),
                     topLeft = KeyC("~", color = MUTED),
                     bottomRight = KeyC(":", color = MUTED),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEase.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_MESSAGEASE_MAIN =
     KeyboardC(
@@ -16,17 +15,14 @@ val KB_EN_MESSAGEASE_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("v"),
                 ),
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("l"),
                 ),
                 KeyItemC(
                     center = KeyC("i", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("x"),
                 ),
                 EMOJI_KEY_ITEM,
@@ -34,7 +30,6 @@ val KB_EN_MESSAGEASE_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("h", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("k"),
                 ),
                 KeyItemC(
@@ -50,7 +45,6 @@ val KB_EN_MESSAGEASE_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("m"),
                     top =
                         KeyC(
@@ -70,7 +64,6 @@ val KB_EN_MESSAGEASE_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("y"),
                 ),
                 KeyItemC(
@@ -84,7 +77,6 @@ val KB_EN_MESSAGEASE_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("f"),
                 ),
                 BACKSPACE_KEY_ITEM,
@@ -102,17 +94,14 @@ val KB_EN_MESSAGEASE_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("V"),
                 ),
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("L"),
                 ),
                 KeyItemC(
                     center = KeyC("I", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("X"),
                 ),
                 EMOJI_KEY_ITEM,
@@ -120,7 +109,6 @@ val KB_EN_MESSAGEASE_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("H", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("K"),
                 ),
                 KeyItemC(
@@ -136,7 +124,6 @@ val KB_EN_MESSAGEASE_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("M"),
                     bottom =
                         KeyC(
@@ -159,7 +146,6 @@ val KB_EN_MESSAGEASE_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("Y"),
                 ),
                 KeyItemC(
@@ -173,7 +159,6 @@ val KB_EN_MESSAGEASE_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("F"),
                 ),
                 BACKSPACE_KEY_ITEM,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseCompose.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseCompose.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_MESSAGEASE_COMPOSED_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseLeft.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseLeft.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_MESSAGEASE_LEFT: KeyboardDefinition =
     KeyboardDefinition(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseLeftSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseLeftSymbols.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_MESSAGEASE_LEFT_SYMBOLS: KeyboardDefinition =
     KeyboardDefinition(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseSymbols.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_MESSAGEASE_SYMBOLS_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseSymbolsTwoHands.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseSymbolsTwoHands.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_MESSAGEASE_SYMBOLS_TWO_HANDS_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseTwoHands.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseTwoHands.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_MESSAGEASE_TWO_HANDS_MAIN =
     KeyboardC(
@@ -16,40 +15,33 @@ val KB_EN_MESSAGEASE_TWO_HANDS_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("v"),
                 ),
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("l"),
                 ),
                 KeyItemC(
                     center = KeyC("i", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("x"),
                 ),
                 EMOJI_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("v"),
                 ),
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("l"),
                 ),
                 KeyItemC(
                     center = KeyC("i", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("x"),
                 ),
             ),
             listOf(
                 KeyItemC(
                     center = KeyC("h", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("k"),
                 ),
                 KeyItemC(
@@ -65,7 +57,6 @@ val KB_EN_MESSAGEASE_TWO_HANDS_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("m"),
                     top =
                         KeyC(
@@ -83,7 +74,6 @@ val KB_EN_MESSAGEASE_TWO_HANDS_MAIN =
                 NUMERIC_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("h", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("k"),
                 ),
                 KeyItemC(
@@ -99,7 +89,6 @@ val KB_EN_MESSAGEASE_TWO_HANDS_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("m"),
                     top =
                         KeyC(
@@ -118,7 +107,6 @@ val KB_EN_MESSAGEASE_TWO_HANDS_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("y"),
                 ),
                 KeyItemC(
@@ -132,13 +120,11 @@ val KB_EN_MESSAGEASE_TWO_HANDS_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("f"),
                 ),
                 BACKSPACE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("y"),
                 ),
                 KeyItemC(
@@ -152,7 +138,6 @@ val KB_EN_MESSAGEASE_TWO_HANDS_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("f"),
                 ),
             ),
@@ -172,40 +157,33 @@ val KB_EN_MESSAGEASE_TWO_HANDS_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("V"),
                 ),
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("L"),
                 ),
                 KeyItemC(
                     center = KeyC("I", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("X"),
                 ),
                 EMOJI_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("V"),
                 ),
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("L"),
                 ),
                 KeyItemC(
                     center = KeyC("I", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("X"),
                 ),
             ),
             listOf(
                 KeyItemC(
                     center = KeyC("H", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("K"),
                 ),
                 KeyItemC(
@@ -221,7 +199,6 @@ val KB_EN_MESSAGEASE_TWO_HANDS_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("M"),
                     bottom =
                         KeyC(
@@ -242,7 +219,6 @@ val KB_EN_MESSAGEASE_TWO_HANDS_SHIFTED =
                 NUMERIC_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("H", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("K"),
                 ),
                 KeyItemC(
@@ -258,7 +234,6 @@ val KB_EN_MESSAGEASE_TWO_HANDS_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("M"),
                     bottom =
                         KeyC(
@@ -280,7 +255,6 @@ val KB_EN_MESSAGEASE_TWO_HANDS_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("Y"),
                 ),
                 KeyItemC(
@@ -294,13 +268,11 @@ val KB_EN_MESSAGEASE_TWO_HANDS_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("F"),
                 ),
                 BACKSPACE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("Y"),
                 ),
                 KeyItemC(
@@ -314,7 +286,6 @@ val KB_EN_MESSAGEASE_TWO_HANDS_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("F"),
                 ),
             ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseWriter.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseWriter.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_MESSAGEASE_WRITER_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENNOMessagEaseSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENNOMessagEaseSymbols.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_NO_MESSAGEASE_SYMBOLS_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENNOThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENNOThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_NO_THUMBKEY_MAIN =
     KeyboardC(
@@ -16,17 +15,14 @@ val KB_EN_NO_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("w"),
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("g"),
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("u"),
                     bottomRight = KeyC("ø"),
                     topLeft = KeyC("ò"),
@@ -37,7 +33,6 @@ val KB_EN_NO_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("m"),
                 ),
                 KeyItemC(
@@ -53,7 +48,6 @@ val KB_EN_NO_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("l"),
                     top =
                         KeyC(
@@ -74,7 +68,6 @@ val KB_EN_NO_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("c"),
                 ),
                 KeyItemC(
@@ -88,7 +81,6 @@ val KB_EN_NO_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("d"),
                     topRight = KeyC("æ"),
                     bottomLeft = KeyC("é"),
@@ -108,17 +100,14 @@ val KB_EN_NO_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("W"),
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("G"),
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("U"),
                     bottomRight = KeyC("Ø"),
                     topLeft = KeyC("Ò"),
@@ -129,7 +118,6 @@ val KB_EN_NO_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("M"),
                 ),
                 KeyItemC(
@@ -145,7 +133,6 @@ val KB_EN_NO_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("L"),
                     bottom =
                         KeyC(
@@ -169,7 +156,6 @@ val KB_EN_NO_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("C"),
                 ),
                 KeyItemC(
@@ -183,7 +169,6 @@ val KB_EN_NO_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("D"),
                     topRight = KeyC("Æ"),
                     bottomLeft = KeyC("É"),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENNOTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENNOTypeSplit.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_NO_TYPESPLIT_MAIN =
     KeyboardC(
@@ -14,7 +13,6 @@ val KB_EN_NO_TYPESPLIT_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("q"),
                     left =
                         KeyC(
@@ -25,13 +23,11 @@ val KB_EN_NO_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("r"),
                 ),
                 EMOJI_KEY_ITEM_ALT,
                 KeyItemC(
                     center = KeyC("i", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("y"),
                     left =
                         KeyC(
@@ -42,7 +38,6 @@ val KB_EN_NO_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("p"),
                     left = KeyC("ø"),
                 ),
@@ -50,13 +45,11 @@ val KB_EN_NO_TYPESPLIT_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("æ"),
                     right = KeyC("å"),
                 ),
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -68,12 +61,10 @@ val KB_EN_NO_TYPESPLIT_MAIN =
                 SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("h", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("g"),
                 ),
                 KeyItemC(
                     center = KeyC("l", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -86,7 +77,6 @@ val KB_EN_NO_TYPESPLIT_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("c", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("z"),
                     left =
                         KeyC(
@@ -97,7 +87,6 @@ val KB_EN_NO_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("b", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("v"),
                 ),
                 SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
@@ -106,7 +95,6 @@ val KB_EN_NO_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("m", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("?", color = MUTED),
                     left = KeyC("!", color = MUTED),
                     bottom = KeyC(":", color = MUTED),
@@ -127,7 +115,6 @@ val KB_EN_NO_TYPESPLIT_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("Q"),
                     left =
                         KeyC(
@@ -138,13 +125,11 @@ val KB_EN_NO_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("R"),
                 ),
                 EMOJI_KEY_ITEM_ALT,
                 KeyItemC(
                     center = KeyC("I", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("Y"),
                     left =
                         KeyC(
@@ -155,7 +140,6 @@ val KB_EN_NO_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("P"),
                     left = KeyC("Ø"),
                 ),
@@ -163,13 +147,11 @@ val KB_EN_NO_TYPESPLIT_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("Æ"),
                     right = KeyC("Å"),
                 ),
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -181,12 +163,10 @@ val KB_EN_NO_TYPESPLIT_SHIFTED =
                 SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("H", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("G"),
                 ),
                 KeyItemC(
                     center = KeyC("L", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -199,7 +179,6 @@ val KB_EN_NO_TYPESPLIT_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("C", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("Z"),
                     left =
                         KeyC(
@@ -210,7 +189,6 @@ val KB_EN_NO_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("B", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("V"),
                 ),
                 SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
@@ -219,7 +197,6 @@ val KB_EN_NO_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("M", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("?", color = MUTED),
                     left = KeyC("!", color = MUTED),
                     bottom = KeyC(":", color = MUTED),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENPHMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENPHMessagEase.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_PH_MESSAGEASE_MAIN =
     KeyboardC(
@@ -34,7 +33,6 @@ val KB_EN_PH_MESSAGEASE_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("h", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("k"),
                 ),
                 KeyItemC(
@@ -50,7 +48,6 @@ val KB_EN_PH_MESSAGEASE_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("m"),
                     top =
                         KeyC(
@@ -70,7 +67,6 @@ val KB_EN_PH_MESSAGEASE_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("y"),
                 ),
                 KeyItemC(
@@ -84,7 +80,6 @@ val KB_EN_PH_MESSAGEASE_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("f"),
                 ),
                 BACKSPACE_KEY_ITEM,
@@ -120,7 +115,6 @@ val KB_EN_PH_MESSAGEASE_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("H", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("K"),
                 ),
                 KeyItemC(
@@ -136,7 +130,6 @@ val KB_EN_PH_MESSAGEASE_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("M"),
                     bottom =
                         KeyC(
@@ -159,7 +152,6 @@ val KB_EN_PH_MESSAGEASE_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("Y"),
                 ),
                 KeyItemC(
@@ -173,7 +165,6 @@ val KB_EN_PH_MESSAGEASE_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("F"),
                 ),
                 BACKSPACE_KEY_ITEM,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENPLThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENPLThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_PL_THUMBKEY_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENQBased.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENQBased.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_QBASED_MAIN =
     KeyboardC(
@@ -45,19 +44,16 @@ val KB_EN_QBASED_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     left = KeyC("a", color = PRIMARY),
                     right = KeyC("d", color = PRIMARY),
                 ),
                 KeyItemC(
                     center = KeyC("g", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     left = KeyC("f", color = PRIMARY),
                     right = KeyC("h", color = PRIMARY),
                 ),
                 KeyItemC(
                     center = KeyC("k", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("j", color = PRIMARY),
                     right = KeyC("l", color = PRIMARY),
                     top = KeyC("\""),
@@ -68,7 +64,6 @@ val KB_EN_QBASED_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("z", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("x", color = PRIMARY),
                     left =
                         KeyC(
@@ -79,14 +74,12 @@ val KB_EN_QBASED_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("v", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("c", color = PRIMARY),
                     right = KeyC("b", color = PRIMARY),
                     bottom = KeyC(","),
                 ),
                 KeyItemC(
                     center = KeyC("m", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("?"),
                     top = KeyC("!"),
                     bottom = KeyC("."),
@@ -136,19 +129,16 @@ val KB_EN_QBASED_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     left = KeyC("A", color = PRIMARY),
                     right = KeyC("D", color = PRIMARY),
                 ),
                 KeyItemC(
                     center = KeyC("G", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     left = KeyC("F", color = PRIMARY),
                     right = KeyC("H", color = PRIMARY),
                 ),
                 KeyItemC(
                     center = KeyC("K", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     left = KeyC("J", color = PRIMARY),
                     right = KeyC("L", color = PRIMARY),
                 ),
@@ -157,7 +147,6 @@ val KB_EN_QBASED_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("Z", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("X", color = PRIMARY),
                     top =
                         KeyC(
@@ -175,13 +164,11 @@ val KB_EN_QBASED_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("V", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     left = KeyC("C", color = PRIMARY),
                     right = KeyC("B", color = PRIMARY),
                 ),
                 KeyItemC(
                     center = KeyC("M", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("/"),
                     left = KeyC("N", color = PRIMARY),
                 ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENQBasedLeft.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENQBasedLeft.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_QBASED_LEFT: KeyboardDefinition =
     KeyboardDefinition(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENQwertEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENQwertEase.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_QWERTEASE_MAIN =
     KeyboardC(
@@ -32,7 +31,6 @@ val KB_EN_QWERTEASE_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("h", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("k"),
                 ),
                 KeyItemC(
@@ -48,7 +46,6 @@ val KB_EN_QWERTEASE_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("l"),
                     top =
                         KeyC(
@@ -117,7 +114,6 @@ val KB_EN_QWERTEASE_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("H", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("K"),
                 ),
                 KeyItemC(
@@ -133,7 +129,6 @@ val KB_EN_QWERTEASE_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("L"),
                     bottom =
                         KeyC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENQwertEaseTwoHands.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENQwertEaseTwoHands.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_QWERTEASE_TWO_HANDS_MAIN =
     KeyboardC(
@@ -45,7 +44,6 @@ val KB_EN_QWERTEASE_TWO_HANDS_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("h", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("k"),
                 ),
                 KeyItemC(
@@ -61,7 +59,6 @@ val KB_EN_QWERTEASE_TWO_HANDS_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("l"),
                     top =
                         KeyC(
@@ -79,7 +76,6 @@ val KB_EN_QWERTEASE_TWO_HANDS_MAIN =
                 NUMERIC_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("h", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("k"),
                 ),
                 KeyItemC(
@@ -95,7 +91,6 @@ val KB_EN_QWERTEASE_TWO_HANDS_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("l"),
                     top =
                         KeyC(
@@ -199,7 +194,6 @@ val KB_EN_QWERTEASE_TWO_HANDS_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("H", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("K"),
                 ),
                 KeyItemC(
@@ -215,7 +209,6 @@ val KB_EN_QWERTEASE_TWO_HANDS_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("L"),
                     bottom =
                         KeyC(
@@ -236,7 +229,6 @@ val KB_EN_QWERTEASE_TWO_HANDS_SHIFTED =
                 NUMERIC_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("H", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("K"),
                 ),
                 KeyItemC(
@@ -252,7 +244,6 @@ val KB_EN_QWERTEASE_TWO_HANDS_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("L"),
                     bottom =
                         KeyC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENQwertyfour.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENQwertyfour.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_QWERTYFOUR_MAIN =
     KeyboardC(
@@ -16,7 +15,6 @@ val KB_EN_QWERTYFOUR_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("\"", color = MUTED),
                     right = KeyC("w"),
                     bottom = KeyC("q"),
@@ -24,7 +22,6 @@ val KB_EN_QWERTYFOUR_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("'", color = MUTED),
                     right = KeyC("u"),
                     bottom = KeyC("y"),
@@ -32,7 +29,6 @@ val KB_EN_QWERTYFOUR_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC(".", color = MUTED),
                     right = KeyC(",", color = MUTED),
                     bottom = KeyC("p"),
@@ -43,7 +39,6 @@ val KB_EN_QWERTYFOUR_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("d"),
                     right = KeyC("s"),
                     bottom = KeyC("f"),
@@ -51,14 +46,12 @@ val KB_EN_QWERTYFOUR_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("h", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("j"),
                     bottom = KeyC("v"),
                     left = KeyC("g"),
                 ),
                 KeyItemC(
                     center = KeyC("l", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top =
                         KeyC(
                             display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
@@ -79,7 +72,6 @@ val KB_EN_QWERTYFOUR_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("c", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("z"),
                     right = KeyC("x"),
                     bottom = KeyC("@", color = MUTED),
@@ -87,7 +79,6 @@ val KB_EN_QWERTYFOUR_MAIN =
                 SPACEBAR_SKINNY_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("m"),
                     right = KeyC("?", color = MUTED),
                     bottom = KeyC("!", color = MUTED),
@@ -108,7 +99,6 @@ val KB_EN_QWERTYFOUR_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("\"", color = MUTED),
                     right = KeyC("W"),
                     bottom = KeyC("Q"),
@@ -116,7 +106,6 @@ val KB_EN_QWERTYFOUR_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("'", color = MUTED),
                     right = KeyC("U"),
                     bottom = KeyC("Y"),
@@ -124,7 +113,6 @@ val KB_EN_QWERTYFOUR_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC(".", color = MUTED),
                     right = KeyC(",", color = MUTED),
                     bottom = KeyC("P"),
@@ -135,7 +123,6 @@ val KB_EN_QWERTYFOUR_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("D"),
                     right = KeyC("S"),
                     bottom = KeyC("F"),
@@ -143,14 +130,12 @@ val KB_EN_QWERTYFOUR_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("H", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("J"),
                     bottom = KeyC("V"),
                     left = KeyC("G"),
                 ),
                 KeyItemC(
                     center = KeyC("L", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top =
                         KeyC(
                             display = KeyDisplay.IconDisplay(Icons.Outlined.KeyboardCapslock),
@@ -174,7 +159,6 @@ val KB_EN_QWERTYFOUR_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("C", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("Z"),
                     right = KeyC("X"),
                     bottom = KeyC("@", color = MUTED),
@@ -182,7 +166,6 @@ val KB_EN_QWERTYFOUR_SHIFTED =
                 SPACEBAR_SKINNY_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("M"),
                     right = KeyC("?", color = MUTED),
                     bottom = KeyC("!", color = MUTED),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENQwertyfourCompose.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENQwertyfourCompose.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_QWERTYFOUR_COMPOSE_MAIN =
     KeyboardC(
@@ -16,7 +15,6 @@ val KB_EN_QWERTYFOUR_COMPOSE_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("\"", color = MUTED),
                     right = KeyC("w"),
                     bottom = KeyC("q"),
@@ -24,7 +22,6 @@ val KB_EN_QWERTYFOUR_COMPOSE_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("'", color = MUTED),
                     right = KeyC("u"),
                     bottom = KeyC("y"),
@@ -32,7 +29,6 @@ val KB_EN_QWERTYFOUR_COMPOSE_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC(".", color = MUTED),
                     right = KeyC(",", color = MUTED),
                     bottom = KeyC("p"),
@@ -43,7 +39,6 @@ val KB_EN_QWERTYFOUR_COMPOSE_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("d"),
                     right = KeyC("s"),
                     bottom = KeyC("f"),
@@ -80,7 +75,6 @@ val KB_EN_QWERTYFOUR_COMPOSE_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("l", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top =
                         KeyC(
                             display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
@@ -101,7 +95,6 @@ val KB_EN_QWERTYFOUR_COMPOSE_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("c", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("z"),
                     left = KeyC("*", color = MUTED),
                     right = KeyC("x"),
@@ -137,7 +130,6 @@ val KB_EN_QWERTYFOUR_COMPOSE_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("m"),
                     right = KeyC("?", color = MUTED),
                     bottom = KeyC("!", color = MUTED),
@@ -158,7 +150,6 @@ val KB_EN_QWERTYFOUR_COMPOSE_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("\"", color = MUTED),
                     right = KeyC("W"),
                     bottom = KeyC("Q"),
@@ -166,7 +157,6 @@ val KB_EN_QWERTYFOUR_COMPOSE_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("'", color = MUTED),
                     right = KeyC("U"),
                     bottom = KeyC("Y"),
@@ -174,7 +164,6 @@ val KB_EN_QWERTYFOUR_COMPOSE_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC(".", color = MUTED),
                     right = KeyC(",", color = MUTED),
                     bottom = KeyC("P"),
@@ -185,7 +174,6 @@ val KB_EN_QWERTYFOUR_COMPOSE_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("D"),
                     right = KeyC("S"),
                     bottom = KeyC("F"),
@@ -222,7 +210,6 @@ val KB_EN_QWERTYFOUR_COMPOSE_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("L", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top =
                         KeyC(
                             display = KeyDisplay.IconDisplay(Icons.Outlined.KeyboardCapslock),
@@ -246,7 +233,6 @@ val KB_EN_QWERTYFOUR_COMPOSE_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("C", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("Z"),
                     left = KeyC("*", color = MUTED),
                     right = KeyC("X"),
@@ -282,7 +268,6 @@ val KB_EN_QWERTYFOUR_COMPOSE_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("M"),
                     right = KeyC("?", color = MUTED),
                     bottom = KeyC("!", color = MUTED),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENROThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENROThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_RO_THUMBKEY_MAIN =
     KeyboardC(
@@ -16,18 +15,15 @@ val KB_EN_RO_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     bottomRight = KeyC("w"),
                     bottom = KeyC("ș"),
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("g"),
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     bottomLeft = KeyC("u"),
                     bottom = KeyC("â"),
                     top = KeyC("î"),
@@ -37,7 +33,6 @@ val KB_EN_RO_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("m"),
                 ),
                 KeyItemC(
@@ -53,7 +48,6 @@ val KB_EN_RO_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("l"),
                     top =
                         KeyC(
@@ -74,7 +68,6 @@ val KB_EN_RO_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     topRight = KeyC("c"),
                     top = KeyC("ț"),
                 ),
@@ -89,7 +82,6 @@ val KB_EN_RO_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("d"),
                 ),
                 BACKSPACE_KEY_ITEM,
@@ -107,18 +99,15 @@ val KB_EN_RO_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     bottomRight = KeyC("W"),
                     bottom = KeyC("Ș"),
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("G"),
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     bottomLeft = KeyC("U"),
                     bottom = KeyC("Â"),
                     top = KeyC("Î"),
@@ -128,7 +117,6 @@ val KB_EN_RO_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("M"),
                 ),
                 KeyItemC(
@@ -144,7 +132,6 @@ val KB_EN_RO_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("L"),
                     bottom =
                         KeyC(
@@ -168,7 +155,6 @@ val KB_EN_RO_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     topRight = KeyC("C"),
                     top = KeyC("Ț"),
                 ),
@@ -183,7 +169,6 @@ val KB_EN_RO_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("D"),
                 ),
                 BACKSPACE_KEY_ITEM,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENRsinoa.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENRsinoa.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_RSINOA_MAIN =
     KeyboardC(
@@ -16,18 +15,15 @@ val KB_EN_RSINOA_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("c"),
                 ),
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("k"),
                     right = KeyC("z"),
                 ),
                 KeyItemC(
                     center = KeyC("i", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top =
                         KeyC(
                             display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
@@ -46,14 +42,12 @@ val KB_EN_RSINOA_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("l"),
                     bottom = KeyC("v"),
                     top = KeyC("x"),
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("f"),
                     topLeft = KeyC("p"),
                     bottomRight = KeyC("d"),
@@ -61,7 +55,6 @@ val KB_EN_RSINOA_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("u"),
                     bottom = KeyC("y"),
                 ),
@@ -70,20 +63,17 @@ val KB_EN_RSINOA_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("h", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("j"),
                     right = KeyC("m"),
                 ),
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("w"),
                     topLeft = KeyC("b"),
                     bottomRight = KeyC(",", color = MUTED),
                 ),
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     topRight = KeyC("q"),
                     topLeft = KeyC("'", color = MUTED),
                     bottom = KeyC(".", color = MUTED),
@@ -103,18 +93,15 @@ val KB_EN_RSINOA_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("C"),
                 ),
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("K"),
                     right = KeyC("Z"),
                 ),
                 KeyItemC(
                     center = KeyC("I", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom =
                         KeyC(
                             display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
@@ -136,14 +123,12 @@ val KB_EN_RSINOA_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("L"),
                     bottom = KeyC("V"),
                     top = KeyC("X"),
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("F"),
                     topLeft = KeyC("P"),
                     bottomRight = KeyC("D"),
@@ -151,7 +136,6 @@ val KB_EN_RSINOA_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("U"),
                     bottom = KeyC("Y"),
                 ),
@@ -160,20 +144,17 @@ val KB_EN_RSINOA_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("H", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("J"),
                     right = KeyC("M"),
                 ),
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("W"),
                     topLeft = KeyC("B"),
                     bottomRight = KeyC(",", color = MUTED),
                 ),
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     topRight = KeyC("Q"),
                     topLeft = KeyC("'", color = MUTED),
                     bottom = KeyC(".", color = MUTED),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENSKThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENSKThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_SK_THUMBKEY_MAIN =
     KeyboardC(
@@ -16,20 +15,17 @@ val KB_EN_SK_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     top = KeyC("š"),
                     bottomRight = KeyC("w"),
                     left = KeyC("ô"),
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("ŕ"),
                     bottom = KeyC("g"),
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     top = KeyC("ó"),
                     bottomRight = KeyC("ú"),
                     bottomLeft = KeyC("u"),
@@ -39,14 +35,12 @@ val KB_EN_SK_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("ň"),
                     right = KeyC("m"),
                     left = KeyC("ä"),
                 ),
                 KeyItemC(
                     center = KeyC("h", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     topLeft = KeyC("j"),
                     top = KeyC("q"),
                     topRight = KeyC("b"),
@@ -58,7 +52,6 @@ val KB_EN_SK_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     topLeft = KeyC("ĺ"),
                     top =
                         KeyC(
@@ -82,14 +75,12 @@ val KB_EN_SK_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     top = KeyC("ť"),
                     topRight = KeyC("c"),
                     bottomRight = KeyC("č"),
                 ),
                 KeyItemC(
                     center = KeyC("i", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     topLeft = KeyC("í"),
                     top = KeyC("f"),
                     topRight = KeyC("'", color = MUTED),
@@ -100,7 +91,6 @@ val KB_EN_SK_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     topLeft = KeyC("d"),
                     top = KeyC("é"),
                     right = KeyC("ž"),
@@ -121,20 +111,17 @@ val KB_EN_SK_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     top = KeyC("Š"),
                     bottomRight = KeyC("W"),
                     left = KeyC("Ô"),
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("Ŕ"),
                     bottom = KeyC("G"),
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     top = KeyC("Ó"),
                     bottomRight = KeyC("Ú"),
                     bottomLeft = KeyC("U"),
@@ -144,14 +131,12 @@ val KB_EN_SK_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("Ň"),
                     right = KeyC("M"),
                     left = KeyC("Ä"),
                 ),
                 KeyItemC(
                     center = KeyC("H", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     topLeft = KeyC("J"),
                     top = KeyC("Q"),
                     topRight = KeyC("B"),
@@ -163,7 +148,6 @@ val KB_EN_SK_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     topLeft = KeyC("Ĺ"),
                     top =
                         KeyC(
@@ -190,14 +174,12 @@ val KB_EN_SK_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     top = KeyC("Ť"),
                     topRight = KeyC("C"),
                     bottomRight = KeyC("Č"),
                 ),
                 KeyItemC(
                     center = KeyC("I", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     topLeft = KeyC("Í"),
                     top = KeyC("F"),
                     topRight = KeyC("'", color = MUTED),
@@ -208,7 +190,6 @@ val KB_EN_SK_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     topLeft = KeyC("D"),
                     top = KeyC("É"),
                     right = KeyC("Ž"),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENSVThumbkeyProgrammer.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENSVThumbkeyProgrammer.kt
@@ -9,7 +9,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 // Adds more punctuation options to the main screen to reduce switches to the numeric keyboard whilst also adding letters å ä ö
 // layout based on "english thumb-key programming". Added å ä ö, changed position of some symbols, and made all symbols accessible without shifting
@@ -72,7 +71,6 @@ val KB_EN_SV_THUMBKEY_PROGRAMMING_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("l"),
                     top =
                         KeyC(
@@ -192,7 +190,6 @@ val KB_EN_SV_THUMBKEY_PROGRAMMING_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("L"),
                     bottom =
                         KeyC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_THUMBKEY_MAIN =
     KeyboardC(
@@ -16,17 +15,14 @@ val KB_EN_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("w"),
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("g"),
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("u"),
                 ),
                 EMOJI_KEY_ITEM,
@@ -34,7 +30,6 @@ val KB_EN_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("m"),
                 ),
                 KeyItemC(
@@ -50,7 +45,6 @@ val KB_EN_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("l"),
                     top =
                         KeyC(
@@ -70,7 +64,6 @@ val KB_EN_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("c"),
                 ),
                 KeyItemC(
@@ -84,7 +77,6 @@ val KB_EN_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("d"),
                 ),
                 BACKSPACE_KEY_ITEM,
@@ -102,17 +94,14 @@ val KB_EN_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("W"),
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("G"),
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("U"),
                 ),
                 EMOJI_KEY_ITEM,
@@ -120,7 +109,6 @@ val KB_EN_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("M"),
                 ),
                 KeyItemC(
@@ -136,7 +124,6 @@ val KB_EN_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("L"),
                     bottom =
                         KeyC(
@@ -159,7 +146,6 @@ val KB_EN_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("C"),
                 ),
                 KeyItemC(
@@ -173,7 +159,6 @@ val KB_EN_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("D"),
                 ),
                 BACKSPACE_KEY_ITEM,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyCompose.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyCompose.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_THUMBKEY_COMPOSE_MAIN =
     KeyboardC(
@@ -16,7 +15,6 @@ val KB_EN_THUMBKEY_COMPOSE_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("w"),
                     topLeft =
                         KeyC(
@@ -39,12 +37,10 @@ val KB_EN_THUMBKEY_COMPOSE_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("g"),
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("u"),
                 ),
                 EMOJI_KEY_ITEM,
@@ -52,7 +48,6 @@ val KB_EN_THUMBKEY_COMPOSE_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     right = KeyC("m"),
                     topRight =
                         KeyC(
@@ -92,7 +87,6 @@ val KB_EN_THUMBKEY_COMPOSE_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("l"),
                     top =
                         KeyC(
@@ -112,7 +106,6 @@ val KB_EN_THUMBKEY_COMPOSE_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("c"),
                     topLeft =
                         KeyC(
@@ -145,7 +138,6 @@ val KB_EN_THUMBKEY_COMPOSE_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("d"),
                 ),
                 BACKSPACE_KEY_ITEM,
@@ -163,7 +155,6 @@ val KB_EN_THUMBKEY_COMPOSE_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("W"),
                     topLeft =
                         KeyC(
@@ -186,12 +177,10 @@ val KB_EN_THUMBKEY_COMPOSE_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("G"),
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("U"),
                 ),
                 EMOJI_KEY_ITEM,
@@ -199,7 +188,6 @@ val KB_EN_THUMBKEY_COMPOSE_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     right = KeyC("M"),
                     topRight =
                         KeyC(
@@ -239,7 +227,6 @@ val KB_EN_THUMBKEY_COMPOSE_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("L"),
                     bottom =
                         KeyC(
@@ -262,7 +249,6 @@ val KB_EN_THUMBKEY_COMPOSE_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("C"),
                     topLeft =
                         KeyC(
@@ -295,7 +281,6 @@ val KB_EN_THUMBKEY_COMPOSE_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("D"),
                 ),
                 BACKSPACE_KEY_ITEM,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyProgrammer.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyProgrammer.kt
@@ -9,7 +9,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 // Adds more punctuation options to the main screen to reduce switches to the numeric keyboard
 val KB_EN_THUMBKEY_PROGRAMMING_MAIN =
@@ -34,7 +33,6 @@ val KB_EN_THUMBKEY_PROGRAMMING_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("u"),
                     bottomRight = KeyC(")", color = MUTED),
                     topLeft = KeyC("=", color = MUTED),
@@ -64,7 +62,6 @@ val KB_EN_THUMBKEY_PROGRAMMING_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("l"),
                     top =
                         KeyC(
@@ -147,7 +144,6 @@ val KB_EN_THUMBKEY_PROGRAMMING_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("U"),
                     bottomRight = KeyC(")", color = MUTED),
                     topLeft = KeyC("=", color = MUTED),
@@ -177,7 +173,6 @@ val KB_EN_THUMBKEY_PROGRAMMING_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("L"),
                     bottom =
                         KeyC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyProgrammerWide.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyProgrammerWide.kt
@@ -9,7 +9,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 // uses programming layout but moves spacebar to the left column in order to make a more aspect ration friendly layout. this grid is 5x3 which is closer to the average phone aspect ration of 16:9 than 4x4 keyboard.
 val KB_EN_THUMBKEY_PROGRAMMING_WIDE_MAIN =
@@ -35,7 +34,6 @@ val KB_EN_THUMBKEY_PROGRAMMING_WIDE_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("u"),
                     bottomRight = KeyC(")", color = MUTED),
                     topLeft = KeyC("=", color = MUTED),
@@ -66,7 +64,6 @@ val KB_EN_THUMBKEY_PROGRAMMING_WIDE_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("l"),
                     top =
                         KeyC(
@@ -147,7 +144,6 @@ val KB_EN_THUMBKEY_PROGRAMMING_WIDE_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("U"),
                     bottomRight = KeyC(")", color = MUTED),
                     topLeft = KeyC("=", color = MUTED),
@@ -178,7 +174,6 @@ val KB_EN_THUMBKEY_PROGRAMMING_WIDE_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("L"),
                     bottom =
                         KeyC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeySymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeySymbols.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 // Adds more punctuation options to the main screen to reduce switches to the numeric keyboard
 val KB_EN_THUMBKEY_SYMBOLS_MAIN =
@@ -17,7 +16,6 @@ val KB_EN_THUMBKEY_SYMBOLS_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("w"),
                     bottomLeft = KeyC("$", color = MUTED),
                 ),
@@ -88,7 +86,6 @@ val KB_EN_THUMBKEY_SYMBOLS_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("c"),
                     topLeft = KeyC("~", color = MUTED),
                     bottomRight = KeyC(":", color = MUTED),
@@ -129,7 +126,6 @@ val KB_EN_THUMBKEY_SYMBOLS_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("W"),
                     bottomLeft = KeyC("$", color = MUTED),
                 ),
@@ -203,7 +199,6 @@ val KB_EN_THUMBKEY_SYMBOLS_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("C"),
                     topLeft = KeyC("~", color = MUTED),
                     bottomRight = KeyC(":", color = MUTED),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyWide.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyWide.kt
@@ -8,12 +8,10 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_THUMBKEY_WIDE_PUNCT_KEY =
     KeyItemC(
         center = KeyC("'", size = LARGE),
-        swipeType = FOUR_WAY_DIAGONAL,
         topLeft = KeyC("!", color = MUTED),
         topRight = KeyC("?", color = MUTED),
         bottomRight = KeyC(".", color = MUTED),
@@ -26,71 +24,59 @@ val KB_EN_THUMBKEY_WIDE_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("w"),
                 ),
                 KeyItemC(
                     center = KeyC("d", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("b"),
                 ),
                 EMOJI_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("l", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("x"),
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("y"),
                 ),
             ),
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("m"),
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     left = KeyC("p"),
                     right = KeyC("q"),
                 ),
                 KB_EN_THUMBKEY_WIDE_PUNCT_KEY,
                 KeyItemC(
                     center = KeyC("u", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     left = KeyC("z"),
                     right = KeyC("v"),
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("g"),
                 ),
             ),
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("c"),
                 ),
                 KeyItemC(
                     center = KeyC("h", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("f"),
                 ),
                 NUMERIC_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("i", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("j"),
                 ),
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("k"),
                 ),
             ),
@@ -98,7 +84,6 @@ val KB_EN_THUMBKEY_WIDE_MAIN =
                 BACKSPACE_KEY_ITEM,
                 SPACEBAR_KEY_ITEM,
                 RETURN_KEY_ITEM.copy(
-                    swipeType = TWO_WAY_VERTICAL,
                     top =
                         KeyC(
                             display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
@@ -122,71 +107,59 @@ val KB_EN_THUMBKEY_WIDE_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("W"),
                 ),
                 KeyItemC(
                     center = KeyC("D", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("B"),
                 ),
                 EMOJI_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("L", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("X"),
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("Y"),
                 ),
             ),
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("M"),
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     left = KeyC("P"),
                     right = KeyC("Q"),
                 ),
                 KB_EN_THUMBKEY_WIDE_PUNCT_KEY,
                 KeyItemC(
                     center = KeyC("U", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     left = KeyC("Z"),
                     right = KeyC("V"),
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("G"),
                 ),
             ),
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("C"),
                 ),
                 KeyItemC(
                     center = KeyC("H", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("F"),
                 ),
                 NUMERIC_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("I", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("J"),
                 ),
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("K"),
                 ),
             ),
@@ -194,7 +167,6 @@ val KB_EN_THUMBKEY_WIDE_SHIFTED =
                 BACKSPACE_KEY_ITEM,
                 SPACEBAR_KEY_ITEM,
                 RETURN_KEY_ITEM.copy(
-                    swipeType = TWO_WAY_VERTICAL,
                     top =
                         KeyC(
                             display = KeyDisplay.IconDisplay(Icons.Outlined.KeyboardCapslock),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyWords.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyWords.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 // Adds common English words to main screen to reduce amount of taps required when typing
 val KB_EN_THUMBKEY_WORDS_MAIN =
@@ -67,7 +66,6 @@ val KB_EN_THUMBKEY_WORDS_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("l"),
                     top =
                         KeyC(
@@ -176,7 +174,6 @@ val KB_EN_THUMBKEY_WORDS_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("L"),
                     bottom =
                         KeyC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyWriter.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyWriter.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 // Adds more punctuation options to the main screen to reduce switches to the numeric keyboard
 val KB_EN_THUMBKEY_WRITER_MAIN =
@@ -17,7 +16,6 @@ val KB_EN_THUMBKEY_WRITER_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("w"),
                     bottomLeft = KeyC("$", color = MUTED),
                 ),
@@ -135,7 +133,6 @@ val KB_EN_THUMBKEY_WRITER_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("W"),
                     bottomLeft = KeyC("$", color = MUTED),
                 ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENTwoHands.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENTwoHands.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_TWO_HANDS_MAIN =
     KeyboardC(
@@ -16,40 +15,33 @@ val KB_EN_TWO_HANDS_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("w"),
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("g"),
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("u"),
                 ),
                 EMOJI_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("w"),
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("g"),
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("u"),
                 ),
             ),
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("m"),
                 ),
                 KeyItemC(
@@ -65,7 +57,6 @@ val KB_EN_TWO_HANDS_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("l"),
                     top =
                         KeyC(
@@ -83,7 +74,6 @@ val KB_EN_TWO_HANDS_MAIN =
                 NUMERIC_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("m"),
                 ),
                 KeyItemC(
@@ -99,7 +89,6 @@ val KB_EN_TWO_HANDS_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("l"),
                     top =
                         KeyC(
@@ -118,7 +107,6 @@ val KB_EN_TWO_HANDS_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("c"),
                 ),
                 KeyItemC(
@@ -132,13 +120,11 @@ val KB_EN_TWO_HANDS_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("d"),
                 ),
                 BACKSPACE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("c"),
                 ),
                 KeyItemC(
@@ -152,7 +138,6 @@ val KB_EN_TWO_HANDS_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("d"),
                 ),
             ),
@@ -172,40 +157,33 @@ val KB_EN_TWO_HANDS_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("W"),
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("G"),
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("U"),
                 ),
                 EMOJI_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("W"),
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("G"),
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("U"),
                 ),
             ),
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("M"),
                 ),
                 KeyItemC(
@@ -221,7 +199,6 @@ val KB_EN_TWO_HANDS_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("L"),
                     bottom =
                         KeyC(
@@ -242,7 +219,6 @@ val KB_EN_TWO_HANDS_SHIFTED =
                 NUMERIC_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("M"),
                 ),
                 KeyItemC(
@@ -258,7 +234,6 @@ val KB_EN_TWO_HANDS_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("L"),
                     bottom =
                         KeyC(
@@ -280,7 +255,6 @@ val KB_EN_TWO_HANDS_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("C"),
                 ),
                 KeyItemC(
@@ -294,13 +268,11 @@ val KB_EN_TWO_HANDS_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("D"),
                 ),
                 BACKSPACE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("C"),
                 ),
                 KeyItemC(
@@ -314,7 +286,6 @@ val KB_EN_TWO_HANDS_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("D"),
                 ),
             ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENTwoHandsSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENTwoHandsSymbols.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_SYMBOLS_TWO_HANDS_MAIN =
     KeyboardC(
@@ -16,7 +15,6 @@ val KB_EN_SYMBOLS_TWO_HANDS_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("w"),
                     bottomLeft = KeyC("$", color = MUTED),
                 ),
@@ -41,7 +39,6 @@ val KB_EN_SYMBOLS_TWO_HANDS_MAIN =
                 EMOJI_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("w"),
                     bottomLeft = KeyC("$", color = MUTED),
                 ),
@@ -152,7 +149,6 @@ val KB_EN_SYMBOLS_TWO_HANDS_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("c"),
                     topLeft = KeyC("~", color = MUTED),
                     bottomRight = KeyC(":", color = MUTED),
@@ -181,7 +177,6 @@ val KB_EN_SYMBOLS_TWO_HANDS_MAIN =
                 BACKSPACE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("c"),
                     topLeft = KeyC("~", color = MUTED),
                     bottomRight = KeyC(":", color = MUTED),
@@ -224,7 +219,6 @@ val KB_EN_SYMBOLS_TWO_HANDS_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("W"),
                     bottomLeft = KeyC("$", color = MUTED),
                 ),
@@ -249,7 +243,6 @@ val KB_EN_SYMBOLS_TWO_HANDS_SHIFTED =
                 EMOJI_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("W"),
                     bottomLeft = KeyC("$", color = MUTED),
                 ),
@@ -366,7 +359,6 @@ val KB_EN_SYMBOLS_TWO_HANDS_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("C"),
                     topLeft = KeyC("~", color = MUTED),
                     bottomRight = KeyC(":", color = MUTED),
@@ -395,7 +387,6 @@ val KB_EN_SYMBOLS_TWO_HANDS_SHIFTED =
                 BACKSPACE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("C"),
                     topLeft = KeyC("~", color = MUTED),
                     bottomRight = KeyC(":", color = MUTED),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENTwoHandsSymbolsNumbers.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENTwoHandsSymbolsNumbers.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_SYMBOLS_NUMBERS_TWO_HANDS_MAIN =
     KeyboardC(
@@ -172,7 +171,6 @@ val KB_EN_SYMBOLS_NUMBERS_TWO_HANDS_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("c"),
                     topLeft = KeyC("~", color = MUTED),
                     bottomRight = KeyC(":", color = MUTED),
@@ -201,7 +199,6 @@ val KB_EN_SYMBOLS_NUMBERS_TWO_HANDS_MAIN =
                 BACKSPACE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("c"),
                     topLeft = KeyC("~", color = MUTED),
                     bottomRight = KeyC(":", color = MUTED),
@@ -406,7 +403,6 @@ val KB_EN_SYMBOLS_NUMBERS_TWO_HANDS_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("C"),
                     topLeft = KeyC("~", color = MUTED),
                     bottomRight = KeyC(":", color = MUTED),
@@ -435,7 +431,6 @@ val KB_EN_SYMBOLS_NUMBERS_TWO_HANDS_SHIFTED =
                 BACKSPACE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("C"),
                     topLeft = KeyC("~", color = MUTED),
                     bottomRight = KeyC(":", color = MUTED),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENTypeSplit.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_TYPESPLIT_MAIN =
     KeyboardC(
@@ -14,7 +13,6 @@ val KB_EN_TYPESPLIT_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("q"),
                     left =
                         KeyC(
@@ -25,13 +23,11 @@ val KB_EN_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("r"),
                 ),
                 EMOJI_KEY_ITEM_ALT,
                 KeyItemC(
                     center = KeyC("i", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("y"),
                     left =
                         KeyC(
@@ -42,7 +38,6 @@ val KB_EN_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("p"),
                 ),
             ),
@@ -52,7 +47,6 @@ val KB_EN_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -64,12 +58,10 @@ val KB_EN_TYPESPLIT_MAIN =
                 SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("h", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("g"),
                 ),
                 KeyItemC(
                     center = KeyC("l", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -82,7 +74,6 @@ val KB_EN_TYPESPLIT_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("c", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("z"),
                     left =
                         KeyC(
@@ -93,7 +84,6 @@ val KB_EN_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("b", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("v"),
                 ),
                 SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
@@ -102,7 +92,6 @@ val KB_EN_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("m", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("?", color = MUTED),
                     left = KeyC("!", color = MUTED),
                     bottom = KeyC(":", color = MUTED),
@@ -123,7 +112,6 @@ val KB_EN_TYPESPLIT_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("Q"),
                     left =
                         KeyC(
@@ -134,13 +122,11 @@ val KB_EN_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("R"),
                 ),
                 EMOJI_KEY_ITEM_ALT,
                 KeyItemC(
                     center = KeyC("I", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("Y"),
                     left =
                         KeyC(
@@ -151,7 +137,6 @@ val KB_EN_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("P"),
                 ),
             ),
@@ -161,7 +146,6 @@ val KB_EN_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -173,12 +157,10 @@ val KB_EN_TYPESPLIT_SHIFTED =
                 SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("H", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("G"),
                 ),
                 KeyItemC(
                     center = KeyC("L", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -191,7 +173,6 @@ val KB_EN_TYPESPLIT_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("C", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("Z"),
                     left =
                         KeyC(
@@ -202,7 +183,6 @@ val KB_EN_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("B", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("V"),
                 ),
                 SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
@@ -211,7 +191,6 @@ val KB_EN_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("M", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("?", color = MUTED),
                     left = KeyC("!", color = MUTED),
                     bottom = KeyC(":", color = MUTED),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENTypeSplitShort.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENTypeSplitShort.kt
@@ -10,12 +10,10 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val EN_TYPESPLIT_SHORT_SPACEBAR_SHIFT_KEY_ITEM =
     KeyItemC(
         center = KeyC(" "),
-        swipeType = FOUR_WAY_CROSS,
         slideType = SlideType.MOVE_CURSOR,
         left =
             KeyC(
@@ -77,7 +75,6 @@ val EN_TYPESPLIT_SHORT_RETURN_KEY_ITEM =
 val EN_TYPESPLIT_SHORT_SPACEBAR_SHIFT_KEY_SHIFTED_ITEM =
     KeyItemC(
         center = KeyC(" "),
-        swipeType = FOUR_WAY_CROSS,
         slideType = SlideType.MOVE_CURSOR,
         left =
             KeyC(
@@ -123,7 +120,6 @@ val EN_TYPESPLIT_SHORT_SPACEBAR_SHIFT_KEY_SHIFTED_ITEM =
 val EN_TYPESPLIT_SHORT_SPACEBAR_ARROWS_KEY_ITEM =
     KeyItemC(
         center = KeyC(" "),
-        swipeType = FOUR_WAY_CROSS,
         slideType = SlideType.MOVE_CURSOR,
         left =
             KeyC(
@@ -183,7 +179,6 @@ val KB_EN_TYPESPLIT_SHORT_MAIN =
             listOf(
                 KeyItemC( // A
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("x"),
                     left = KeyC("-", color = MUTED),
                     bottom = KeyC("z"),
@@ -191,7 +186,6 @@ val KB_EN_TYPESPLIT_SHORT_MAIN =
                 ), // done
                 KeyItemC( // E
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC(".", color = MUTED),
                     left = KeyC("g"),
                     bottom = KeyC("u"),
@@ -200,7 +194,6 @@ val KB_EN_TYPESPLIT_SHORT_MAIN =
                 EMOJI_KEY_ITEM,
                 KeyItemC( // T
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("d"),
                     left = KeyC(",", color = MUTED),
                     bottom = KeyC("r"),
@@ -208,7 +201,6 @@ val KB_EN_TYPESPLIT_SHORT_MAIN =
                 ), // done
                 KeyItemC( // S
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("*", color = MUTED),
                     left = KeyC("b"),
                     bottom = KeyC("c"),
@@ -218,7 +210,6 @@ val KB_EN_TYPESPLIT_SHORT_MAIN =
             listOf(
                 KeyItemC( // i
                     center = KeyC("i", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC(":", color = MUTED),
                     left = KeyC("(", color = MUTED),
                     top = KeyC("q"),
@@ -226,7 +217,6 @@ val KB_EN_TYPESPLIT_SHORT_MAIN =
                 ), // done
                 KeyItemC( // o
                     center = KeyC("o", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("!", color = MUTED),
                     left = KeyC("j"),
                     bottom = KeyC("k"),
@@ -235,7 +225,6 @@ val KB_EN_TYPESPLIT_SHORT_MAIN =
                 NUMERIC_KEY_ITEM,
                 KeyItemC( // n
                     center = KeyC("n", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("f"),
                     left = KeyC("?", color = MUTED),
                     bottom = KeyC("w"),
@@ -243,7 +232,6 @@ val KB_EN_TYPESPLIT_SHORT_MAIN =
                 ), // done
                 KeyItemC( // h
                     center = KeyC("h", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC(";", color = MUTED),
                     right = KeyC(")", color = MUTED),
                     top = KeyC("v"),
@@ -264,7 +252,6 @@ val KB_EN_TYPESPLIT_SHORT_SHIFTED =
             listOf(
                 KeyItemC( // A
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("X"),
                     left = KeyC("-", color = MUTED),
                     bottom = KeyC("Z"),
@@ -272,7 +259,6 @@ val KB_EN_TYPESPLIT_SHORT_SHIFTED =
                 ), // done
                 KeyItemC( // E
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC(".", color = MUTED),
                     left = KeyC("G"),
                     bottom = KeyC("U"),
@@ -281,7 +267,6 @@ val KB_EN_TYPESPLIT_SHORT_SHIFTED =
                 EMOJI_KEY_ITEM,
                 KeyItemC( // T
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("D"),
                     left = KeyC(",", color = MUTED),
                     bottom = KeyC("R"),
@@ -289,7 +274,6 @@ val KB_EN_TYPESPLIT_SHORT_SHIFTED =
                 ), // done
                 KeyItemC( // S
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("*", color = MUTED),
                     left = KeyC("B"),
                     bottom = KeyC("C"),
@@ -299,7 +283,6 @@ val KB_EN_TYPESPLIT_SHORT_SHIFTED =
             listOf(
                 KeyItemC( // i
                     center = KeyC("I", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC(":", color = MUTED),
                     left = KeyC("(", color = MUTED),
                     top = KeyC("Q"),
@@ -307,7 +290,6 @@ val KB_EN_TYPESPLIT_SHORT_SHIFTED =
                 ), // done
                 KeyItemC( // o
                     center = KeyC("O", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("!", color = MUTED),
                     left = KeyC("J"),
                     bottom = KeyC("K"),
@@ -316,7 +298,6 @@ val KB_EN_TYPESPLIT_SHORT_SHIFTED =
                 NUMERIC_KEY_ITEM,
                 KeyItemC( // n
                     center = KeyC("N", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("F"),
                     left = KeyC("?", color = MUTED),
                     bottom = KeyC("W"),
@@ -324,7 +305,6 @@ val KB_EN_TYPESPLIT_SHORT_SHIFTED =
                 ), // done
                 KeyItemC( // h
                     center = KeyC("H", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC(";", color = MUTED),
                     right = KeyC(")", color = MUTED),
                     top = KeyC("V"),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/EOCyrillicThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/EOCyrillicThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EO_CYRILLIC_THUMBKEY_MAIN =
     KeyboardC(
@@ -16,7 +15,6 @@ val KB_EO_CYRILLIC_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("о", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("к"),
                     top = KeyC("м"),
                     left = KeyC("'"),
@@ -24,7 +22,6 @@ val KB_EO_CYRILLIC_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("с", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("ш"),
                     top = KeyC("п"),
                     left = KeyC("ϗ"),
@@ -32,7 +29,6 @@ val KB_EO_CYRILLIC_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("е", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("х"),
                     top = KeyC("һ"),
                     left = KeyC("#"),
@@ -43,7 +39,6 @@ val KB_EO_CYRILLIC_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("н", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("ж"),
                     top = KeyC("j"),
                     left = KeyC("."),
@@ -51,7 +46,6 @@ val KB_EO_CYRILLIC_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("р", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("в"),
                     top = KeyC("ф"),
                     left = KeyC("?"),
@@ -59,7 +53,6 @@ val KB_EO_CYRILLIC_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("а", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("д"),
                     left = KeyC("("),
                     right = KeyC(")"),
@@ -76,21 +69,18 @@ val KB_EO_CYRILLIC_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("т", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("ч"),
                     top = KeyC("ц"),
                     left = KeyC("б"),
                 ),
                 KeyItemC(
                     center = KeyC("л", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("џ"),
                     top = KeyC("г"),
                     right = KeyC("з"),
                 ),
                 KeyItemC(
                     center = KeyC("и", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("ў"),
                     top = KeyC("у"),
                 ),
@@ -109,7 +99,6 @@ val KB_EO_CYRILLIC_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("О", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("К"),
                     top = KeyC("М"),
                     left = KeyC("'"),
@@ -117,7 +106,6 @@ val KB_EO_CYRILLIC_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("С", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("Ш"),
                     top = KeyC("П"),
                     left = KeyC("ϗ"),
@@ -125,7 +113,6 @@ val KB_EO_CYRILLIC_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("Е", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("Х"),
                     top = KeyC("Һ"),
                     left = KeyC("#"),
@@ -136,7 +123,6 @@ val KB_EO_CYRILLIC_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("Н", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("Ж"),
                     top = KeyC("J"),
                     left = KeyC("."),
@@ -144,7 +130,6 @@ val KB_EO_CYRILLIC_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("Р", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("В"),
                     top = KeyC("Ф"),
                     left = KeyC("?"),
@@ -152,7 +137,6 @@ val KB_EO_CYRILLIC_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("А", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("Д"),
                     left = KeyC("("),
                     right = KeyC(")"),
@@ -169,21 +153,18 @@ val KB_EO_CYRILLIC_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("Т", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("Ч"),
                     top = KeyC("Ц"),
                     left = KeyC("Б"),
                 ),
                 KeyItemC(
                     center = KeyC("Л", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("Џ"),
                     top = KeyC("Г"),
                     right = KeyC("З"),
                 ),
                 KeyItemC(
                     center = KeyC("И", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("Ў"),
                     top = KeyC("У"),
                 ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/EOENDEThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/EOENDEThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EO_EN_DE_THUMBKEY_MAIN =
     KeyboardC(
@@ -16,7 +15,6 @@ val KB_EO_EN_DE_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("ŝ"),
                     topRight = KeyC("ß"),
                     bottomLeft = KeyC("x"),
@@ -24,13 +22,11 @@ val KB_EO_EN_DE_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("y"),
                     bottom = KeyC("d"),
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("ö"),
                     topRight = KeyC("ü"),
                     bottomLeft = KeyC("u"),
@@ -41,7 +37,6 @@ val KB_EO_EN_DE_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     left = KeyC("ĵ"),
                     right = KeyC("j"),
                 ),
@@ -58,7 +53,6 @@ val KB_EO_EN_DE_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("m"),
                     right = KeyC("ä"),
                     top =
@@ -79,7 +73,6 @@ val KB_EO_EN_DE_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("g"),
                     bottomLeft = KeyC("ĝ"),
                 ),
@@ -94,7 +87,6 @@ val KB_EO_EN_DE_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("h"),
                     bottomRight = KeyC("ĥ"),
                 ),
@@ -113,7 +105,6 @@ val KB_EO_EN_DE_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("Ŝ"),
                     topRight = KeyC("ẞ"),
                     bottomRight = KeyC("K"),
@@ -121,13 +112,11 @@ val KB_EO_EN_DE_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("Y"),
                     bottom = KeyC("D"),
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("Ö"),
                     topRight = KeyC("Ü"),
                     bottomLeft = KeyC("U"),
@@ -138,7 +127,6 @@ val KB_EO_EN_DE_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     left = KeyC("Ĵ"),
                     right = KeyC("J"),
                 ),
@@ -155,7 +143,6 @@ val KB_EO_EN_DE_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("M"),
                     right = KeyC("Ä"),
                     bottom =
@@ -179,7 +166,6 @@ val KB_EO_EN_DE_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("G"),
                     bottomLeft = KeyC("Ĝ"),
                 ),
@@ -194,7 +180,6 @@ val KB_EO_EN_DE_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("H"),
                     bottomRight = KeyC("Ĥ"),
                 ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ESCAMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ESCAMessagEase.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_ES_CA_MESSAGEASE_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ESCAThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ESCAThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_ES_CA_THUMBKEY_MAIN =
     KeyboardC(
@@ -41,7 +40,6 @@ val KB_ES_CA_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("p"),
                 ),
                 KeyItemC(
@@ -57,7 +55,6 @@ val KB_ES_CA_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("à"),
                     top =
                         KeyC(
@@ -78,7 +75,6 @@ val KB_ES_CA_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("m"),
                 ),
                 KeyItemC(
@@ -139,7 +135,6 @@ val KB_ES_CA_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("P"),
                 ),
                 KeyItemC(
@@ -155,7 +150,6 @@ val KB_ES_CA_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("À"),
                     bottom =
                         KeyC(
@@ -179,7 +173,6 @@ val KB_ES_CA_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("M"),
                 ),
                 KeyItemC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ESEOThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ESEOThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_ES_EO_THUMBKEY_MAIN =
     KeyboardC(
@@ -21,7 +20,6 @@ val KB_ES_EO_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("l"),
                     top = KeyC("ñ"),
                 ),
@@ -35,7 +33,6 @@ val KB_ES_EO_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("d", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("k"),
                     top = KeyC("ŭ"),
                 ),
@@ -52,7 +49,6 @@ val KB_ES_EO_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("m"),
                     top =
                         KeyC(
@@ -72,7 +68,6 @@ val KB_ES_EO_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("y"),
                 ),
                 KeyItemC(
@@ -108,7 +103,6 @@ val KB_ES_EO_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("L"),
                     top = KeyC("Ñ"),
                 ),
@@ -122,7 +116,6 @@ val KB_ES_EO_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("D", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("K"),
                     top = KeyC("ŭ"),
                 ),
@@ -139,7 +132,6 @@ val KB_ES_EO_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("M"),
                     bottom =
                         KeyC(
@@ -162,7 +154,6 @@ val KB_ES_EO_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("Y"),
                 ),
                 KeyItemC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ESMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ESMessagEase.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_ES_MESSAGEASE_MAIN =
     KeyboardC(
@@ -42,7 +41,6 @@ val KB_ES_MESSAGEASE_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("d", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("(", color = MUTED),
                     top = KeyC("ü"),
                     right = KeyC("k"),
@@ -99,7 +97,6 @@ val KB_ES_MESSAGEASE_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("f"),
                 ),
                 BACKSPACE_KEY_ITEM,
@@ -140,7 +137,6 @@ val KB_ES_MESSAGEASE_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("D", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("(", color = MUTED),
                     top = KeyC("Ü"),
                     right = KeyC("K"),
@@ -200,7 +196,6 @@ val KB_ES_MESSAGEASE_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("F"),
                 ),
                 BACKSPACE_KEY_ITEM,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ESThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ESThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_ES_THUMBKEY_MAIN =
     KeyboardC(
@@ -21,7 +20,6 @@ val KB_ES_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("l", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("v"),
                     right = KeyC("!", color = MUTED),
                 ),
@@ -38,7 +36,6 @@ val KB_ES_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("p"),
                 ),
                 KeyItemC(
@@ -54,7 +51,6 @@ val KB_ES_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("t"),
                     top =
                         KeyC(
@@ -75,7 +71,6 @@ val KB_ES_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("m"),
                 ),
                 KeyItemC(
@@ -113,7 +108,6 @@ val KB_ES_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("L", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("V"),
                     right = KeyC("¡", color = MUTED),
                 ),
@@ -130,7 +124,6 @@ val KB_ES_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("P"),
                 ),
                 KeyItemC(
@@ -146,7 +139,6 @@ val KB_ES_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("T"),
                     bottom =
                         KeyC(
@@ -170,7 +162,6 @@ val KB_ES_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("M"),
                 ),
                 KeyItemC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ESThumbKeySymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ESThumbKeySymbols.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_ES_THUMBKEY_SYMBOLS_MAIN =
     KeyboardC(
@@ -23,7 +22,6 @@ val KB_ES_THUMBKEY_SYMBOLS_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("l", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     topLeft = KeyC("`"),
                     top = KeyC("^"),
                     topRight = KeyC("´"),
@@ -49,7 +47,6 @@ val KB_ES_THUMBKEY_SYMBOLS_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     topLeft = KeyC("{"),
                     topRight = KeyC("%"),
                     right = KeyC("p"),
@@ -70,7 +67,6 @@ val KB_ES_THUMBKEY_SYMBOLS_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     topLeft = KeyC("|"),
                     top =
                         KeyC(
@@ -95,7 +91,6 @@ val KB_ES_THUMBKEY_SYMBOLS_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("~"),
                     topRight = KeyC("m"),
                     bottomLeft = KeyC("<"),
@@ -143,7 +138,6 @@ val KB_ES_THUMBKEY_SYMBOLS_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("L", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("¡", color = MUTED),
                     bottom = KeyC("V"),
                 ),
@@ -160,7 +154,6 @@ val KB_ES_THUMBKEY_SYMBOLS_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("P"),
                 ),
                 KeyItemC(
@@ -176,7 +169,6 @@ val KB_ES_THUMBKEY_SYMBOLS_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top =
                         KeyC(
                             display = KeyDisplay.IconDisplay(Icons.Outlined.KeyboardCapslock),
@@ -200,7 +192,6 @@ val KB_ES_THUMBKEY_SYMBOLS_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("M"),
                 ),
                 KeyItemC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ESTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ESTypeSplit.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_ES_TYPESPLIT_MAIN =
     KeyboardC(
@@ -14,14 +13,12 @@ val KB_ES_TYPESPLIT_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("é", color = MUTED),
                     bottom = KeyC("q"),
                     top = KeyC("w"),
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -33,7 +30,6 @@ val KB_ES_TYPESPLIT_MAIN =
                 EMOJI_KEY_ITEM_ALT,
                 KeyItemC(
                     center = KeyC("i", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("í", color = MUTED),
                     left = KeyC("ú", color = MUTED),
                     bottom = KeyC("u"),
@@ -41,7 +37,6 @@ val KB_ES_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -54,7 +49,6 @@ val KB_ES_TYPESPLIT_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("á", color = MUTED),
                     left =
                         KeyC(
@@ -65,7 +59,6 @@ val KB_ES_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("#", color = MUTED),
                     left =
                         KeyC(
@@ -76,7 +69,6 @@ val KB_ES_TYPESPLIT_MAIN =
                 SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("d", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("f"),
                     left =
                         KeyC(
@@ -87,7 +79,6 @@ val KB_ES_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("l", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -101,7 +92,6 @@ val KB_ES_TYPESPLIT_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("c", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("x"),
                     left =
                         KeyC(
@@ -112,21 +102,18 @@ val KB_ES_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("b", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("v"),
                     top = KeyC("\""),
                 ),
                 SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("¡", color = MUTED),
                     left = KeyC("¿", color = MUTED),
                     bottom = KeyC("ñ", color = MUTED),
                 ),
                 KeyItemC(
                     center = KeyC("m", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("?", color = MUTED),
                     left = KeyC("!", color = MUTED),
                     bottom = KeyC(":", color = MUTED),
@@ -147,14 +134,12 @@ val KB_ES_TYPESPLIT_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("É", color = MUTED),
                     bottom = KeyC("Q"),
                     top = KeyC("W"),
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -166,7 +151,6 @@ val KB_ES_TYPESPLIT_SHIFTED =
                 EMOJI_KEY_ITEM_ALT,
                 KeyItemC(
                     center = KeyC("I", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("Í", color = MUTED),
                     left = KeyC("Ú", color = MUTED),
                     bottom = KeyC("U"),
@@ -174,7 +158,6 @@ val KB_ES_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -187,7 +170,6 @@ val KB_ES_TYPESPLIT_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("Á", color = MUTED),
                     left =
                         KeyC(
@@ -198,7 +180,6 @@ val KB_ES_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("#", color = MUTED),
                     left =
                         KeyC(
@@ -209,7 +190,6 @@ val KB_ES_TYPESPLIT_SHIFTED =
                 SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("D", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("F"),
                     left =
                         KeyC(
@@ -220,7 +200,6 @@ val KB_ES_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("L", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -234,7 +213,6 @@ val KB_ES_TYPESPLIT_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("C", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("X"),
                     left =
                         KeyC(
@@ -245,21 +223,18 @@ val KB_ES_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("B", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("V"),
                     top = KeyC("\""),
                 ),
                 SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("¡", color = MUTED),
                     left = KeyC("¿", color = MUTED),
                     bottom = KeyC("Ñ", color = MUTED),
                 ),
                 KeyItemC(
                     center = KeyC("M", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("?", color = MUTED),
                     left = KeyC("!", color = MUTED),
                     bottom = KeyC(":", color = MUTED),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/EUESThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/EUESThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EU_ES_THUMBKEY_MAIN =
     KeyboardC(
@@ -16,12 +15,10 @@ val KB_EU_ES_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("s"),
                 ),
                 KeyItemC(
                     center = KeyC("z", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("h"),
                 ),
                 KeyItemC(
@@ -34,7 +31,6 @@ val KB_EU_ES_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("g"),
                     left = KeyC("w"),
                 ),
@@ -51,7 +47,6 @@ val KB_EU_ES_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("b"),
                     top =
                         KeyC(
@@ -106,12 +101,10 @@ val KB_EU_ES_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("S"),
                 ),
                 KeyItemC(
                     center = KeyC("Z", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("H"),
                 ),
                 KeyItemC(
@@ -124,7 +117,6 @@ val KB_EU_ES_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("G"),
                     left = KeyC("W"),
                 ),
@@ -141,7 +133,6 @@ val KB_EU_ES_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("B"),
                     bottom =
                         KeyC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/EUThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/EUThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EU_THUMBKEY_MAIN =
     KeyboardC(
@@ -16,17 +15,14 @@ val KB_EU_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("s"),
                 ),
                 KeyItemC(
                     center = KeyC("z", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("h"),
                 ),
                 KeyItemC(
                     center = KeyC("i", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("d"),
                 ),
                 EMOJI_KEY_ITEM,
@@ -34,7 +30,6 @@ val KB_EU_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("g"),
                 ),
                 KeyItemC(
@@ -50,7 +45,6 @@ val KB_EU_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("b"),
                     top =
                         KeyC(
@@ -70,7 +64,6 @@ val KB_EU_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("l"),
                 ),
                 KeyItemC(
@@ -84,7 +77,6 @@ val KB_EU_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("k"),
                 ),
                 BACKSPACE_KEY_ITEM,
@@ -102,17 +94,14 @@ val KB_EU_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("S"),
                 ),
                 KeyItemC(
                     center = KeyC("Z", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("H"),
                 ),
                 KeyItemC(
                     center = KeyC("I", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("D"),
                 ),
                 EMOJI_KEY_ITEM,
@@ -120,7 +109,6 @@ val KB_EU_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("G"),
                 ),
                 KeyItemC(
@@ -136,7 +124,6 @@ val KB_EU_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("B"),
                     bottom =
                         KeyC(
@@ -159,7 +146,6 @@ val KB_EU_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("L"),
                 ),
                 KeyItemC(
@@ -173,7 +159,6 @@ val KB_EU_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("K"),
                 ),
                 BACKSPACE_KEY_ITEM,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/EuropeThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/EuropeThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EUROPE_THUMBKEY_MAIN =
     KeyboardC(
@@ -42,7 +41,6 @@ val KB_EUROPE_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("i", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("\u0303", displayText = "◌̃"),
                     topRight = KeyC("\u0306", displayText = "◌̆"),
                     bottomLeft =
@@ -259,7 +257,6 @@ val KB_EUROPE_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("I", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("\u0303", displayText = "◌̃"),
                     topRight = KeyC("\u0306", displayText = "◌̆"),
                     bottomLeft =

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FAThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FAThumbKey.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_FA_THUMBKEY_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FAThumbKeySamsung.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FAThumbKeySamsung.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_FA_THUMBKEY_SAMSUNG: KeyboardDefinition =
     KeyboardDefinition(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FIEEMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FIEEMessagEase.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_FI_EE_MESSAGEASE_SYMBOLS_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FIMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FIMessagEase.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_FI_MESSAGEASE_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FIThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FIThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_FI_THUMBKEY_MAIN =
     KeyboardC(
@@ -16,18 +15,15 @@ val KB_FI_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("r"),
                     topLeft = KeyC("z"),
                 ),
                 KeyItemC(
                     center = KeyC("k", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("j"),
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("ö"),
                     topRight = KeyC("å"),
                 ),
@@ -36,7 +32,6 @@ val KB_FI_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("m"),
                 ),
                 KeyItemC(
@@ -52,7 +47,6 @@ val KB_FI_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("ä"),
                     top =
                         KeyC(
@@ -72,7 +66,6 @@ val KB_FI_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("v"),
                     bottomLeft = KeyC("w"),
                 ),
@@ -87,7 +80,6 @@ val KB_FI_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("i", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("u"),
                 ),
                 BACKSPACE_KEY_ITEM,
@@ -105,18 +97,15 @@ val KB_FI_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("R"),
                     topLeft = KeyC("Z"),
                 ),
                 KeyItemC(
                     center = KeyC("K", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("J"),
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("Ö"),
                     topRight = KeyC("Å"),
                 ),
@@ -125,7 +114,6 @@ val KB_FI_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("M"),
                 ),
                 KeyItemC(
@@ -141,7 +129,6 @@ val KB_FI_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("Ä"),
                     bottom =
                         KeyC(
@@ -164,7 +151,6 @@ val KB_FI_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("V"),
                     bottomLeft = KeyC("W"),
                 ),
@@ -179,7 +165,6 @@ val KB_FI_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("I", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("U"),
                 ),
                 BACKSPACE_KEY_ITEM,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FIThumbKeyWide.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FIThumbKeyWide.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_FI_THUMBKEY_WIDE_MAIN =
     KeyboardC(
@@ -16,18 +15,15 @@ val KB_FI_THUMBKEY_WIDE_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("r"),
                     topLeft = KeyC("z"),
                 ),
                 KeyItemC(
                     center = KeyC("k", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("j"),
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("ö"),
                     topRight = KeyC("å"),
                 ),
@@ -37,7 +33,6 @@ val KB_FI_THUMBKEY_WIDE_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("m"),
                 ),
                 KeyItemC(
@@ -53,7 +48,6 @@ val KB_FI_THUMBKEY_WIDE_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("ä"),
                     top =
                         KeyC(
@@ -74,7 +68,6 @@ val KB_FI_THUMBKEY_WIDE_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("v"),
                     bottomLeft = KeyC("w"),
                 ),
@@ -89,7 +82,6 @@ val KB_FI_THUMBKEY_WIDE_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("i", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("u"),
                 ),
                 RETURN_KEY_ITEM,
@@ -104,18 +96,15 @@ val KB_FI_THUMBKEY_WIDE_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("R"),
                     topLeft = KeyC("Z"),
                 ),
                 KeyItemC(
                     center = KeyC("K", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("J"),
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("Ö"),
                     topRight = KeyC("Å"),
                 ),
@@ -125,7 +114,6 @@ val KB_FI_THUMBKEY_WIDE_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("M"),
                 ),
                 KeyItemC(
@@ -141,7 +129,6 @@ val KB_FI_THUMBKEY_WIDE_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("Ä"),
                     bottom =
                         KeyC(
@@ -165,7 +152,6 @@ val KB_FI_THUMBKEY_WIDE_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("V"),
                     bottomLeft = KeyC("W"),
                 ),
@@ -180,7 +166,6 @@ val KB_FI_THUMBKEY_WIDE_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("I", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("U"),
                 ),
                 RETURN_KEY_ITEM,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FITypesSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FITypesSplit.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_FI_TYPESPLIT_MAIN =
     KeyboardC(
@@ -14,7 +13,6 @@ val KB_FI_TYPESPLIT_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("c"),
                     left =
                         KeyC(
@@ -25,7 +23,6 @@ val KB_FI_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("m", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("z"),
                     left =
                         KeyC(
@@ -40,7 +37,6 @@ val KB_FI_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -53,14 +49,12 @@ val KB_FI_TYPESPLIT_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("b"),
                     left = KeyC("q"),
                     bottom = KeyC("v"),
                 ),
                 KeyItemC(
                     center = KeyC("k", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("w"),
                     left =
                         KeyC(
@@ -75,7 +69,6 @@ val KB_FI_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("i", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -88,14 +81,12 @@ val KB_FI_TYPESPLIT_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("g"),
                     left = KeyC("x"),
                     bottom = KeyC("r"),
                 ),
                 KeyItemC(
                     center = KeyC("l", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("f"),
                     left =
                         KeyC(
@@ -107,12 +98,10 @@ val KB_FI_TYPESPLIT_MAIN =
                 SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("ö"),
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -137,7 +126,6 @@ val KB_FI_TYPESPLIT_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("C"),
                     left =
                         KeyC(
@@ -148,7 +136,6 @@ val KB_FI_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("M", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("Z"),
                     left =
                         KeyC(
@@ -163,7 +150,6 @@ val KB_FI_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -176,14 +162,12 @@ val KB_FI_TYPESPLIT_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("B"),
                     left = KeyC("Q"),
                     bottom = KeyC("V"),
                 ),
                 KeyItemC(
                     center = KeyC("K", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("W"),
                     left =
                         KeyC(
@@ -198,7 +182,6 @@ val KB_FI_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("I", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -211,14 +194,12 @@ val KB_FI_TYPESPLIT_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("G"),
                     left = KeyC("X"),
                     bottom = KeyC("R"),
                 ),
                 KeyItemC(
                     center = KeyC("L", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("F"),
                     left =
                         KeyC(
@@ -230,12 +211,10 @@ val KB_FI_TYPESPLIT_SHIFTED =
                 SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("Ö"),
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FRMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FRMessagEase.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_FR_MESSAGEASE_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FRThumbKeyV1.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FRThumbKeyV1.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_FR_THUMBKEY_V1_MAIN =
     KeyboardC(
@@ -16,7 +15,6 @@ val KB_FR_THUMBKEY_V1_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("v"),
                 ),
                 KeyItemC(
@@ -38,7 +36,6 @@ val KB_FR_THUMBKEY_V1_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("m"),
                 ),
                 KeyItemC(
@@ -75,7 +72,6 @@ val KB_FR_THUMBKEY_V1_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("p"),
                 ),
                 KeyItemC(
@@ -113,7 +109,6 @@ val KB_FR_THUMBKEY_V1_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("V"),
                 ),
                 KeyItemC(
@@ -135,7 +130,6 @@ val KB_FR_THUMBKEY_V1_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("M"),
                 ),
                 KeyItemC(
@@ -174,7 +168,6 @@ val KB_FR_THUMBKEY_V1_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("P"),
                 ),
                 KeyItemC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FRThumbKeyV2.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FRThumbKeyV2.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_FR_THUMBKEY_V2_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FRTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FRTypeSplit.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_FR_TYPESPLIT_MAIN =
     KeyboardC(
@@ -14,7 +13,6 @@ val KB_FR_TYPESPLIT_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("à", color = MUTED),
                     left =
                         KeyC(
@@ -26,7 +24,6 @@ val KB_FR_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("é", color = MUTED),
                     left = KeyC("è", color = MUTED),
                     bottom = KeyC("r"),
@@ -35,7 +32,6 @@ val KB_FR_TYPESPLIT_MAIN =
                 EMOJI_KEY_ITEM_ALT,
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("y"),
                     left = KeyC("ù", color = MUTED),
                     bottom = KeyC("u"),
@@ -43,7 +39,6 @@ val KB_FR_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("i", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("ô", color = MUTED),
                     left = KeyC("p"),
                     bottom = KeyC("o"),
@@ -53,13 +48,11 @@ val KB_FR_TYPESPLIT_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("q"),
                     top = KeyC("œ", color = MUTED),
                 ),
                 KeyItemC(
                     center = KeyC("d", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -72,7 +65,6 @@ val KB_FR_TYPESPLIT_MAIN =
                 SPACEBAR_FRENCH_TYPESPLIT_MIDDLE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("l", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("j"),
                     left = KeyC("k"),
                     bottom = KeyC("h"),
@@ -80,14 +72,12 @@ val KB_FR_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("m", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("ï", color = MUTED),
                 ),
             ),
             listOf(
                 KeyItemC(
                     center = KeyC("c", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("w"),
                     left =
                         KeyC(
@@ -106,7 +96,6 @@ val KB_FR_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("?", color = MUTED),
                     left = KeyC("!", color = MUTED),
                     bottom = KeyC(":", color = MUTED),
@@ -127,7 +116,6 @@ val KB_FR_TYPESPLIT_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("À", color = MUTED),
                     left =
                         KeyC(
@@ -139,7 +127,6 @@ val KB_FR_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("É", color = MUTED),
                     left = KeyC("È", color = MUTED),
                     bottom = KeyC("R"),
@@ -148,7 +135,6 @@ val KB_FR_TYPESPLIT_SHIFTED =
                 EMOJI_KEY_ITEM_ALT,
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("Y"),
                     left = KeyC("Ù", color = MUTED),
                     bottom = KeyC("U"),
@@ -156,7 +142,6 @@ val KB_FR_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("I", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("Ô", color = MUTED),
                     left = KeyC("P"),
                     bottom = KeyC("O"),
@@ -166,13 +151,11 @@ val KB_FR_TYPESPLIT_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("Q"),
                     top = KeyC("Œ", color = MUTED),
                 ),
                 KeyItemC(
                     center = KeyC("D", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -185,7 +168,6 @@ val KB_FR_TYPESPLIT_SHIFTED =
                 SPACEBAR_FRENCH_TYPESPLIT_MIDDLE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("L", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("J"),
                     left = KeyC("K"),
                     bottom = KeyC("H"),
@@ -193,14 +175,12 @@ val KB_FR_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("M", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("Ï", color = MUTED),
                 ),
             ),
             listOf(
                 KeyItemC(
                     center = KeyC("C", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("W"),
                     left =
                         KeyC(
@@ -219,7 +199,6 @@ val KB_FR_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("?", color = MUTED),
                     left = KeyC("!", color = MUTED),
                     bottom = KeyC(":", color = MUTED),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/GRThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/GRThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_GR_THUMBKEY_MAIN =
     KeyboardC(
@@ -16,12 +15,10 @@ val KB_GR_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("ν", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("χ"),
                 ),
                 KeyItemC(
                     center = KeyC("υ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("ΰ"),
                     right = KeyC("ύ"),
                     bottom = KeyC("φ"),
@@ -40,7 +37,6 @@ val KB_GR_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("σ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("γ"),
                     top = KeyC("ς"),
                 ),
@@ -57,7 +53,6 @@ val KB_GR_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("ο", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("ξ"),
                     right = KeyC("ό"),
                     top =
@@ -78,7 +73,6 @@ val KB_GR_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("τ", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("δ"),
                 ),
                 KeyItemC(
@@ -92,7 +86,6 @@ val KB_GR_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("α", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("β"),
                     bottomLeft = KeyC("ά"),
                 ),
@@ -111,12 +104,10 @@ val KB_GR_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("Ν", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("Χ"),
                 ),
                 KeyItemC(
                     center = KeyC("Υ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("Ϋ́"),
                     right = KeyC("Ύ"),
                     bottom = KeyC("Φ"),
@@ -135,7 +126,6 @@ val KB_GR_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("Σ", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("Γ"),
                 ),
                 KeyItemC(
@@ -151,7 +141,6 @@ val KB_GR_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("Ο", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("Ξ"),
                     right = KeyC("Ό"),
                     bottom =
@@ -175,7 +164,6 @@ val KB_GR_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("Τ", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("Δ"),
                 ),
                 KeyItemC(
@@ -189,7 +177,6 @@ val KB_GR_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("Α", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("Β"),
                     bottomLeft = KeyC("Ά"),
                 ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/GlagoliticThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/GlagoliticThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_GLAGOLITIC_THUMBKEY_MAIN =
     KeyboardC(
@@ -63,7 +62,6 @@ val KB_GLAGOLITIC_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("ⰰ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("ⱇ"),
                     top =
                         KeyC(
@@ -171,7 +169,6 @@ val KB_GLAGOLITIC_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("Ⰰ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("Ⱇ"),
                     top =
                         KeyC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/HEMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/HEMessagEase.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_HE_MESSAGEASE_MAIN =
     KeyboardC(
@@ -14,12 +13,10 @@ val KB_HE_MESSAGEASE_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("ר", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("ן"),
                 ),
                 KeyItemC(
                     center = KeyC("ב", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("ג"),
                 ),
                 KeyItemC(
@@ -48,7 +45,6 @@ val KB_HE_MESSAGEASE_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("ו", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("ף"),
                 ),
                 NUMERIC_KEY_ITEM,
@@ -56,7 +52,6 @@ val KB_HE_MESSAGEASE_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("ת", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("ז"),
                 ),
                 KeyItemC(
@@ -69,7 +64,6 @@ val KB_HE_MESSAGEASE_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("ל", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("ט"),
                 ),
                 BACKSPACE_KEY_ITEM,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/HEMessagEaseSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/HEMessagEaseSymbols.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_HE_MESSAGEASE_SYMBOLS_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/HEThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/HEThumbKey.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_HE_THUMBKEY_MAIN =
     KeyboardC(
@@ -15,17 +14,14 @@ val KB_HE_THUMBKEY_MAIN =
                 KeyItemC(
                     center = KeyC("מ", size = LARGE),
                     bottomRight = KeyC("נ"),
-                    swipeType = FOUR_WAY_DIAGONAL,
                 ),
                 KeyItemC(
                     center = KeyC("ב", size = LARGE),
                     bottom = KeyC("ע"),
-                    swipeType = TWO_WAY_VERTICAL,
                 ),
                 KeyItemC(
                     center = KeyC("א", size = LARGE),
                     bottomLeft = KeyC("כ"),
-                    swipeType = FOUR_WAY_DIAGONAL,
                 ),
                 EMOJI_KEY_ITEM,
             ),
@@ -34,7 +30,6 @@ val KB_HE_THUMBKEY_MAIN =
                     center = KeyC("ת", size = LARGE),
                     right = KeyC("ם"),
                     left = KeyC("ץ"),
-                    swipeType = TWO_WAY_HORIZONTAL,
                 ),
                 KeyItemC(
                     center = KeyC("ל", size = LARGE),
@@ -51,7 +46,6 @@ val KB_HE_THUMBKEY_MAIN =
                     center = KeyC("ו", size = LARGE),
                     left = KeyC("פ"),
                     right = KeyC("ף"),
-                    swipeType = TWO_WAY_HORIZONTAL,
                 ),
                 NUMERIC_KEY_ITEM,
             ),
@@ -60,7 +54,6 @@ val KB_HE_THUMBKEY_MAIN =
                     center = KeyC("ר", size = LARGE),
                     topRight = KeyC("ש"),
                     bottomRight = KeyC("”", color = MUTED),
-                    swipeType = FOUR_WAY_DIAGONAL,
                 ),
                 KeyItemC(
                     center = KeyC("ה", size = LARGE),
@@ -77,7 +70,6 @@ val KB_HE_THUMBKEY_MAIN =
                     center = KeyC("י", size = LARGE),
                     topLeft = KeyC("ח"),
                     bottomLeft = KeyC("’", color = MUTED),
-                    swipeType = FOUR_WAY_DIAGONAL,
                 ),
                 BACKSPACE_KEY_ITEM,
             ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/HRThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/HRThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_HR_THUMBKEY_MAIN =
     KeyboardC(
@@ -22,12 +21,10 @@ val KB_HR_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("g"),
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("u"),
                 ),
                 EMOJI_KEY_ITEM,
@@ -35,7 +32,6 @@ val KB_HR_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("m"),
                 ),
                 KeyItemC(
@@ -51,7 +47,6 @@ val KB_HR_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("l"),
                     top =
                         KeyC(
@@ -110,12 +105,10 @@ val KB_HR_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("G"),
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("U"),
                 ),
                 EMOJI_KEY_ITEM,
@@ -123,7 +116,6 @@ val KB_HR_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("M"),
                 ),
                 KeyItemC(
@@ -139,7 +131,6 @@ val KB_HR_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("L"),
                     bottom =
                         KeyC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/HRThumbKeySymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/HRThumbKeySymbols.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 // Adds more punctuation options to the main screen to reduce switches to the numeric keyboard
 val KB_HR_THUMBKEY_SYMBOLS_MAIN =

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/HRTwoHands.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/HRTwoHands.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_HR_TWO_HANDS_MAIN =
     KeyboardC(
@@ -22,12 +21,10 @@ val KB_HR_TWO_HANDS_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("g"),
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("u"),
                 ),
                 EMOJI_KEY_ITEM,
@@ -39,19 +36,16 @@ val KB_HR_TWO_HANDS_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("g"),
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("u"),
                 ),
             ),
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("m"),
                 ),
                 KeyItemC(
@@ -67,7 +61,6 @@ val KB_HR_TWO_HANDS_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("l"),
                     top =
                         KeyC(
@@ -85,7 +78,6 @@ val KB_HR_TWO_HANDS_MAIN =
                 NUMERIC_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("m"),
                 ),
                 KeyItemC(
@@ -101,7 +93,6 @@ val KB_HR_TWO_HANDS_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("l"),
                     top =
                         KeyC(
@@ -182,12 +173,10 @@ val KB_HR_TWO_HANDS_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("G"),
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("U"),
                 ),
                 EMOJI_KEY_ITEM,
@@ -199,19 +188,16 @@ val KB_HR_TWO_HANDS_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("G"),
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("U"),
                 ),
             ),
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("M"),
                 ),
                 KeyItemC(
@@ -227,7 +213,6 @@ val KB_HR_TWO_HANDS_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("L"),
                     top =
                         KeyC(
@@ -245,7 +230,6 @@ val KB_HR_TWO_HANDS_SHIFTED =
                 NUMERIC_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("M"),
                 ),
                 KeyItemC(
@@ -261,7 +245,6 @@ val KB_HR_TWO_HANDS_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("L"),
                     top =
                         KeyC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/HUThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/HUThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_HU_THUMBKEY_MAIN =
     KeyboardC(
@@ -16,12 +15,10 @@ val KB_HU_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("w"),
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("g"),
                 ),
                 KeyItemC(
@@ -39,7 +36,6 @@ val KB_HU_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("m"),
                 ),
                 KeyItemC(
@@ -75,7 +71,6 @@ val KB_HU_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("c"),
                 ),
                 KeyItemC(
@@ -108,12 +103,10 @@ val KB_HU_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("W"),
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("G"),
                 ),
                 KeyItemC(
@@ -131,7 +124,6 @@ val KB_HU_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("M"),
                 ),
                 KeyItemC(
@@ -170,7 +162,6 @@ val KB_HU_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("C"),
                 ),
                 KeyItemC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/HUTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/HUTypeSplit.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_HU_TYPESPLIT_MAIN =
     KeyboardC(
@@ -14,7 +13,6 @@ val KB_HU_TYPESPLIT_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("q"),
                     left =
                         KeyC(
@@ -25,13 +23,11 @@ val KB_HU_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("r"),
                 ),
                 EMOJI_KEY_ITEM_ALT,
                 KeyItemC(
                     center = KeyC("i", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("z"),
                     left = KeyC("ö"),
                     bottom = KeyC("u"),
@@ -39,7 +35,6 @@ val KB_HU_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("ú"),
                     left = KeyC("ő"),
                     bottom = KeyC("p"),
@@ -52,7 +47,6 @@ val KB_HU_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -64,7 +58,6 @@ val KB_HU_TYPESPLIT_MAIN =
                 SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("h", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left =
                         KeyC(
                             display = null,
@@ -75,7 +68,6 @@ val KB_HU_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("l", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("é"),
                     top = KeyC("á"),
                     right = KeyC("ű"),
@@ -85,14 +77,12 @@ val KB_HU_TYPESPLIT_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("c", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("y"),
                     left = KeyC("í"),
                     bottom = KeyC("x"),
                 ),
                 KeyItemC(
                     center = KeyC("b", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("v"),
                 ),
                 SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
@@ -101,7 +91,6 @@ val KB_HU_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("m", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("?", color = MUTED),
                     left = KeyC("!", color = MUTED),
                     bottom = KeyC(":", color = MUTED),
@@ -122,7 +111,6 @@ val KB_HU_TYPESPLIT_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("Q"),
                     left =
                         KeyC(
@@ -133,13 +121,11 @@ val KB_HU_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("R"),
                 ),
                 EMOJI_KEY_ITEM_ALT,
                 KeyItemC(
                     center = KeyC("I", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("Z"),
                     left = KeyC("Ö"),
                     bottom = KeyC("U"),
@@ -147,7 +133,6 @@ val KB_HU_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("Ú"),
                     left = KeyC("Ő"),
                     bottom = KeyC("P"),
@@ -160,7 +145,6 @@ val KB_HU_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -172,7 +156,6 @@ val KB_HU_TYPESPLIT_SHIFTED =
                 SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("H", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("J"),
                     left =
                         KeyC(
@@ -183,7 +166,6 @@ val KB_HU_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("L", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("É"),
                     top = KeyC("Á"),
                     right = KeyC("Ű"),
@@ -193,14 +175,12 @@ val KB_HU_TYPESPLIT_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("C", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("Y"),
                     left = KeyC("Í"),
                     bottom = KeyC("X"),
                 ),
                 KeyItemC(
                     center = KeyC("B", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("V"),
                 ),
                 SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
@@ -209,7 +189,6 @@ val KB_HU_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("M", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("?", color = MUTED),
                     left = KeyC("!", color = MUTED),
                     bottom = KeyC(":", color = MUTED),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/IDThumbKeySymbolsNumbersV1.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/IDThumbKeySymbolsNumbersV1.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 // Adds more punctuation options to the main screen to reduce switches to the numeric keyboard
 val KB_ID_THUMBKEY_SYMBOLS_NUMBERS_V1_MAIN =

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/IDThumbKeySymbolsV1.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/IDThumbKeySymbolsV1.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 // Adds more punctuation options to the main screen to reduce switches to the numeric keyboard
 val KB_ID_THUMBKEY_SYMBOLS_V1_MAIN =
@@ -17,7 +16,6 @@ val KB_ID_THUMBKEY_SYMBOLS_V1_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("h"),
                     bottomLeft = KeyC("$", color = MUTED),
                 ),
@@ -90,7 +88,6 @@ val KB_ID_THUMBKEY_SYMBOLS_V1_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("p"),
                     topLeft = KeyC("~", color = MUTED),
                     bottomRight = KeyC(":", color = MUTED),
@@ -131,7 +128,6 @@ val KB_ID_THUMBKEY_SYMBOLS_V1_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("H"),
                     bottomLeft = KeyC("$", color = MUTED),
                 ),
@@ -205,7 +201,6 @@ val KB_ID_THUMBKEY_SYMBOLS_V1_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("P"),
                     topLeft = KeyC("~", color = MUTED),
                     bottomRight = KeyC(":", color = MUTED),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/IDThumbKeySymbolsV2.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/IDThumbKeySymbolsV2.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 // Adds more punctuation options to the main screen to reduce switches to the numeric keyboard
 val KB_ID_THUMBKEY_SYMBOLS_V2_MAIN =
@@ -17,7 +16,6 @@ val KB_ID_THUMBKEY_SYMBOLS_V2_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("d", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("h"),
                     bottomLeft = KeyC("$", color = MUTED),
                 ),
@@ -90,7 +88,6 @@ val KB_ID_THUMBKEY_SYMBOLS_V2_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("p"),
                     topLeft = KeyC("~", color = MUTED),
                     bottomRight = KeyC(":", color = MUTED),
@@ -131,7 +128,6 @@ val KB_ID_THUMBKEY_SYMBOLS_V2_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("D", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("H"),
                     bottomLeft = KeyC("$", color = MUTED),
                 ),
@@ -205,7 +201,6 @@ val KB_ID_THUMBKEY_SYMBOLS_V2_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("P"),
                     topLeft = KeyC("~", color = MUTED),
                     bottomRight = KeyC(":", color = MUTED),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ITMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ITMessagEase.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_IT_MESSAGEASE_MAIN =
     KeyboardC(
@@ -16,18 +15,15 @@ val KB_IT_MESSAGEASE_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("v"),
                     topRight = KeyC("à"),
                 ),
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("h"),
                 ),
                 KeyItemC(
                     center = KeyC("i", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("x"),
                     topLeft = KeyC("ì"),
                 ),
@@ -53,7 +49,6 @@ val KB_IT_MESSAGEASE_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("m"),
                     top =
                         KeyC(
@@ -88,7 +83,6 @@ val KB_IT_MESSAGEASE_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("f"),
                 ),
                 BACKSPACE_KEY_ITEM,
@@ -106,18 +100,15 @@ val KB_IT_MESSAGEASE_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("V"),
                     topRight = KeyC("À"),
                 ),
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("H"),
                 ),
                 KeyItemC(
                     center = KeyC("I", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("X"),
                     topLeft = KeyC("Ì"),
                 ),
@@ -143,7 +134,6 @@ val KB_IT_MESSAGEASE_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("M"),
                     bottom =
                         KeyC(
@@ -181,7 +171,6 @@ val KB_IT_MESSAGEASE_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("F"),
                 ),
                 BACKSPACE_KEY_ITEM,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ITMessagEaseSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ITMessagEaseSymbols.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_IT_MESSAGEASE_SYMBOLS_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ITThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ITThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_IT_THUMBKEY_MAIN =
     KeyboardC(
@@ -16,7 +15,6 @@ val KB_IT_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("z"),
                     right = KeyC("v"),
                 ),
@@ -37,7 +35,6 @@ val KB_IT_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("m"),
                 ),
                 KeyItemC(
@@ -73,7 +70,6 @@ val KB_IT_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("!", color = MUTED),
                     bottomLeft = KeyC("?", color = MUTED),
                     bottomRight = KeyC("@", color = MUTED),
@@ -112,7 +108,6 @@ val KB_IT_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("Z"),
                     right = KeyC("V"),
                 ),
@@ -133,7 +128,6 @@ val KB_IT_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("M"),
                 ),
                 KeyItemC(
@@ -172,7 +166,6 @@ val KB_IT_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("!", color = MUTED),
                     bottomLeft = KeyC("?", color = MUTED),
                     bottomRight = KeyC("@", color = MUTED),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ITTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ITTypeSplit.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_IT_TYPESPLIT_MAIN =
     KeyboardC(
@@ -14,12 +13,10 @@ val KB_IT_TYPESPLIT_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("m"),
                 ),
                 KeyItemC(
                     center = KeyC("l", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("g"),
                     left = KeyC("h"),
                     bottom = KeyC("gh", color = MUTED),
@@ -28,13 +25,11 @@ val KB_IT_TYPESPLIT_MAIN =
                 EMOJI_KEY_ITEM_ALT,
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("ò", color = MUTED),
                     left = KeyC("@", color = MUTED),
                 ),
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("è", color = MUTED),
                     left = KeyC("é", color = MUTED),
                     top = KeyC("ə", color = MUTED),
@@ -44,7 +39,6 @@ val KB_IT_TYPESPLIT_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("v"),
                     top = KeyC("w"),
                     bottom = KeyC("z"),
@@ -55,13 +49,11 @@ val KB_IT_TYPESPLIT_MAIN =
                 SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("u", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("ù", color = MUTED),
                     left = KeyC("qu", color = MUTED),
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("à", color = MUTED),
                     left = KeyC(";", color = MUTED),
                 ),
@@ -69,14 +61,12 @@ val KB_IT_TYPESPLIT_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("j"),
                     bottom = KeyC("y"),
                     top = KeyC("x"),
                 ),
                 KeyItemC(
                     center = KeyC("c", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("d"),
                     left = KeyC("b"),
                     bottom = KeyC("ch", color = MUTED),
@@ -85,14 +75,12 @@ val KB_IT_TYPESPLIT_MAIN =
                 SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("p", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("q"),
                     right = KeyC("?", color = MUTED),
                     left = KeyC("!", color = MUTED),
                 ),
                 KeyItemC(
                     center = KeyC("i", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("ì", color = MUTED),
                     left = KeyC(":", color = MUTED),
                 ),
@@ -111,12 +99,10 @@ val KB_IT_TYPESPLIT_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("M"),
                 ),
                 KeyItemC(
                     center = KeyC("L", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("G"),
                     left = KeyC("H"),
                     bottom = KeyC("Gh", color = MUTED),
@@ -125,13 +111,11 @@ val KB_IT_TYPESPLIT_SHIFTED =
                 EMOJI_KEY_ITEM_ALT,
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("Ò", color = MUTED),
                     left = KeyC("@", color = MUTED),
                 ),
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("È", color = MUTED),
                     left = KeyC("É", color = MUTED),
                     top = KeyC("3", color = MUTED),
@@ -141,7 +125,6 @@ val KB_IT_TYPESPLIT_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("V"),
                     top = KeyC("W"),
                     bottom = KeyC("Z"),
@@ -152,13 +135,11 @@ val KB_IT_TYPESPLIT_SHIFTED =
                 SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("U", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("Ù", color = MUTED),
                     left = KeyC("Qu", color = MUTED),
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("À", color = MUTED),
                     left = KeyC(";", color = MUTED),
                 ),
@@ -166,14 +147,12 @@ val KB_IT_TYPESPLIT_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("J"),
                     bottom = KeyC("Y"),
                     top = KeyC("X"),
                 ),
                 KeyItemC(
                     center = KeyC("C", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("D"),
                     left = KeyC("B"),
                     bottom = KeyC("Ch", color = MUTED),
@@ -182,14 +161,12 @@ val KB_IT_TYPESPLIT_SHIFTED =
                 SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("P", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("Q"),
                     right = KeyC("?", color = MUTED),
                     left = KeyC("!", color = MUTED),
                 ),
                 KeyItemC(
                     center = KeyC("I", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("Ì", color = MUTED),
                     left = KeyC(":", color = MUTED),
                 ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/JAHiraganaThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/JAHiraganaThumbKey.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_JA_HIRAGANA_THUMBKEY_MAIN =
     KeyboardC(
@@ -14,7 +13,6 @@ val KB_JA_HIRAGANA_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("ま", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("み"),
                     left = KeyC("む"),
                     top = KeyC("め"),
@@ -22,7 +20,6 @@ val KB_JA_HIRAGANA_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("は", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("ひ"),
                     left = KeyC("ふ"),
                     top = KeyC("へ"),
@@ -30,7 +27,6 @@ val KB_JA_HIRAGANA_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("さ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("し"),
                     left = KeyC("す"),
                     top = KeyC("せ"),
@@ -41,13 +37,11 @@ val KB_JA_HIRAGANA_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("や", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("ゆ"),
                     right = KeyC("よ"),
                 ),
                 KeyItemC(
                     center = KeyC("な", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("に"),
                     left = KeyC("ぬ"),
                     top = KeyC("ね"),
@@ -55,7 +49,6 @@ val KB_JA_HIRAGANA_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("か", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("き"),
                     left = KeyC("く"),
                     top = KeyC("け"),
@@ -66,7 +59,6 @@ val KB_JA_HIRAGANA_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("ら", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("り"),
                     left = KeyC("る"),
                     top = KeyC("れ"),
@@ -74,7 +66,6 @@ val KB_JA_HIRAGANA_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("た", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("ち"),
                     left = KeyC("つ"),
                     top = KeyC("て"),
@@ -82,7 +73,6 @@ val KB_JA_HIRAGANA_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("あ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("い"),
                     left = KeyC("う"),
                     top = KeyC("え"),
@@ -93,7 +83,6 @@ val KB_JA_HIRAGANA_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("わ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("ゐ"),
                     left = KeyC("ん"),
                     top = KeyC("ゑ"),
@@ -106,7 +95,6 @@ val KB_JA_HIRAGANA_THUMBKEY_MAIN =
                             action = ComposeLastKey("゛"),
                             size = LARGE,
                         ),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("。"),
                     top =
                         KeyC(
@@ -137,7 +125,6 @@ val KB_JA_HIRAGANA_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("「", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("【"),
                     left = KeyC("〔"),
                     top = KeyC("〖"),
@@ -145,12 +132,10 @@ val KB_JA_HIRAGANA_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("・", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("※"),
                 ),
                 KeyItemC(
                     center = KeyC("」", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("】"),
                     left = KeyC("』"),
                     top = KeyC("〗"),
@@ -185,7 +170,6 @@ val KB_JA_HIRAGANA_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("ー", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("〜"),
                     top = KeyC("…"),
                 ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/JAHiraganaTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/JAHiraganaTypeSplit.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_JA_HIRAGANA_TYPESPLIT_MAIN =
     KeyboardC(
@@ -14,7 +13,6 @@ val KB_JA_HIRAGANA_TYPESPLIT_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("わ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("ん"),
                     left =
                         KeyC(
@@ -25,7 +23,6 @@ val KB_JA_HIRAGANA_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("た", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("て"),
                     left = KeyC("ち"),
                     bottom = KeyC("と"),
@@ -34,7 +31,6 @@ val KB_JA_HIRAGANA_TYPESPLIT_MAIN =
                 EMOJI_KEY_ITEM_ALT,
                 KeyItemC(
                     center = KeyC("や", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -50,7 +46,6 @@ val KB_JA_HIRAGANA_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("ら", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("れ"),
                     left = KeyC("り"),
                     bottom = KeyC("ろ"),
@@ -60,7 +55,6 @@ val KB_JA_HIRAGANA_TYPESPLIT_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("あ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("い"),
                     left = KeyC("え"),
                     bottom = KeyC("お"),
@@ -68,7 +62,6 @@ val KB_JA_HIRAGANA_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("さ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("せ"),
                     left = KeyC("し"),
                     bottom = KeyC("そ"),
@@ -77,7 +70,6 @@ val KB_JA_HIRAGANA_TYPESPLIT_MAIN =
                 SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("は", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("ひ"),
                     left = KeyC("へ"),
                     bottom = KeyC("ほ"),
@@ -85,7 +77,6 @@ val KB_JA_HIRAGANA_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("か", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("け"),
                     left = KeyC("き"),
                     bottom = KeyC("こ"),
@@ -95,7 +86,6 @@ val KB_JA_HIRAGANA_TYPESPLIT_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("、", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("」", color = MUTED),
                     left = KeyC("「", color = MUTED),
                     bottom = KeyC("ー", color = MUTED),
@@ -103,7 +93,6 @@ val KB_JA_HIRAGANA_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("。", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("？", color = MUTED),
                     left = KeyC("！", color = MUTED),
                     bottom = KeyC("：", color = MUTED),
@@ -112,7 +101,6 @@ val KB_JA_HIRAGANA_TYPESPLIT_MAIN =
                 SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("な", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("に"),
                     left = KeyC("ね"),
                     bottom = KeyC("の"),
@@ -120,7 +108,6 @@ val KB_JA_HIRAGANA_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("ま", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("め"),
                     left = KeyC("み"),
                     bottom = KeyC("も"),
@@ -141,7 +128,6 @@ val KB_JA_HIRAGANA_TYPESPLIT_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("¥", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -153,7 +139,6 @@ val KB_JA_HIRAGANA_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("だ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("で"),
                     left = KeyC("ぢ"),
                     bottom = KeyC("ど"),
@@ -162,7 +147,6 @@ val KB_JA_HIRAGANA_TYPESPLIT_SHIFTED =
                 EMOJI_KEY_ITEM_ALT,
                 KeyItemC(
                     center = KeyC("ゃ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -183,7 +167,6 @@ val KB_JA_HIRAGANA_TYPESPLIT_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("ぁ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("ぃ"),
                     left = KeyC("ぇ"),
                     bottom = KeyC("ぉ"),
@@ -191,7 +174,6 @@ val KB_JA_HIRAGANA_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("ざ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("ぜ"),
                     left = KeyC("じ"),
                     bottom = KeyC("ぞ"),
@@ -200,7 +182,6 @@ val KB_JA_HIRAGANA_TYPESPLIT_SHIFTED =
                 SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("ば", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("び"),
                     left = KeyC("べ"),
                     bottom = KeyC("ぼ"),
@@ -208,7 +189,6 @@ val KB_JA_HIRAGANA_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("が", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("げ"),
                     left = KeyC("ぎ"),
                     bottom = KeyC("ご"),
@@ -218,7 +198,6 @@ val KB_JA_HIRAGANA_TYPESPLIT_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("・", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("】", color = MUTED),
                     left = KeyC("【", color = MUTED),
                     bottom = KeyC("：", color = MUTED),
@@ -226,7 +205,6 @@ val KB_JA_HIRAGANA_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("＝", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("×", color = MUTED),
                     left = KeyC("÷", color = MUTED),
                     bottom = KeyC("＋", color = MUTED),
@@ -235,7 +213,6 @@ val KB_JA_HIRAGANA_TYPESPLIT_SHIFTED =
                 SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("ぱ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("ぴ"),
                     left = KeyC("ぺ"),
                     bottom = KeyC("ぽ"),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/JAKanaThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/JAKanaThumbKey.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_JA_KANA_THUMBKEY_HIRAGANA =
     KeyboardC(
@@ -14,7 +13,6 @@ val KB_JA_KANA_THUMBKEY_HIRAGANA =
             listOf(
                 KeyItemC(
                     center = KeyC("ま", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("み"),
                     left = KeyC("む"),
                     top = KeyC("め"),
@@ -22,7 +20,6 @@ val KB_JA_KANA_THUMBKEY_HIRAGANA =
                 ),
                 KeyItemC(
                     center = KeyC("は", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("ひ"),
                     left = KeyC("ふ"),
                     top = KeyC("へ"),
@@ -30,7 +27,6 @@ val KB_JA_KANA_THUMBKEY_HIRAGANA =
                 ),
                 KeyItemC(
                     center = KeyC("さ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("し"),
                     left = KeyC("す"),
                     top = KeyC("せ"),
@@ -41,7 +37,6 @@ val KB_JA_KANA_THUMBKEY_HIRAGANA =
             listOf(
                 KeyItemC(
                     center = KeyC("や", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("）"),
                     left = KeyC("ゆ"),
                     top = KeyC("（"),
@@ -49,7 +44,6 @@ val KB_JA_KANA_THUMBKEY_HIRAGANA =
                 ),
                 KeyItemC(
                     center = KeyC("な", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("に"),
                     left = KeyC("ぬ"),
                     top = KeyC("ね"),
@@ -57,7 +51,6 @@ val KB_JA_KANA_THUMBKEY_HIRAGANA =
                 ),
                 KeyItemC(
                     center = KeyC("か", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("き"),
                     left = KeyC("く"),
                     top = KeyC("け"),
@@ -68,7 +61,6 @@ val KB_JA_KANA_THUMBKEY_HIRAGANA =
             listOf(
                 KeyItemC(
                     center = KeyC("ら", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("り"),
                     left = KeyC("る"),
                     top = KeyC("れ"),
@@ -76,7 +68,6 @@ val KB_JA_KANA_THUMBKEY_HIRAGANA =
                 ),
                 KeyItemC(
                     center = KeyC("た", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("ち"),
                     left = KeyC("つ"),
                     top = KeyC("て"),
@@ -84,7 +75,6 @@ val KB_JA_KANA_THUMBKEY_HIRAGANA =
                 ),
                 KeyItemC(
                     center = KeyC("あ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("い"),
                     left = KeyC("う"),
                     top = KeyC("え"),
@@ -95,7 +85,6 @@ val KB_JA_KANA_THUMBKEY_HIRAGANA =
             listOf(
                 KeyItemC(
                     center = KeyC("わ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("ー"),
                     left = KeyC("ん"),
                     top = KeyC("〜"),
@@ -109,7 +98,6 @@ val KB_JA_KANA_THUMBKEY_HIRAGANA =
                             size = LARGE,
                             color = MUTED,
                         ),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("…"),
                     left = KeyC("「"),
                     top = KeyC("・"),
@@ -122,7 +110,6 @@ val KB_JA_KANA_THUMBKEY_HIRAGANA =
                             action = ComposeLastKey("゛"),
                             size = LARGE,
                         ),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("！"),
                     left = KeyC("。"),
                     top = KeyC("？"),
@@ -139,7 +126,6 @@ val KB_JA_KANA_THUMBKEY_KATAKANA =
             listOf(
                 KeyItemC(
                     center = KeyC("マ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("ミ"),
                     left = KeyC("ム"),
                     top = KeyC("メ"),
@@ -147,7 +133,6 @@ val KB_JA_KANA_THUMBKEY_KATAKANA =
                 ),
                 KeyItemC(
                     center = KeyC("ハ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("ヒ"),
                     left = KeyC("フ"),
                     top = KeyC("ヘ"),
@@ -155,7 +140,6 @@ val KB_JA_KANA_THUMBKEY_KATAKANA =
                 ),
                 KeyItemC(
                     center = KeyC("サ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("シ"),
                     left = KeyC("ス"),
                     top = KeyC("セ"),
@@ -166,7 +150,6 @@ val KB_JA_KANA_THUMBKEY_KATAKANA =
             listOf(
                 KeyItemC(
                     center = KeyC("ヤ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("）"),
                     left = KeyC("ユ"),
                     top = KeyC("（"),
@@ -174,7 +157,6 @@ val KB_JA_KANA_THUMBKEY_KATAKANA =
                 ),
                 KeyItemC(
                     center = KeyC("ナ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("ニ"),
                     left = KeyC("ヌ"),
                     top = KeyC("ネ"),
@@ -182,7 +164,6 @@ val KB_JA_KANA_THUMBKEY_KATAKANA =
                 ),
                 KeyItemC(
                     center = KeyC("カ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("キ"),
                     left = KeyC("ク"),
                     top = KeyC("ケ"),
@@ -193,7 +174,6 @@ val KB_JA_KANA_THUMBKEY_KATAKANA =
             listOf(
                 KeyItemC(
                     center = KeyC("ラ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("リ"),
                     left = KeyC("ル"),
                     top = KeyC("レ"),
@@ -201,7 +181,6 @@ val KB_JA_KANA_THUMBKEY_KATAKANA =
                 ),
                 KeyItemC(
                     center = KeyC("タ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("チ"),
                     left = KeyC("ツ"),
                     top = KeyC("テ"),
@@ -209,7 +188,6 @@ val KB_JA_KANA_THUMBKEY_KATAKANA =
                 ),
                 KeyItemC(
                     center = KeyC("ア", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("イ"),
                     left = KeyC("ウ"),
                     top = KeyC("エ"),
@@ -220,7 +198,6 @@ val KB_JA_KANA_THUMBKEY_KATAKANA =
             listOf(
                 KeyItemC(
                     center = KeyC("ワ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("ー"),
                     left = KeyC("ン"),
                     top = KeyC("〜"),
@@ -234,7 +211,6 @@ val KB_JA_KANA_THUMBKEY_KATAKANA =
                             size = LARGE,
                             color = MUTED,
                         ),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("…"),
                     left = KeyC("「"),
                     top = KeyC("・"),
@@ -247,7 +223,6 @@ val KB_JA_KANA_THUMBKEY_KATAKANA =
                             action = ComposeLastKey("゛"),
                             size = LARGE,
                         ),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("！"),
                     left = KeyC("。"),
                     top = KeyC("？"),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/JAKatakanaThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/JAKatakanaThumbKey.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_JA_KATAKANA_THUMBKEY_MAIN =
     KeyboardC(
@@ -14,7 +13,6 @@ val KB_JA_KATAKANA_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("マ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("ミ"),
                     left = KeyC("ム"),
                     top = KeyC("メ"),
@@ -22,7 +20,6 @@ val KB_JA_KATAKANA_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("ハ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("ヒ"),
                     left = KeyC("フ"),
                     top = KeyC("ヘ"),
@@ -30,7 +27,6 @@ val KB_JA_KATAKANA_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("サ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("シ"),
                     left = KeyC("ス"),
                     top = KeyC("セ"),
@@ -41,13 +37,11 @@ val KB_JA_KATAKANA_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("ヤ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("ユ"),
                     right = KeyC("ヨ"),
                 ),
                 KeyItemC(
                     center = KeyC("ナ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("ニ"),
                     left = KeyC("ヌ"),
                     top = KeyC("ネ"),
@@ -55,7 +49,6 @@ val KB_JA_KATAKANA_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("カ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("キ"),
                     left = KeyC("ク"),
                     top = KeyC("ケ"),
@@ -66,7 +59,6 @@ val KB_JA_KATAKANA_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("ラ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("リ"),
                     left = KeyC("ル"),
                     top = KeyC("レ"),
@@ -74,7 +66,6 @@ val KB_JA_KATAKANA_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("タ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("チ"),
                     left = KeyC("ツ"),
                     top = KeyC("テ"),
@@ -82,7 +73,6 @@ val KB_JA_KATAKANA_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("ア", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("イ"),
                     left = KeyC("ウ"),
                     top = KeyC("エ"),
@@ -93,7 +83,6 @@ val KB_JA_KATAKANA_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("ワ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("ヰ"),
                     left = KeyC("ン"),
                     top = KeyC("ヱ"),
@@ -106,7 +95,6 @@ val KB_JA_KATAKANA_THUMBKEY_MAIN =
                             action = ComposeLastKey("゛"),
                             size = LARGE,
                         ),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("。"),
                     top =
                         KeyC(
@@ -132,7 +120,6 @@ val KB_JA_KATAKANA_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("「", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("【"),
                     left = KeyC("〔"),
                     top = KeyC("〖"),
@@ -140,12 +127,10 @@ val KB_JA_KATAKANA_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("・", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("※"),
                 ),
                 KeyItemC(
                     center = KeyC("」", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("】"),
                     left = KeyC("』"),
                     top = KeyC("〗"),
@@ -180,7 +165,6 @@ val KB_JA_KATAKANA_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("ー", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("〜"),
                     top = KeyC("…"),
                 ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/JAKatakanaTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/JAKatakanaTypeSplit.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_JA_KATAKANA_TYPESPLIT_MAIN =
     KeyboardC(
@@ -14,7 +13,6 @@ val KB_JA_KATAKANA_TYPESPLIT_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("ワ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("ン"),
                     left =
                         KeyC(
@@ -25,7 +23,6 @@ val KB_JA_KATAKANA_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("タ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("テ"),
                     left = KeyC("チ"),
                     bottom = KeyC("ト"),
@@ -34,7 +31,6 @@ val KB_JA_KATAKANA_TYPESPLIT_MAIN =
                 EMOJI_KEY_ITEM_ALT,
                 KeyItemC(
                     center = KeyC("ヤ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -50,7 +46,6 @@ val KB_JA_KATAKANA_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("ラ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("レ"),
                     left = KeyC("リ"),
                     bottom = KeyC("ロ"),
@@ -60,7 +55,6 @@ val KB_JA_KATAKANA_TYPESPLIT_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("ア", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("イ"),
                     left = KeyC("エ"),
                     bottom = KeyC("オ"),
@@ -68,7 +62,6 @@ val KB_JA_KATAKANA_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("サ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("セ"),
                     left = KeyC("シ"),
                     bottom = KeyC("ソ"),
@@ -77,7 +70,6 @@ val KB_JA_KATAKANA_TYPESPLIT_MAIN =
                 SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("ハ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("ヒ"),
                     left = KeyC("ヘ"),
                     bottom = KeyC("ホ"),
@@ -85,7 +77,6 @@ val KB_JA_KATAKANA_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("カ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("ケ"),
                     left = KeyC("キ"),
                     bottom = KeyC("コ"),
@@ -95,7 +86,6 @@ val KB_JA_KATAKANA_TYPESPLIT_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("、", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("」", color = MUTED),
                     left = KeyC("「", color = MUTED),
                     bottom = KeyC("ー", color = MUTED),
@@ -103,7 +93,6 @@ val KB_JA_KATAKANA_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("。", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("？", color = MUTED),
                     left = KeyC("！", color = MUTED),
                     bottom = KeyC("：", color = MUTED),
@@ -112,7 +101,6 @@ val KB_JA_KATAKANA_TYPESPLIT_MAIN =
                 SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("ナ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("ニ"),
                     left = KeyC("ネ"),
                     bottom = KeyC("ノ"),
@@ -120,7 +108,6 @@ val KB_JA_KATAKANA_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("マ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("メ"),
                     left = KeyC("ミ"),
                     bottom = KeyC("モ"),
@@ -141,7 +128,6 @@ val KB_JA_KATAKANA_TYPESPLIT_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("¥", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -153,7 +139,6 @@ val KB_JA_KATAKANA_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("ダ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("デ"),
                     left = KeyC("ヂ"),
                     bottom = KeyC("ド"),
@@ -162,7 +147,6 @@ val KB_JA_KATAKANA_TYPESPLIT_SHIFTED =
                 EMOJI_KEY_ITEM_ALT,
                 KeyItemC(
                     center = KeyC("ャ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -183,7 +167,6 @@ val KB_JA_KATAKANA_TYPESPLIT_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("ァ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("ィ"),
                     left = KeyC("ェ"),
                     bottom = KeyC("ォ"),
@@ -191,7 +174,6 @@ val KB_JA_KATAKANA_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("ザ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("ゼ"),
                     left = KeyC("ジ"),
                     bottom = KeyC("ゾ"),
@@ -200,7 +182,6 @@ val KB_JA_KATAKANA_TYPESPLIT_SHIFTED =
                 SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("バ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("ビ"),
                     left = KeyC("ベ"),
                     bottom = KeyC("ボ"),
@@ -208,7 +189,6 @@ val KB_JA_KATAKANA_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("ガ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("ゲ"),
                     left = KeyC("ギ"),
                     bottom = KeyC("ゴ"),
@@ -218,7 +198,6 @@ val KB_JA_KATAKANA_TYPESPLIT_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("・", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("】", color = MUTED),
                     left = KeyC("【", color = MUTED),
                     bottom = KeyC("：", color = MUTED),
@@ -226,7 +205,6 @@ val KB_JA_KATAKANA_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("＝", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("×", color = MUTED),
                     left = KeyC("÷", color = MUTED),
                     bottom = KeyC("＋", color = MUTED),
@@ -235,7 +213,6 @@ val KB_JA_KATAKANA_TYPESPLIT_SHIFTED =
                 SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("パ", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("ピ"),
                     left = KeyC("ペ"),
                     bottom = KeyC("ポ"),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/KAThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/KAThumbKey.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_KA_THUMBKEY_MAIN =
     KeyboardC(
@@ -20,12 +19,10 @@ val KB_KA_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("ბ", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("ლ"),
                 ),
                 KeyItemC(
                     center = KeyC("ე", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("გ"),
                     bottomRight = KeyC("ჰ"),
                 ),
@@ -34,7 +31,6 @@ val KB_KA_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("ს", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("თ"),
                     bottom = KeyC("ნ"),
                 ),
@@ -51,7 +47,6 @@ val KB_KA_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("ი", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("კ"),
                 ),
                 NUMERIC_KEY_ITEM,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/KZThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/KZThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_KZ_THUMBKEY_MAIN =
     KeyboardC(
@@ -22,12 +21,10 @@ val KB_KZ_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("р", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("х"),
                 ),
                 KeyItemC(
                     center = KeyC("а", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("ж"),
                     topRight = KeyC("ә"),
                     bottomRight = KeyC("і"),
@@ -122,12 +119,10 @@ val KB_KZ_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("Р", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("Х"),
                 ),
                 KeyItemC(
                     center = KeyC("А", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("Ж"),
                     topRight = KeyC("Ә"),
                     bottomRight = KeyC("І"),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/LTThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/LTThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_LT_THUMBKEY_MAIN =
     KeyboardC(
@@ -21,7 +20,6 @@ val KB_LT_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("g"),
                 ),
                 KeyItemC(
@@ -52,7 +50,6 @@ val KB_LT_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("ą"),
                     left = KeyC("m"),
                     top =
@@ -111,7 +108,6 @@ val KB_LT_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("G"),
                 ),
                 KeyItemC(
@@ -142,7 +138,6 @@ val KB_LT_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("Ą"),
                     left = KeyC("M"),
                     bottom =

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/LVLTGThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/LVLTGThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_LV_LTG_THUMBKEY_MAIN =
     KeyboardC(
@@ -16,12 +15,10 @@ val KB_LV_LTG_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("d"),
                 ),
                 KeyItemC(
                     center = KeyC("k", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("ķ"),
                     bottom = KeyC("v"),
                 ),
@@ -35,7 +32,6 @@ val KB_LV_LTG_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("ļ"),
                     right = KeyC("l"),
                 ),
@@ -107,12 +103,10 @@ val KB_LV_LTG_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("D"),
                 ),
                 KeyItemC(
                     center = KeyC("K", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("Ķ"),
                     bottom = KeyC("V"),
                 ),
@@ -126,7 +120,6 @@ val KB_LV_LTG_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("Ļ"),
                     right = KeyC("L"),
                 ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/MATHThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/MATHThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_MATH_THUMBKEY_MAIN =
     KeyboardC(
@@ -16,14 +15,12 @@ val KB_MATH_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("∀", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     topLeft = KeyC("⊊"),
                     left = KeyC("⊆"),
                     bottomLeft = KeyC("⊂"),
                 ),
                 KeyItemC(
                     center = KeyC("∫", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     left = KeyC("+"),
                     topLeft = KeyC("±"),
                     right = KeyC("!"),
@@ -33,7 +30,6 @@ val KB_MATH_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("∃", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     topRight = KeyC("⊋"),
                     right = KeyC("⊇"),
                     bottomRight = KeyC("⊃"),
@@ -46,7 +42,6 @@ val KB_MATH_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("∅", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     topRight = KeyC("∩"),
                     right = KeyC("∪"),
                     bottomRight = KeyC("⊍"),
@@ -62,7 +57,6 @@ val KB_MATH_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("¬", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     topLeft = KeyC("∧"),
                     left = KeyC("∨"),
                     bottomLeft = KeyC("⩒"),
@@ -86,7 +80,6 @@ val KB_MATH_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("→", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     topLeft = KeyC("~"),
                     left = KeyC("≤"),
                     bottomLeft = KeyC("<"),
@@ -109,7 +102,6 @@ val KB_MATH_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("ℕ", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     topRight = KeyC("°"),
                     right = KeyC("≥"),
                     bottomRight = KeyC(">"),
@@ -134,20 +126,17 @@ val KB_MATH_THUMBKEY_SLASH =
             listOf(
                 KeyItemC(
                     center = KeyC("", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     left = KeyC("⊈"),
                     bottomLeft = KeyC("⊄"),
                 ),
                 KeyItemC(
                     center = KeyC("∮", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     topLeft = KeyC("∓"),
                     bottomLeft = KeyC("∌"),
                     bottomRight = KeyC("∉"),
                 ),
                 KeyItemC(
                     center = KeyC("∄", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     right = KeyC("⊉"),
                     bottomRight = KeyC("⊅"),
                     bottom = KeyC("≠"),
@@ -158,7 +147,6 @@ val KB_MATH_THUMBKEY_SLASH =
             listOf(
                 KeyItemC(
                     center = KeyC("∅", size = LARGE),
-                    swipeType = EIGHT_WAY,
                 ),
                 KeyItemC(
                     center = KeyC("↯", size = LARGE),
@@ -168,7 +156,6 @@ val KB_MATH_THUMBKEY_SLASH =
                 ),
                 KeyItemC(
                     center = KeyC("¬", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     bottom =
                         KeyC(
                             display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
@@ -182,7 +169,6 @@ val KB_MATH_THUMBKEY_SLASH =
             listOf(
                 KeyItemC(
                     center = KeyC("↛", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     topLeft = KeyC("≁"),
                     left = KeyC("≰"),
                     bottomLeft = KeyC("≮"),
@@ -192,7 +178,6 @@ val KB_MATH_THUMBKEY_SLASH =
                 ),
                 KeyItemC(
                     center = KeyC("", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     left = KeyC("≱"),
                     bottomLeft = KeyC("≯"),
                 ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/NLThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/NLThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_NL_THUMBKEY_MAIN =
     KeyboardC(
@@ -16,17 +15,14 @@ val KB_NL_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("h"),
                 ),
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("p"),
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("k"),
                 ),
                 EMOJI_KEY_ITEM,
@@ -34,7 +30,6 @@ val KB_NL_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("c"),
                 ),
                 KeyItemC(
@@ -50,7 +45,6 @@ val KB_NL_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("i", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("g"),
                     top =
                         KeyC(
@@ -70,7 +64,6 @@ val KB_NL_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("m"),
                 ),
                 KeyItemC(
@@ -104,17 +97,14 @@ val KB_NL_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("H"),
                 ),
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("P"),
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("K"),
                 ),
                 EMOJI_KEY_ITEM,
@@ -122,7 +112,6 @@ val KB_NL_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("C"),
                 ),
                 KeyItemC(
@@ -138,7 +127,6 @@ val KB_NL_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("I", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("G"),
                     bottom =
                         KeyC(
@@ -161,7 +149,6 @@ val KB_NL_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("M"),
                 ),
                 KeyItemC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/NLTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/NLTypeSplit.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_NL_TYPESPLIT_MAIN =
     KeyboardC(
@@ -29,12 +28,10 @@ val KB_NL_TYPESPLIT_MAIN =
                 EMOJI_KEY_ITEM_ALT,
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("h"),
                 ),
                 KeyItemC(
                     center = KeyC("l", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("z"),
                 ),
             ),
@@ -59,14 +56,12 @@ val KB_NL_TYPESPLIT_MAIN =
                 SPACEBAR_ALL_DIRECTIONS,
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("v"),
                     right = KeyC("m"),
                     bottom = KeyC("w"),
                 ),
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("g"),
                     left = KeyC("j"),
                 ),
@@ -74,7 +69,6 @@ val KB_NL_TYPESPLIT_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("p", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("!", color = MUTED),
                 ),
                 KeyItemC(
@@ -87,12 +81,10 @@ val KB_NL_TYPESPLIT_MAIN =
                 SPACEBAR_ALL_SYMBOLS,
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("k"),
                 ),
                 KeyItemC(
                     center = KeyC("d", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("b"),
                 ),
             ),
@@ -125,12 +117,10 @@ val KB_NL_TYPESPLIT_SHIFTED =
                 EMOJI_KEY_ITEM_ALT,
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("H"),
                 ),
                 KeyItemC(
                     center = KeyC("L", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("Z"),
                 ),
             ),
@@ -155,14 +145,12 @@ val KB_NL_TYPESPLIT_SHIFTED =
                 SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("V"),
                     right = KeyC("M"),
                     bottom = KeyC("W"),
                 ),
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("G"),
                     left = KeyC("J"),
                 ),
@@ -170,7 +158,6 @@ val KB_NL_TYPESPLIT_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("P", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("!", color = MUTED),
                 ),
                 KeyItemC(
@@ -183,12 +170,10 @@ val KB_NL_TYPESPLIT_SHIFTED =
                 SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("K"),
                 ),
                 KeyItemC(
                     center = KeyC("D", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("B"),
                 ),
             ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/NOThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/NOThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_NO_THUMBKEY_MAIN =
     KeyboardC(
@@ -16,7 +15,6 @@ val KB_NO_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("p"),
                 ),
                 KeyItemC(
@@ -27,7 +25,6 @@ val KB_NO_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("u"),
                 ),
                 EMOJI_KEY_ITEM,
@@ -35,7 +32,6 @@ val KB_NO_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("v"),
                 ),
                 KeyItemC(
@@ -51,7 +47,6 @@ val KB_NO_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("g"),
                     top =
                         KeyC(
@@ -71,7 +66,6 @@ val KB_NO_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("m"),
                 ),
                 KeyItemC(
@@ -86,7 +80,6 @@ val KB_NO_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("l"),
                 ),
                 BACKSPACE_KEY_ITEM,
@@ -104,7 +97,6 @@ val KB_NO_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("P"),
                 ),
                 KeyItemC(
@@ -115,7 +107,6 @@ val KB_NO_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("U"),
                 ),
                 EMOJI_KEY_ITEM,
@@ -123,7 +114,6 @@ val KB_NO_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("V"),
                 ),
                 KeyItemC(
@@ -139,7 +129,6 @@ val KB_NO_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("G"),
                     bottom =
                         KeyC(
@@ -162,7 +151,6 @@ val KB_NO_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("M"),
                 ),
                 KeyItemC(
@@ -177,7 +165,6 @@ val KB_NO_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("L"),
                 ),
                 BACKSPACE_KEY_ITEM,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/Numeric.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/Numeric.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val NUMERIC_KEYBOARD =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericDouble.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericDouble.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val DOUBLE_NUMERIC_KEYBOARD =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericENDENL.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericENDENL.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val NUMERIC_ENDENL_KEYBOARD =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericENMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericENMessagEase.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_MESSAGEASE_NUMERIC =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericENMessagEaseTwoHands.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericENMessagEaseTwoHands.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_EN_MESSAGEASE_TWO_HANDS_NUMERIC =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericESMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericESMessagEase.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 // this val is so we can can use mapOf in the key with currency symbol
 val KB_ES_MESSAGEASE_CURRENCY_SYMBOL: String =

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericFarsi.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericFarsi.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val FARSI_NUMERIC_KEYBOARD =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericFarsiSamsung.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericFarsiSamsung.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val FARSI_NUMERIC_SAMSUNG_KEYBOARD =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericFrench.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericFrench.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val FRENCH_NUMERIC_KEYBOARD =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericFrenchTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericFrenchTypeSplit.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val FRENCH_TYPESPLIT_NUMERIC_KEYBOARD =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericNordicMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericNordicMessagEase.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_NORDIC_MESSAGEASE_NUMERIC =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericPTEN.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericPTEN.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val NUMERIC_PT_EN_KEYBOARD =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericTwoHands.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericTwoHands.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val TWO_HANDS_NUMERIC_KEYBOARD =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericTypeSplit.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val TYPESPLIT_NUMERIC_KEYBOARD =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericWide.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericWide.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val WIDE_NUMERIC_KEYBOARD =
     KeyboardC(
@@ -17,7 +16,6 @@ val WIDE_NUMERIC_KEYBOARD =
                 EMOJI_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("1", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("¬"),
                     topRight =
                         KeyC(
@@ -30,7 +28,6 @@ val WIDE_NUMERIC_KEYBOARD =
                 ),
                 KeyItemC(
                     center = KeyC("2", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("°"),
                     topRight =
                         KeyC(
@@ -43,7 +40,6 @@ val WIDE_NUMERIC_KEYBOARD =
                 ),
                 KeyItemC(
                     center = KeyC("3", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("^"),
                     topRight =
                         KeyC(
@@ -57,14 +53,12 @@ val WIDE_NUMERIC_KEYBOARD =
             listOf(
                 KeyItemC(
                     center = KeyC("(", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("<"),
                     left = KeyC("{"),
                     right = KeyC("["),
                 ),
                 KeyItemC(
                     center = KeyC("4", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("€"),
                     bottomLeft = KeyC("$"),
                     bottomRight =
@@ -78,7 +72,6 @@ val WIDE_NUMERIC_KEYBOARD =
                 ),
                 KeyItemC(
                     center = KeyC("5", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("!"),
                     topRight = KeyC("?"),
                     bottomRight = KeyC("."),
@@ -86,7 +79,6 @@ val WIDE_NUMERIC_KEYBOARD =
                 ),
                 KeyItemC(
                     center = KeyC("6", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("`"),
                     topRight = KeyC("´"),
                     bottomLeft = KeyC("\""),
@@ -94,7 +86,6 @@ val WIDE_NUMERIC_KEYBOARD =
                 ),
                 KeyItemC(
                     center = KeyC(")", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC(">"),
                     left = KeyC("]"),
                     right = KeyC("}"),
@@ -112,7 +103,6 @@ val WIDE_NUMERIC_KEYBOARD =
                 ),
                 KeyItemC(
                     center = KeyC("7", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("="),
                     topRight = KeyC("%"),
                     bottomLeft = KeyC("-"),
@@ -120,7 +110,6 @@ val WIDE_NUMERIC_KEYBOARD =
                 ),
                 KeyItemC(
                     center = KeyC("8", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("@"),
                     topRight = KeyC("&"),
                     bottomLeft = KeyC("*"),
@@ -128,7 +117,6 @@ val WIDE_NUMERIC_KEYBOARD =
                 ),
                 KeyItemC(
                     center = KeyC("9", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("~"),
                     bottomLeft = KeyC("\\"),
                     bottomRight = KeyC("/"),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/PLMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/PLMessagEase.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_PL_MESSAGEASE_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/PLThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/PLThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_PL_THUMBKEY_MAIN =
     KeyboardC(
@@ -16,7 +15,6 @@ val KB_PL_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("p"),
                 ),
                 KeyItemC(
@@ -26,7 +24,6 @@ val KB_PL_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("u"),
                     bottomRight = KeyC("ó"),
                 ),
@@ -71,7 +68,6 @@ val KB_PL_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("z", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("k"),
                     bottomLeft = KeyC("ż"),
                     bottomRight = KeyC("ź"),
@@ -89,7 +85,6 @@ val KB_PL_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("t"),
                     bottomRight = KeyC("ą"),
                 ),
@@ -108,7 +103,6 @@ val KB_PL_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("P"),
                 ),
                 KeyItemC(
@@ -118,7 +112,6 @@ val KB_PL_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("U"),
                     bottomRight = KeyC("Ó"),
                 ),
@@ -166,7 +159,6 @@ val KB_PL_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("Z", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("K"),
                     bottomLeft = KeyC("Ż"),
                     bottomRight = KeyC("Ź"),
@@ -184,7 +176,6 @@ val KB_PL_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("T"),
                     bottomRight = KeyC("Ą"),
                 ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/PLTypeSplitSymbolsV1.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/PLTypeSplitSymbolsV1.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_PL_TYPESPLIT_SYMBOLS_V1_MAIN =
     KeyboardC(
@@ -14,7 +13,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V1_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("ę", color = MUTED),
                     left = KeyC("{", color = MUTED),
                     bottom = KeyC("w"),
@@ -22,7 +20,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V1_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("\\"),
                     bottom = KeyC("t"),
                     left = KeyC("/"),
@@ -31,7 +28,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V1_MAIN =
                 EMOJI_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("i", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("y"),
                     left = KeyC("%", color = MUTED),
                     bottom = KeyC("u"),
@@ -39,7 +35,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V1_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("}", color = MUTED),
                     left = KeyC("ó", color = MUTED),
                     bottom = KeyC("p"),
@@ -49,7 +44,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V1_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("ą", color = MUTED),
                     left = KeyC("(", color = MUTED),
                     bottom = KeyC("@", color = MUTED),
@@ -57,7 +51,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V1_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("`"),
                     left = KeyC("ś", color = MUTED),
                     top = KeyC("\"", color = MUTED),
@@ -66,14 +59,12 @@ val KB_PL_TYPESPLIT_SYMBOLS_V1_MAIN =
                 SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("d", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("h"),
                     bottom = KeyC("g", color = MUTED),
                     top = KeyC("f", color = MUTED),
                 ),
                 KeyItemC(
                     center = KeyC("k", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC(")", color = MUTED),
                     bottom = KeyC("l"),
                     top = KeyC("ł"),
@@ -83,7 +74,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V1_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("z", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     right = KeyC("ź", color = MUTED),
                     left =
                         KeyC(
@@ -97,7 +87,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V1_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("c", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("©", color = MUTED),
                     left = KeyC("ć", color = MUTED),
                     bottom = KeyC("b"),
@@ -106,13 +95,11 @@ val KB_PL_TYPESPLIT_SYMBOLS_V1_MAIN =
                 SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("ń", color = MUTED),
                     left = KeyC("&", color = MUTED),
                 ),
                 KeyItemC(
                     center = KeyC("m", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     left = KeyC("!", color = MUTED),
                     bottom = KeyC(":", color = MUTED),
                     top = KeyC(";", color = MUTED),
@@ -135,7 +122,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V1_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("Ę", color = MUTED),
                     left = KeyC("{", color = MUTED),
                     bottom = KeyC("W"),
@@ -143,7 +129,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V1_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("\\"),
                     bottom = KeyC("T"),
                     left = KeyC("/"),
@@ -152,7 +137,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V1_SHIFTED =
                 EMOJI_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("I", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("Y"),
                     left = KeyC("%", color = MUTED),
                     bottom = KeyC("U"),
@@ -160,7 +144,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V1_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("}", color = MUTED),
                     left = KeyC("Ó", color = MUTED),
                     bottom = KeyC("P"),
@@ -170,7 +153,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V1_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("Ą", color = MUTED),
                     left = KeyC("(", color = MUTED),
                     bottom = KeyC("@", color = MUTED),
@@ -178,7 +160,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V1_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("`"),
                     left = KeyC("Ś", color = MUTED),
                     top = KeyC("\"", color = MUTED),
@@ -187,14 +168,12 @@ val KB_PL_TYPESPLIT_SYMBOLS_V1_SHIFTED =
                 SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("D", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("H"),
                     bottom = KeyC("G", color = MUTED),
                     top = KeyC("F", color = MUTED),
                 ),
                 KeyItemC(
                     center = KeyC("K", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC(")", color = MUTED),
                     bottom = KeyC("L"),
                     top = KeyC("Ł"),
@@ -204,7 +183,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V1_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("Z", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     right = KeyC("Ź", color = MUTED),
                     left =
                         KeyC(
@@ -218,7 +196,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V1_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("C", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("©", color = MUTED),
                     left = KeyC("Ć", color = MUTED),
                     bottom = KeyC("B"),
@@ -227,13 +204,11 @@ val KB_PL_TYPESPLIT_SYMBOLS_V1_SHIFTED =
                 SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("Ń", color = MUTED),
                     left = KeyC("&", color = MUTED),
                 ),
                 KeyItemC(
                     center = KeyC("M", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     left = KeyC("!", color = MUTED),
                     bottom = KeyC(":", color = MUTED),
                     top = KeyC(";", color = MUTED),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/PLTypeSplitSymbolsV2.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/PLTypeSplitSymbolsV2.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val TYPESPLIT_SYMBOLS_MIDDLE_KEY =
     KeyItemC(
@@ -16,7 +15,6 @@ val TYPESPLIT_SYMBOLS_MIDDLE_KEY =
                 size = LARGE,
                 color = MUTED,
             ),
-        swipeType = EIGHT_WAY,
         topLeft = KeyC("+", color = MUTED),
         top = KeyC("*", color = MUTED),
         topRight = KeyC("=", color = MUTED),
@@ -32,7 +30,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V2_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("ę", color = MUTED),
                     left = KeyC("{", color = MUTED),
                     bottom = KeyC("w"),
@@ -40,7 +37,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V2_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("t"),
                     right = KeyC("®", color = MUTED),
                     top = KeyC("`", color = MUTED),
@@ -49,7 +45,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V2_MAIN =
                 EMOJI_KEY_ITEM_ALT,
                 KeyItemC(
                     center = KeyC("i", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("y"),
                     left = KeyC("%", color = MUTED),
                     bottom = KeyC("u"),
@@ -57,7 +52,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V2_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("}", color = MUTED),
                     left = KeyC("ó", color = MUTED),
                     bottom = KeyC("p"),
@@ -67,7 +61,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V2_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("ą", color = MUTED),
                     left = KeyC("(", color = MUTED),
                     bottom = KeyC("@", color = MUTED),
@@ -75,7 +68,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V2_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("f"),
                     left = KeyC("ś", color = MUTED),
                     top = KeyC("\"", color = MUTED),
@@ -84,7 +76,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V2_MAIN =
                 TYPESPLIT_SYMBOLS_MIDDLE_KEY,
                 KeyItemC(
                     center = KeyC("d", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("h"),
                     left = KeyC("j"),
                     bottom = KeyC("$", color = MUTED),
@@ -92,7 +83,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V2_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("k", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC(")", color = MUTED),
                     bottom = KeyC("l"),
                     top = KeyC("ł"),
@@ -102,7 +92,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V2_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("z", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     right = KeyC("ź", color = MUTED),
                     left =
                         KeyC(
@@ -116,7 +105,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V2_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("c", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("©", color = MUTED),
                     left = KeyC("ć", color = MUTED),
                     bottom = KeyC("b"),
@@ -125,7 +113,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V2_MAIN =
                 SPACEBAR_SKINNY_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("ń", color = MUTED),
                     left = KeyC("&", color = MUTED),
                     top = KeyC("!", color = MUTED),
@@ -133,7 +120,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V2_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("m", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     left = KeyC(":", color = MUTED),
                     bottom = KeyC("/", color = MUTED),
                     top = KeyC("\\", color = MUTED),
@@ -155,7 +141,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V2_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("Ę", color = MUTED),
                     left = KeyC("{", color = MUTED),
                     bottom = KeyC("W"),
@@ -163,7 +148,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V2_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("T"),
                     right = KeyC("®", color = MUTED),
                     top = KeyC("`", color = MUTED),
@@ -172,7 +156,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V2_SHIFTED =
                 EMOJI_KEY_ITEM_ALT,
                 KeyItemC(
                     center = KeyC("I", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("Y"),
                     left = KeyC("%", color = MUTED),
                     bottom = KeyC("U"),
@@ -180,7 +163,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V2_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("}", color = MUTED),
                     left = KeyC("Ó", color = MUTED),
                     bottom = KeyC("P"),
@@ -190,7 +172,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V2_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("Ą", color = MUTED),
                     left = KeyC("(", color = MUTED),
                     bottom = KeyC("@", color = MUTED),
@@ -198,7 +179,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V2_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("F"),
                     left = KeyC("Ś", color = MUTED),
                     top = KeyC("\"", color = MUTED),
@@ -207,7 +187,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V2_SHIFTED =
                 TYPESPLIT_SYMBOLS_MIDDLE_KEY,
                 KeyItemC(
                     center = KeyC("D", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("H"),
                     left = KeyC("J"),
                     bottom = KeyC("$", color = MUTED),
@@ -215,7 +194,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V2_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("K", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC(")", color = MUTED),
                     bottom = KeyC("L"),
                     top = KeyC("Ł"),
@@ -225,7 +203,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V2_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("Z", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     right = KeyC("Ź", color = MUTED),
                     left =
                         KeyC(
@@ -239,7 +216,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V2_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("C", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("©", color = MUTED),
                     left = KeyC("Ć", color = MUTED),
                     bottom = KeyC("B"),
@@ -248,7 +224,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V2_SHIFTED =
                 SPACEBAR_SKINNY_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("Ń", color = MUTED),
                     left = KeyC("&", color = MUTED),
                     top = KeyC("!", color = MUTED),
@@ -256,7 +231,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V2_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("M", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     left = KeyC(":", color = MUTED),
                     bottom = KeyC("/", color = MUTED),
                     top = KeyC("\\", color = MUTED),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/PLTypeSplitV1.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/PLTypeSplitV1.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_PL_TYPESPLIT_V1_MAIN =
     KeyboardC(
@@ -14,7 +13,6 @@ val KB_PL_TYPESPLIT_V1_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("ę", color = MUTED),
                     left =
                         KeyC(
@@ -26,13 +24,11 @@ val KB_PL_TYPESPLIT_V1_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("t"),
                 ),
                 EMOJI_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("i", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("y"),
                     left =
                         KeyC(
@@ -43,7 +39,6 @@ val KB_PL_TYPESPLIT_V1_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -56,7 +51,6 @@ val KB_PL_TYPESPLIT_V1_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("ą", color = MUTED),
                     left =
                         KeyC(
@@ -66,7 +60,6 @@ val KB_PL_TYPESPLIT_V1_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right =
                         KeyC(
                             display = null,
@@ -77,14 +70,12 @@ val KB_PL_TYPESPLIT_V1_MAIN =
                 SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("d", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("h"),
                     top = KeyC("f"),
                     bottom = KeyC("g"),
                 ),
                 KeyItemC(
                     center = KeyC("k", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("l"),
                     top = KeyC("ł"),
                     left = KeyC("j"),
@@ -93,7 +84,6 @@ val KB_PL_TYPESPLIT_V1_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("z", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("ź", color = MUTED),
                     left =
                         KeyC(
@@ -105,7 +95,6 @@ val KB_PL_TYPESPLIT_V1_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("c", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -118,7 +107,6 @@ val KB_PL_TYPESPLIT_V1_MAIN =
                 SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("ń", color = MUTED),
                     left =
                         KeyC(
@@ -128,7 +116,6 @@ val KB_PL_TYPESPLIT_V1_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("m", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("?", color = MUTED),
                     left = KeyC("!", color = MUTED),
                     bottom = KeyC(":", color = MUTED),
@@ -149,7 +136,6 @@ val KB_PL_TYPESPLIT_V1_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("Ę", color = MUTED),
                     left =
                         KeyC(
@@ -161,13 +147,11 @@ val KB_PL_TYPESPLIT_V1_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("T"),
                 ),
                 EMOJI_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("I", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("Y"),
                     left =
                         KeyC(
@@ -178,7 +162,6 @@ val KB_PL_TYPESPLIT_V1_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -191,7 +174,6 @@ val KB_PL_TYPESPLIT_V1_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("Ą", color = MUTED),
                     left =
                         KeyC(
@@ -201,7 +183,6 @@ val KB_PL_TYPESPLIT_V1_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right =
                         KeyC(
                             display = null,
@@ -212,14 +193,12 @@ val KB_PL_TYPESPLIT_V1_SHIFTED =
                 SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("D", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("H"),
                     top = KeyC("F"),
                     bottom = KeyC("G"),
                 ),
                 KeyItemC(
                     center = KeyC("K", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("L"),
                     top = KeyC("Ł"),
                     left = KeyC("J"),
@@ -228,7 +207,6 @@ val KB_PL_TYPESPLIT_V1_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("Z", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("Ź", color = MUTED),
                     left =
                         KeyC(
@@ -240,7 +218,6 @@ val KB_PL_TYPESPLIT_V1_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("C", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -253,7 +230,6 @@ val KB_PL_TYPESPLIT_V1_SHIFTED =
                 SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("Ń", color = MUTED),
                     left =
                         KeyC(
@@ -263,7 +239,6 @@ val KB_PL_TYPESPLIT_V1_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("M", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("?", color = MUTED),
                     left = KeyC("!", color = MUTED),
                     bottom = KeyC(":", color = MUTED),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/PLTypeSplitV2.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/PLTypeSplitV2.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_PL_TYPESPLIT_V2_MAIN =
     KeyboardC(
@@ -14,7 +13,6 @@ val KB_PL_TYPESPLIT_V2_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("ę", color = MUTED),
                     left =
                         KeyC(
@@ -26,13 +24,11 @@ val KB_PL_TYPESPLIT_V2_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("t"),
                 ),
                 EMOJI_KEY_ITEM_ALT,
                 KeyItemC(
                     center = KeyC("i", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("y"),
                     left =
                         KeyC(
@@ -43,7 +39,6 @@ val KB_PL_TYPESPLIT_V2_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -56,7 +51,6 @@ val KB_PL_TYPESPLIT_V2_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("ą", color = MUTED),
                     left =
                         KeyC(
@@ -66,7 +60,6 @@ val KB_PL_TYPESPLIT_V2_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("f"),
                     left = KeyC("ś", color = MUTED),
                     top =
@@ -79,13 +72,11 @@ val KB_PL_TYPESPLIT_V2_MAIN =
                 SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("d", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("h"),
                     left = KeyC("j"),
                 ),
                 KeyItemC(
                     center = KeyC("k", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("l"),
                     top = KeyC("ł"),
                 ),
@@ -93,7 +84,6 @@ val KB_PL_TYPESPLIT_V2_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("z", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("ź", color = MUTED),
                     left =
                         KeyC(
@@ -105,7 +95,6 @@ val KB_PL_TYPESPLIT_V2_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("c", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -118,7 +107,6 @@ val KB_PL_TYPESPLIT_V2_MAIN =
                 SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("ń", color = MUTED),
                     left =
                         KeyC(
@@ -128,7 +116,6 @@ val KB_PL_TYPESPLIT_V2_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("m", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("?", color = MUTED),
                     left = KeyC("!", color = MUTED),
                     bottom = KeyC(":", color = MUTED),
@@ -149,7 +136,6 @@ val KB_PL_TYPESPLIT_V2_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("Ę", color = MUTED),
                     left =
                         KeyC(
@@ -161,13 +147,11 @@ val KB_PL_TYPESPLIT_V2_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("T"),
                 ),
                 EMOJI_KEY_ITEM_ALT,
                 KeyItemC(
                     center = KeyC("I", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("Y"),
                     left =
                         KeyC(
@@ -178,7 +162,6 @@ val KB_PL_TYPESPLIT_V2_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -191,7 +174,6 @@ val KB_PL_TYPESPLIT_V2_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("Ą", color = MUTED),
                     left =
                         KeyC(
@@ -201,7 +183,6 @@ val KB_PL_TYPESPLIT_V2_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("F"),
                     left = KeyC("Ś", color = MUTED),
                     top =
@@ -214,13 +195,11 @@ val KB_PL_TYPESPLIT_V2_SHIFTED =
                 SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("D", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("H"),
                     left = KeyC("J"),
                 ),
                 KeyItemC(
                     center = KeyC("K", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("L"),
                     top = KeyC("Ł"),
                 ),
@@ -228,7 +207,6 @@ val KB_PL_TYPESPLIT_V2_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("Z", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("Ź", color = MUTED),
                     left =
                         KeyC(
@@ -240,7 +218,6 @@ val KB_PL_TYPESPLIT_V2_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("C", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -253,7 +230,6 @@ val KB_PL_TYPESPLIT_V2_SHIFTED =
                 SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("Ń", color = MUTED),
                     left =
                         KeyC(
@@ -263,7 +239,6 @@ val KB_PL_TYPESPLIT_V2_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("M", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("?", color = MUTED),
                     left = KeyC("!", color = MUTED),
                     bottom = KeyC(":", color = MUTED),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/PTENThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/PTENThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_PT_EN_THUMBKEY_MAIN =
     KeyboardC(
@@ -16,12 +15,10 @@ val KB_PT_EN_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("w"),
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("g"),
                 ),
                 KeyItemC(
@@ -37,7 +34,6 @@ val KB_PT_EN_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("m"),
                 ),
                 KeyItemC(
@@ -90,7 +86,6 @@ val KB_PT_EN_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("d"),
                     topRight = KeyC("é", color = MUTED),
                     bottomRight = KeyC("ê", color = MUTED),
@@ -110,12 +105,10 @@ val KB_PT_EN_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("W"),
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("G"),
                 ),
                 KeyItemC(
@@ -131,7 +124,6 @@ val KB_PT_EN_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("M"),
                 ),
                 KeyItemC(
@@ -187,7 +179,6 @@ val KB_PT_EN_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("D"),
                     topRight = KeyC("É", color = MUTED),
                     bottomRight = KeyC("Ê", color = MUTED),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/PTThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/PTThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_PT_THUMBKEY_MAIN =
     KeyboardC(
@@ -16,12 +15,10 @@ val KB_PT_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("v"),
                 ),
                 KeyItemC(
                     center = KeyC("m", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("h"),
                 ),
                 KeyItemC(
@@ -37,7 +34,6 @@ val KB_PT_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("p"),
                 ),
                 KeyItemC(
@@ -74,7 +70,6 @@ val KB_PT_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("l"),
                 ),
                 KeyItemC(
@@ -111,12 +106,10 @@ val KB_PT_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("V"),
                 ),
                 KeyItemC(
                     center = KeyC("M", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("H"),
                 ),
                 KeyItemC(
@@ -132,7 +125,6 @@ val KB_PT_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("P"),
                 ),
                 KeyItemC(
@@ -172,7 +164,6 @@ val KB_PT_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("L"),
                 ),
                 KeyItemC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/PTTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/PTTypeSplit.kt
@@ -6,7 +6,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_PT_TYPESPLIT_MAIN =
     KeyboardC(
@@ -14,7 +13,6 @@ val KB_PT_TYPESPLIT_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("é", color = MUTED),
                     left = KeyC("ê", color = MUTED),
                     bottom = KeyC("q"),
@@ -22,7 +20,6 @@ val KB_PT_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -34,14 +31,12 @@ val KB_PT_TYPESPLIT_MAIN =
                 EMOJI_KEY_ITEM_ALT,
                 KeyItemC(
                     center = KeyC("i", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("í", color = MUTED),
                     left = KeyC("ú", color = MUTED),
                     bottom = KeyC("u"),
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("ô", color = MUTED),
                     left = KeyC("ó", color = MUTED),
                     bottom = KeyC("p"),
@@ -51,7 +46,6 @@ val KB_PT_TYPESPLIT_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("á", color = MUTED),
                     left = KeyC("â", color = MUTED),
                     bottom = KeyC("ã", color = MUTED),
@@ -63,7 +57,6 @@ val KB_PT_TYPESPLIT_MAIN =
                 SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("d", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("f"),
                     left =
                         KeyC(
@@ -74,7 +67,6 @@ val KB_PT_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("l", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -88,7 +80,6 @@ val KB_PT_TYPESPLIT_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("c", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("z"),
                     left =
                         KeyC(
@@ -100,7 +91,6 @@ val KB_PT_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("v", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("b"),
                 ),
                 SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
@@ -109,7 +99,6 @@ val KB_PT_TYPESPLIT_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("m", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("?", color = MUTED),
                     left = KeyC("!", color = MUTED),
                     bottom = KeyC(":", color = MUTED),
@@ -130,7 +119,6 @@ val KB_PT_TYPESPLIT_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("É", color = MUTED),
                     left = KeyC("Ê", color = MUTED),
                     bottom = KeyC("Q"),
@@ -138,7 +126,6 @@ val KB_PT_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -150,14 +137,12 @@ val KB_PT_TYPESPLIT_SHIFTED =
                 EMOJI_KEY_ITEM_ALT,
                 KeyItemC(
                     center = KeyC("I", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("Í", color = MUTED),
                     left = KeyC("Ú", color = MUTED),
                     bottom = KeyC("U"),
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("Ô", color = MUTED),
                     left = KeyC("Ó", color = MUTED),
                     bottom = KeyC("P"),
@@ -167,7 +152,6 @@ val KB_PT_TYPESPLIT_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("Á", color = MUTED),
                     left = KeyC("Â", color = MUTED),
                     bottom = KeyC("Ã", color = MUTED),
@@ -179,7 +163,6 @@ val KB_PT_TYPESPLIT_SHIFTED =
                 SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("D", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("F"),
                     left =
                         KeyC(
@@ -190,7 +173,6 @@ val KB_PT_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("L", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right =
                         KeyC(
                             display = null,
@@ -204,7 +186,6 @@ val KB_PT_TYPESPLIT_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("C", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("Z"),
                     left =
                         KeyC(
@@ -216,7 +197,6 @@ val KB_PT_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("V", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("B"),
                 ),
                 SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
@@ -225,7 +205,6 @@ val KB_PT_TYPESPLIT_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("M", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("?", color = MUTED),
                     left = KeyC("!", color = MUTED),
                     bottom = KeyC(":", color = MUTED),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/RUMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/RUMessagEase.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_RU_MESSAGEASE_MAIN =
     KeyboardC(
@@ -22,13 +21,11 @@ val KB_RU_MESSAGEASE_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("и", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("й"),
                     bottom = KeyC("к"),
                 ),
                 KeyItemC(
                     center = KeyC("т", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("ь"),
                 ),
                 EMOJI_KEY_ITEM,
@@ -36,7 +33,6 @@ val KB_RU_MESSAGEASE_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("в", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("б"),
                     right = KeyC("ы"),
                     bottom = KeyC("ъ"),
@@ -54,7 +50,6 @@ val KB_RU_MESSAGEASE_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("а", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("л"),
                     top =
                         KeyC(
@@ -88,7 +83,6 @@ val KB_RU_MESSAGEASE_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("н", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("ф"),
                 ),
                 BACKSPACE_KEY_ITEM,
@@ -111,13 +105,11 @@ val KB_RU_MESSAGEASE_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("И", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     top = KeyC("Й"),
                     bottom = KeyC("К"),
                 ),
                 KeyItemC(
                     center = KeyC("Т", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("Ь"),
                 ),
                 EMOJI_KEY_ITEM,
@@ -125,7 +117,6 @@ val KB_RU_MESSAGEASE_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("В", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     top = KeyC("Б"),
                     right = KeyC("Ы"),
                     bottom = KeyC("Ъ"),
@@ -143,7 +134,6 @@ val KB_RU_MESSAGEASE_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("А", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("Л"),
                     bottom =
                         KeyC(
@@ -180,7 +170,6 @@ val KB_RU_MESSAGEASE_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("Н", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("Ф"),
                 ),
                 BACKSPACE_KEY_ITEM,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/RUMessagEaseSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/RUMessagEaseSymbols.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_RU_MESSAGEASE_SYMBOLS_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/RUMessagEaseWriter.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/RUMessagEaseWriter.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_RU_MESSAGEASE_WRITER_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/RUThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/RUThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_RU_THUMBKEY_MAIN =
     KeyboardC(
@@ -22,12 +21,10 @@ val KB_RU_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("р", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("х"),
                 ),
                 KeyItemC(
                     center = KeyC("а", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("ж"),
                 ),
                 EMOJI_KEY_ITEM,
@@ -35,7 +32,6 @@ val KB_RU_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("н", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("м"),
                     bottom = KeyC("л"),
                 ),
@@ -52,7 +48,6 @@ val KB_RU_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("е", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("ф"),
                     top =
                         KeyC(
@@ -116,12 +111,10 @@ val KB_RU_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("Р", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("Х"),
                 ),
                 KeyItemC(
                     center = KeyC("А", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("Ж"),
                 ),
                 EMOJI_KEY_ITEM,
@@ -129,7 +122,6 @@ val KB_RU_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("Н", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("М"),
                     bottom = KeyC("Л"),
                 ),
@@ -146,7 +138,6 @@ val KB_RU_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("Е", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("Ф"),
                     top =
                         KeyC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/RUThumbKeySymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/RUThumbKeySymbols.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_RU_THUMBKEY_SYMBOLS_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/RUThumbKeyWriter.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/RUThumbKeyWriter.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_RU_THUMBKEY_WRITER_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/SKThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/SKThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_SK_THUMBKEY_V1_MAIN =
     KeyboardC(
@@ -16,19 +15,16 @@ val KB_SK_THUMBKEY_V1_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("w"),
                     topRight = KeyC("š"),
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("g"),
                     top = KeyC("ŕ"),
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("u"),
                     topRight = KeyC("ó"),
                     topLeft = KeyC("ú"),
@@ -39,7 +35,6 @@ val KB_SK_THUMBKEY_V1_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("m"),
                     top = KeyC("ň"),
                 ),
@@ -117,19 +112,16 @@ val KB_SK_THUMBKEY_V1_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("W"),
                     topRight = KeyC("Š"),
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("G"),
                     top = KeyC("Ŕ"),
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("U"),
                     topRight = KeyC("Ó"),
                     topLeft = KeyC("Ú"),
@@ -140,7 +132,6 @@ val KB_SK_THUMBKEY_V1_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("M"),
                     top = KeyC("Ň"),
                 ),
@@ -200,7 +191,6 @@ val KB_SK_THUMBKEY_V1_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     topLeft = KeyC("D"),
                     top = KeyC("É"),
                     right = KeyC("Ď"),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/SKThumbKeyV2.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/SKThumbKeyV2.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_SK_THUMBKEY_V2_MAIN =
     KeyboardC(
@@ -209,7 +208,6 @@ val KB_SK_THUMBKEY_V2_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     topLeft = KeyC("L"),
                     topRight = KeyC("Á"),
                     bottomRight = KeyC("Ä"),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/SKThumbKeyV3.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/SKThumbKeyV3.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_SK_THUMBKEY_V3_MAIN =
     KeyboardC(
@@ -16,17 +15,14 @@ val KB_SK_THUMBKEY_V3_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("w"),
                 ),
                 KeyItemC(
                     center = KeyC("v", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("g"),
                 ),
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("u"),
                 ),
                 EMOJI_KEY_ITEM,
@@ -34,7 +30,6 @@ val KB_SK_THUMBKEY_V3_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("m"),
                 ),
                 KeyItemC(
@@ -50,7 +45,6 @@ val KB_SK_THUMBKEY_V3_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("l"),
                     top =
                         KeyC(
@@ -70,7 +64,6 @@ val KB_SK_THUMBKEY_V3_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("c"),
                 ),
                 KeyItemC(
@@ -84,7 +77,6 @@ val KB_SK_THUMBKEY_V3_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("d"),
                 ),
                 BACKSPACE_KEY_ITEM,
@@ -102,17 +94,14 @@ val KB_SK_THUMBKEY_V3_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("W"),
                 ),
                 KeyItemC(
                     center = KeyC("V", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("G"),
                 ),
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("U"),
                 ),
                 EMOJI_KEY_ITEM,
@@ -120,7 +109,6 @@ val KB_SK_THUMBKEY_V3_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("M"),
                 ),
                 KeyItemC(
@@ -136,7 +124,6 @@ val KB_SK_THUMBKEY_V3_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("L"),
                     bottom =
                         KeyC(
@@ -159,7 +146,6 @@ val KB_SK_THUMBKEY_V3_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("C"),
                 ),
                 KeyItemC(
@@ -173,7 +159,6 @@ val KB_SK_THUMBKEY_V3_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("D"),
                 ),
                 BACKSPACE_KEY_ITEM,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/SLMessagEaseSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/SLMessagEaseSymbols.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_SL_MESSAGEASE_SYMBOLS_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/SVMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/SVMessagEase.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_SV_MESSAGEASE_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/SVThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/SVThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_SV_THUMBKEY_MAIN =
     KeyboardC(
@@ -21,12 +20,10 @@ val KB_SV_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("g"),
                 ),
                 KeyItemC(
                     center = KeyC("l", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("u"),
                 ),
                 EMOJI_KEY_ITEM,
@@ -34,7 +31,6 @@ val KB_SV_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("m"),
                     top = KeyC("w"),
                 ),
@@ -51,7 +47,6 @@ val KB_SV_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("o"),
                     top =
                         KeyC(
@@ -85,7 +80,6 @@ val KB_SV_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("v"),
                 ),
                 BACKSPACE_KEY_ITEM,
@@ -108,12 +102,10 @@ val KB_SV_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("G"),
                 ),
                 KeyItemC(
                     center = KeyC("L", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("U"),
                 ),
                 EMOJI_KEY_ITEM,
@@ -121,7 +113,6 @@ val KB_SV_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     right = KeyC("M"),
                     top = KeyC("W"),
                 ),
@@ -138,7 +129,6 @@ val KB_SV_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
                     left = KeyC("O"),
                     bottom =
                         KeyC(
@@ -175,7 +165,6 @@ val KB_SV_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("V"),
                 ),
                 BACKSPACE_KEY_ITEM,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/T9.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/T9.kt
@@ -10,7 +10,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_T9_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/TOKSitelenThumbkeyEmoji.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/TOKSitelenThumbkeyEmoji.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 // Frequencies from here: https://www.reddit.com/r/tokipona/comments/cxlpt5/frequency_list_of_toki_pona_words_from_tatoeba
 // Since these aren't vowels, no need to alternate, just do bottom right to left, bottom to top

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/TOKThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/TOKThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 // Frequencies from here: https://www.reddit.com/r/tokipona/comments/cxlpt5/frequency_list_of_toki_pona_words_from_tatoeba
 // Since these aren't vowels, no need to alternate, just do bottom right to left, bottom to top

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/TRThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/TRThumbKey.kt
@@ -9,7 +9,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_TR_THUMBKEY_MAIN =
     KeyboardC(
@@ -35,7 +34,6 @@ val KB_TR_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("l", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("n"),
                     bottomRight = KeyC(")", color = MUTED),
                     topLeft = KeyC("=", color = MUTED),
@@ -153,7 +151,6 @@ val KB_TR_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("L", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("N"),
                     bottomRight = KeyC(")", color = MUTED),
                     topLeft = KeyC("=", color = MUTED),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/UKBYRUThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/UKBYRUThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_UK_BY_RU_THUMBKEY_MAIN =
     KeyboardC(
@@ -22,12 +21,10 @@ val KB_UK_BY_RU_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("р", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("х"),
                 ),
                 KeyItemC(
                     center = KeyC("а", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("ы"),
                     bottomLeft = KeyC("ж"),
                 ),
@@ -36,7 +33,6 @@ val KB_UK_BY_RU_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("н", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("м"),
                 ),
                 KeyItemC(
@@ -116,12 +112,10 @@ val KB_UK_BY_RU_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("Р", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("Х"),
                 ),
                 KeyItemC(
                     center = KeyC("А", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("Ы"),
                     bottomLeft = KeyC("Ж"),
                 ),
@@ -130,7 +124,6 @@ val KB_UK_BY_RU_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("Н", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("М"),
                 ),
                 KeyItemC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/UKMessagEaseSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/UKMessagEaseSymbols.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_UK_MESSAGEASE_SYMBOLS_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/UKRUMessagEaseSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/UKRUMessagEaseSymbols.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_UK_RU_MESSAGEASE_SYMBOLS_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/UKThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/UKThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_UK_THUMBKEY_MAIN =
     KeyboardC(
@@ -16,17 +15,14 @@ val KB_UK_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("с", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("й"),
                 ),
                 KeyItemC(
                     center = KeyC("р", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("х"),
                 ),
                 KeyItemC(
                     center = KeyC("а", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("ж"),
                 ),
                 EMOJI_KEY_ITEM,
@@ -34,7 +30,6 @@ val KB_UK_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("н", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("м"),
                 ),
                 KeyItemC(
@@ -106,17 +101,14 @@ val KB_UK_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("С", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("Й"),
                 ),
                 KeyItemC(
                     center = KeyC("Р", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("Х"),
                 ),
                 KeyItemC(
                     center = KeyC("А", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomLeft = KeyC("Ж"),
                 ),
                 EMOJI_KEY_ITEM,
@@ -124,7 +116,6 @@ val KB_UK_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("Н", size = LARGE),
-                    swipeType = TWO_WAY_HORIZONTAL,
                     right = KeyC("М"),
                 ),
                 KeyItemC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/VNThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/VNThumbKey.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_VN_THUMBKEY_MAIN =
     KeyboardC(
@@ -16,7 +15,6 @@ val KB_VN_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("w"),
                     topLeft =
                         KeyC(
@@ -39,7 +37,6 @@ val KB_VN_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("g"),
                 ),
                 KeyItemC(
@@ -54,7 +51,6 @@ val KB_VN_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     right = KeyC("m"),
                     topRight = KeyC("m", displayText = ""),
                     bottomRight = KeyC("m", displayText = ""),
@@ -105,7 +101,6 @@ val KB_VN_THUMBKEY_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("c"),
                     topLeft =
                         KeyC(
@@ -156,7 +151,6 @@ val KB_VN_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     bottomRight = KeyC("W"),
                     topLeft =
                         KeyC(
@@ -179,7 +173,6 @@ val KB_VN_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
                     bottom = KeyC("G"),
                 ),
                 KeyItemC(
@@ -194,7 +187,6 @@ val KB_VN_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
-                    swipeType = EIGHT_WAY,
                     right = KeyC("M"),
                     topRight = KeyC("M", displayText = ""),
                     bottomRight = KeyC("M", displayText = ""),
@@ -248,7 +240,6 @@ val KB_VN_THUMBKEY_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topRight = KeyC("C"),
                     topLeft =
                         KeyC(

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
@@ -60,7 +60,6 @@ import com.dessalines.thumbkey.utils.KeyboardDefinitionSettings
 import com.dessalines.thumbkey.utils.Selection
 import com.dessalines.thumbkey.utils.SlideType
 import com.dessalines.thumbkey.utils.SwipeDirection
-import com.dessalines.thumbkey.utils.SwipeNWay
 import com.dessalines.thumbkey.utils.buildTapActions
 import com.dessalines.thumbkey.utils.circularDirection
 import com.dessalines.thumbkey.utils.colorVariantToColor
@@ -464,23 +463,31 @@ fun KeyboardKey(
                             }
 
                             if (action == null && dragReturnEnabled && maxOffsetBigEnough && finalOffsetSmallEnough) {
-                                val swipeDirection =
-                                    swipeDirection(maxOffset.x, maxOffset.y, minSwipeLength, key.swipeType)
-                                action = key.getSwipe(swipeDirection)?.swipeReturnAction
-                                    ?: oppositeCaseKey?.getSwipe(swipeDirection)?.action
+                                action =
+                                    key
+                                        .getSwipe(
+                                            swipeDirection(key, maxOffset.x, maxOffset.y, minSwipeLength),
+                                        )?.swipeReturnAction
+
+                                action =
+                                    action ?: oppositeCaseKey
+                                        ?.getSwipe(
+                                            swipeDirection(oppositeCaseKey, maxOffset.x, maxOffset.y, minSwipeLength),
+                                        )?.action
                             }
 
                             if (action == null && (!maxOffsetBigEnough || !finalOffsetSmallEnough)) {
-                                val swipeDirection =
-                                    swipeDirection(
-                                        offsetX,
-                                        offsetY,
-                                        minSwipeLength,
-                                        if (ghostKey == null) key.swipeType else SwipeNWay.EIGHT_WAY,
-                                    )
-                                action = key.getSwipe(swipeDirection)?.action ?: (
-                                    ghostKey?.getSwipe(swipeDirection)?.action
-                                )
+                                action =
+                                    key
+                                        .getSwipe(
+                                            swipeDirection(key, offsetX, offsetY, minSwipeLength),
+                                        )?.action
+
+                                action =
+                                    action ?: ghostKey
+                                        ?.getSwipe(
+                                            swipeDirection(ghostKey, offsetX, offsetY, minSwipeLength),
+                                        )?.action
                             }
 
                             if (action == null) {

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
@@ -1,5 +1,6 @@
 package com.dessalines.thumbkey.utils
 
+import android.graphics.PointF
 import android.view.KeyEvent
 import androidx.annotation.StringRes
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -50,7 +51,6 @@ data class KeyItemC(
     val nextTapActions: List<KeyAction>? = null,
     val widthMultiplier: Int = 1,
     val backgroundColor: ColorVariant = ColorVariant.SURFACE,
-    val swipeType: SwipeNWay = SwipeNWay.EIGHT_WAY,
     val slideType: SlideType = SlideType.NONE,
     val longPress: KeyAction? = null,
 ) {
@@ -208,6 +208,18 @@ enum class SwipeDirection {
     BOTTOM_LEFT,
 }
 
+fun SwipeDirection.vector() =
+    when (this) {
+        SwipeDirection.LEFT -> PointF(-1f, 0f)
+        SwipeDirection.TOP_LEFT -> PointF(-1f, -1f)
+        SwipeDirection.TOP -> PointF(0f, -1f)
+        SwipeDirection.TOP_RIGHT -> PointF(+1f, -1f)
+        SwipeDirection.RIGHT -> PointF(+1f, 0f)
+        SwipeDirection.BOTTOM_RIGHT -> PointF(+1f, +1f)
+        SwipeDirection.BOTTOM -> PointF(0f, +1f)
+        SwipeDirection.BOTTOM_LEFT -> PointF(-1f, +1f)
+    }
+
 enum class ColorVariant {
     PRIMARY,
     SECONDARY,
@@ -252,14 +264,6 @@ enum class KeyboardPosition(
     Center(R.string.center),
     Right(R.string.right),
     Left(R.string.left),
-}
-
-enum class SwipeNWay {
-    EIGHT_WAY,
-    FOUR_WAY_CROSS,
-    FOUR_WAY_DIAGONAL,
-    TWO_WAY_VERTICAL,
-    TWO_WAY_HORIZONTAL,
 }
 
 enum class SlideType {

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -46,13 +46,14 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.text.NumberFormat
+import kotlin.enums.enumEntries
 import kotlin.math.PI
 import kotlin.math.abs
 import kotlin.math.atan2
+import kotlin.math.hypot
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.pow
-import kotlin.math.sqrt
 
 const val TAG = "com.thumbkey"
 
@@ -256,69 +257,33 @@ fun keyboardPositionToAlignment(position: KeyboardPosition): Alignment =
         KeyboardPosition.Left -> Alignment.BottomStart
     }
 
-/**
- * If this doesn't meet the minimum swipe length, it returns null
- */
 fun swipeDirection(
+    key: KeyItemC,
     x: Float,
     y: Float,
     minSwipeLength: Int,
-    swipeType: SwipeNWay = SwipeNWay.EIGHT_WAY,
 ): SwipeDirection? {
-    val xD = x.toDouble()
-    val yD = y.toDouble()
+    val swipeLength = hypot(x, y)
+    if (swipeLength < minSwipeLength) return null
 
-    val swipeLength = sqrt(xD.pow(2) + yD.pow(2))
+    var bestDir: SwipeDirection? = null
+    var bestCosine: Float = 0.0f
 
-    if (swipeLength > minSwipeLength) {
-        val angleDir = (atan2(xD, yD) / Math.PI * 180)
-        val angle =
-            if (angleDir < 0) {
-                360 + angleDir
-            } else {
-                angleDir
-            }
+    for (dir in enumEntries<SwipeDirection>()) {
+        if (key.getSwipe(dir) == null) continue
 
-        when (swipeType) {
-            // 0 degrees = down, increasing counter-clockwise
-            SwipeNWay.EIGHT_WAY -> return when (angle) {
-                in 22.5..67.5 -> SwipeDirection.BOTTOM_RIGHT
-                in 67.5..112.5 -> SwipeDirection.RIGHT
-                in 112.5..157.5 -> SwipeDirection.TOP_RIGHT
-                in 157.5..202.5 -> SwipeDirection.TOP
-                in 202.5..247.5 -> SwipeDirection.TOP_LEFT
-                in 247.5..292.5 -> SwipeDirection.LEFT
-                in 292.5..337.5 -> SwipeDirection.BOTTOM_LEFT
-                else -> SwipeDirection.BOTTOM
-            }
+        var dirVec = dir.vector()
+        val dotProduct = dirVec.x * x + dirVec.y * y
+        val cosine = dotProduct / (swipeLength * hypot(dirVec.x, dirVec.y))
+        if (cosine <= 0) continue
 
-            SwipeNWay.FOUR_WAY_CROSS -> return when (angle) {
-                in 45.0..135.0 -> SwipeDirection.RIGHT
-                in 135.0..225.0 -> SwipeDirection.TOP
-                in 225.0..315.0 -> SwipeDirection.LEFT
-                else -> SwipeDirection.BOTTOM
-            }
-
-            SwipeNWay.FOUR_WAY_DIAGONAL -> return when (angle) {
-                in 0.0..90.0 -> SwipeDirection.BOTTOM_RIGHT
-                in 90.0..180.0 -> SwipeDirection.TOP_RIGHT
-                in 180.0..270.0 -> SwipeDirection.TOP_LEFT
-                else -> SwipeDirection.BOTTOM_LEFT
-            }
-
-            SwipeNWay.TWO_WAY_HORIZONTAL -> return when (angle) {
-                in 0.0..180.0 -> SwipeDirection.RIGHT
-                else -> SwipeDirection.LEFT
-            }
-
-            SwipeNWay.TWO_WAY_VERTICAL -> return when (angle) {
-                in 90.0..270.0 -> SwipeDirection.TOP
-                else -> SwipeDirection.BOTTOM
-            }
+        if (cosine > bestCosine) {
+            bestDir = dir
+            bestCosine = cosine
         }
-    } else {
-        return null
     }
+
+    return bestDir
 }
 
 fun performKeyAction(


### PR DESCRIPTION
Using the information of what swipes are available for a key, we can calculate swipe zones without relying on explicit `SwipeNWay`.

The [algorithm] assigns each `SwipeDirection` a "precise direction" vector - for example `(+1, -1)` for `TOP_RIGHT`. It then uses a [dot product] to calculate a cosine of an angle between the swipe and this precise direction. The biggest cosine (that is, the smallest angle) that has an action attached wins, but only if the cosine is positive (that is, if the angle is in the ±90 degree range).

This new behavior differs from the old one in a few notable ways, though:

1. It is no longer possible to reduce the swipe zone size by utilizing `SwipeNWay.EIGHT_WAY`, but then only setting the four cardinal directions. This behavior was fairly obscure, and AFAIK no layout was using it intentionally.

2. Some swipe zones are now bigger than before. Notably, if `TOP`, `BOTTOM`, and `LEFT` all have actions attached to them, then swiping right would trigger the closest of the `TOP` and `BOTTOM` actions - which wasn't happening with `SwipeNWay.FOUR_WAY_CROSS`. On the other hand, the `TWO_WAY_*` values do have this behaviour - swiping right on a `TWO_WAY_VERTICAL` would trigger one of the actions.

I'm still not sure if I like point 2 so far. It also looks like it would break the "ghost keys" feature. Point 1, I am okay with.

The end goal of this PR is to eliminate the need to set `swipeType` in keyboard definitions, in all or most cases. A more conservative approach to that would be to just calculate `KeyItemC.swipeType` in the constructor based on which swipes are set. I might just end up doing that instead, in a separate PR.

[algorithm]: https://github.com/iliazeus/thumb-key/blob/1631dd4b5cc16d57d73c599f474648a740ca09a8/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt#L260

[dot product]: https://en.wikipedia.org/wiki/Dot_product