### PR TITLE
Add more actions for changing keyboard position

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/ComposeKeyboardView.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ComposeKeyboardView.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.lifecycleScope
 import com.dessalines.thumbkey.db.AppSettingsRepository
 import com.dessalines.thumbkey.ui.components.keyboard.KeyboardScreen
 import com.dessalines.thumbkey.ui.theme.ThumbkeyTheme
+import com.dessalines.thumbkey.utils.KeyboardPosition
 import com.dessalines.thumbkey.utils.keyboardLayoutsSetFromDbIndexString
 import kotlinx.coroutines.launch
 
@@ -59,12 +60,11 @@ class ComposeKeyboardView(
                             }
                         }
                     },
-                    onSwitchPosition = {
+                    onChangePosition = { f ->
                         ctx.lifecycleScope.launch {
-                            // Cycle to the next position
                             val state = settingsState.value
                             state?.let { s ->
-                                val nextPosition = (s.position + 1).mod(3)
+                                val nextPosition = f(KeyboardPosition.entries[s.position]).ordinal
                                 val s2 = s.copy(position = nextPosition)
                                 settingsRepo.update(s2)
                             }

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/CommonKeys.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/CommonKeys.kt
@@ -87,7 +87,7 @@ fun specialActionKeyItem(center: KeyC) =
         right =
             KeyC(
                 display = KeyDisplay.IconDisplay(Icons.Outlined.LinearScale),
-                action = SwitchPosition,
+                action = MoveKeyboard.CycleRight,
                 color = MUTED,
             ),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/T9.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/T9.kt
@@ -275,7 +275,7 @@ val KB_T9_MAIN =
                     bottomRight =
                         KeyC(
                             display = KeyDisplay.TextDisplay("↔"),
-                            action = SwitchPosition,
+                            action = MoveKeyboard.CycleRight,
                             color = MUTED,
                         ),
                     backgroundColor = SURFACE_VARIANT,
@@ -554,7 +554,7 @@ val KB_T9_SHIFTED =
                     bottomRight =
                         KeyC(
                             display = KeyDisplay.TextDisplay("↔"),
-                            action = SwitchPosition,
+                            action = MoveKeyboard.CycleRight,
                             color = MUTED,
                         ),
                     backgroundColor = SURFACE_VARIANT,

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
@@ -57,6 +57,7 @@ import com.dessalines.thumbkey.utils.KeyC
 import com.dessalines.thumbkey.utils.KeyDisplay
 import com.dessalines.thumbkey.utils.KeyItemC
 import com.dessalines.thumbkey.utils.KeyboardDefinitionSettings
+import com.dessalines.thumbkey.utils.KeyboardPosition
 import com.dessalines.thumbkey.utils.Selection
 import com.dessalines.thumbkey.utils.SlideType
 import com.dessalines.thumbkey.utils.SwipeDirection
@@ -118,7 +119,7 @@ fun KeyboardKey(
     onToggleCapsLock: () -> Unit,
     onAutoCapitalize: (enable: Boolean) -> Unit,
     onSwitchLanguage: () -> Unit,
-    onSwitchPosition: () -> Unit,
+    onChangePosition: ((old: KeyboardPosition) -> KeyboardPosition) -> Unit,
     oppositeCaseKey: KeyItemC? = null,
     numericKey: KeyItemC? = null,
     dragReturnEnabled: Boolean,
@@ -235,7 +236,7 @@ fun KeyboardKey(
                         onToggleCapsLock = onToggleCapsLock,
                         onAutoCapitalize = onAutoCapitalize,
                         onSwitchLanguage = onSwitchLanguage,
-                        onSwitchPosition = onSwitchPosition,
+                        onChangePosition = onChangePosition,
                     )
                     doneKeyAction(scope, action, isDragged, releasedKey, animationHelperSpeed)
                 },
@@ -252,7 +253,7 @@ fun KeyboardKey(
                             onToggleCapsLock = onToggleCapsLock,
                             onAutoCapitalize = onAutoCapitalize,
                             onSwitchLanguage = onSwitchLanguage,
-                            onSwitchPosition = onSwitchPosition,
+                            onChangePosition = onChangePosition,
                         )
                         doneKeyAction(scope, action, isDragged, releasedKey, animationHelperSpeed)
                         if (vibrateOnTap) {
@@ -501,7 +502,7 @@ fun KeyboardKey(
                                 onToggleCapsLock = onToggleCapsLock,
                                 onAutoCapitalize = onAutoCapitalize,
                                 onSwitchLanguage = onSwitchLanguage,
-                                onSwitchPosition = onSwitchPosition,
+                                onChangePosition = onChangePosition,
                             )
                             doneKeyAction(
                                 scope,
@@ -533,7 +534,7 @@ fun KeyboardKey(
                                         onToggleCapsLock = onToggleCapsLock,
                                         onAutoCapitalize = onAutoCapitalize,
                                         onSwitchLanguage = onSwitchLanguage,
-                                        onSwitchPosition = onSwitchPosition,
+                                        onChangePosition = onChangePosition,
                                         onToggleEmojiMode = onToggleEmojiMode,
                                     )
                                 }

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
@@ -78,7 +78,7 @@ import kotlin.time.TimeMark
 fun KeyboardScreen(
     settings: AppSettings?,
     onSwitchLanguage: () -> Unit,
-    onSwitchPosition: () -> Unit,
+    onChangePosition: ((old: KeyboardPosition) -> KeyboardPosition) -> Unit,
 ) {
     val ctx = LocalContext.current as IMEService
 
@@ -310,7 +310,7 @@ fun KeyboardScreen(
                                     }
                                 },
                                 onSwitchLanguage = onSwitchLanguage,
-                                onSwitchPosition = onSwitchPosition,
+                                onChangePosition = onChangePosition,
                                 dragReturnEnabled = dragReturnEnabled,
                                 circularDragEnabled = circularDragEnabled,
                                 clockwiseDragAction = clockwiseDragAction,
@@ -445,7 +445,7 @@ fun KeyboardScreen(
                                         }
                                     },
                                     onSwitchLanguage = onSwitchLanguage,
-                                    onSwitchPosition = onSwitchPosition,
+                                    onChangePosition = onChangePosition,
                                     oppositeCaseKey =
                                         when (mode) {
                                             KeyboardMode.MAIN -> keyboardDefinition.modes.shifted

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
@@ -150,6 +150,20 @@ sealed class KeyAction {
         val text: String,
     ) : KeyAction()
 
+    sealed class MoveKeyboard : KeyAction() {
+        class ToPosition(
+            val position: KeyboardPosition,
+        ) : KeyAction()
+
+        data object Left : KeyAction()
+
+        data object Right : KeyAction()
+
+        data object CycleLeft : KeyAction()
+
+        data object CycleRight : KeyAction()
+    }
+
     data object DeleteWordBeforeCursor : KeyAction()
 
     data object DeleteWordAfterCursor : KeyAction()
@@ -173,8 +187,6 @@ sealed class KeyAction {
     data object Redo : KeyAction()
 
     data object SwitchLanguage : KeyAction()
-
-    data object SwitchPosition : KeyAction()
 
     data object SwitchIME : KeyAction()
 

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -332,7 +332,7 @@ fun performKeyAction(
     onToggleCapsLock: () -> Unit,
     onAutoCapitalize: (enable: Boolean) -> Unit,
     onSwitchLanguage: () -> Unit,
-    onSwitchPosition: () -> Unit,
+    onChangePosition: ((old: KeyboardPosition) -> KeyboardPosition) -> Unit,
 ) {
     when (action) {
         is KeyAction.CommitText -> {
@@ -945,8 +945,39 @@ fun performKeyAction(
             )
         }
 
+        is KeyAction.MoveKeyboard.ToPosition -> onChangePosition { action.position }
+        KeyAction.MoveKeyboard.Left ->
+            onChangePosition {
+                when (it) {
+                    KeyboardPosition.Right -> KeyboardPosition.Center
+                    else -> KeyboardPosition.Left
+                }
+            }
+        KeyAction.MoveKeyboard.Right ->
+            onChangePosition {
+                when (it) {
+                    KeyboardPosition.Left -> KeyboardPosition.Center
+                    else -> KeyboardPosition.Right
+                }
+            }
+        KeyAction.MoveKeyboard.CycleLeft ->
+            onChangePosition {
+                when (it) {
+                    KeyboardPosition.Right -> KeyboardPosition.Center
+                    KeyboardPosition.Center -> KeyboardPosition.Left
+                    KeyboardPosition.Left -> KeyboardPosition.Right
+                }
+            }
+        KeyAction.MoveKeyboard.CycleRight ->
+            onChangePosition {
+                when (it) {
+                    KeyboardPosition.Left -> KeyboardPosition.Center
+                    KeyboardPosition.Center -> KeyboardPosition.Right
+                    KeyboardPosition.Right -> KeyboardPosition.Left
+                }
+            }
+
         KeyAction.SwitchLanguage -> onSwitchLanguage()
-        KeyAction.SwitchPosition -> onSwitchPosition()
         KeyAction.SwitchIME -> {
             val imeManager =
                 ime.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager


### PR DESCRIPTION
Add actions to move keyboard to a specified position, or in a specified direction.

The existing layouts only use the `CycleRight` option, but the extra ones are handy for custom layouts. For example, my fork has two separate keys for moving the keyboard right and left respectively, because I switch hands often.