### PR TITLE
add english nederlands typesplit layout

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENNLTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENNLTypeSplit.kt
@@ -36,7 +36,7 @@ val KB_EN_NL_TYPESPLIT_MAIN =
                 KeyItemC(
                     center = KeyC("l", size = LARGE),
                     bottom = KeyC("j"),
-                    bottomLeft = KeyC("f")
+                    bottomLeft = KeyC("f"),
                 ),
             ),
             listOf(
@@ -60,7 +60,7 @@ val KB_EN_NL_TYPESPLIT_MAIN =
                     right = KeyC("m"),
                     bottom = KeyC("p"),
                     topRight = KeyC("b"),
-                    bottomRight = KeyC("w")
+                    bottomRight = KeyC("w"),
                 ),
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
@@ -129,7 +129,7 @@ val KB_EN_NL_TYPESPLIT_SHIFTED =
                 KeyItemC(
                     center = KeyC("L", size = LARGE),
                     bottom = KeyC("J"),
-                    bottomLeft = KeyC("F")
+                    bottomLeft = KeyC("F"),
                 ),
             ),
             listOf(
@@ -153,7 +153,7 @@ val KB_EN_NL_TYPESPLIT_SHIFTED =
                     right = KeyC("M"),
                     bottom = KeyC("P"),
                     topRight = KeyC("B"),
-                    bottomRight = KeyC("W")
+                    bottomRight = KeyC("W"),
                 ),
                 KeyItemC(
                     center = KeyC("N", size = LARGE),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENNLTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENNLTypeSplit.kt
@@ -1,0 +1,204 @@
+@file:Suppress("ktlint:standard:no-wildcard-imports")
+
+package com.dessalines.thumbkey.keyboards
+
+import com.dessalines.thumbkey.utils.*
+import com.dessalines.thumbkey.utils.ColorVariant.*
+import com.dessalines.thumbkey.utils.FontSizeVariant.*
+import com.dessalines.thumbkey.utils.KeyAction.*
+import com.dessalines.thumbkey.utils.SwipeNWay.*
+
+val KB_EN_NL_TYPESPLIT_MAIN =
+    KeyboardC(
+        listOf(
+            listOf(
+                KeyItemC(
+                    center = KeyC("u", size = LARGE),
+                    bottomLeft = KeyC("ú", color = MUTED),
+                    left = KeyC("ü", color = MUTED),
+                    topLeft = KeyC("ù", color = MUTED),
+                    bottom = KeyC(";", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("o", size = LARGE),
+                    bottomRight = KeyC("ò", color = MUTED),
+                    right = KeyC("ö", color = MUTED),
+                    topRight = KeyC("ó", color = MUTED),
+                    bottom = KeyC(":", color = MUTED),
+                ),
+                EMOJI_KEY_ITEM_ALT,
+                KeyItemC(
+                    center = KeyC("s", size = LARGE),
+                    swipeType = TWO_WAY_VERTICAL,
+                    bottom = KeyC("c"),
+                ),
+                KeyItemC(
+                    center = KeyC("l", size = LARGE),
+                    bottom = KeyC("j"),
+                    bottomLeft = KeyC("f")
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("i", size = LARGE),
+                    bottomLeft = KeyC("í", color = MUTED),
+                    right = KeyC("y"),
+                    topLeft = KeyC("ì", color = MUTED),
+                    left = KeyC("ï", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("e", size = LARGE),
+                    bottomRight = KeyC("è", color = MUTED),
+                    topRight = KeyC("é", color = MUTED),
+                    right = KeyC("ë", color = MUTED),
+                ),
+                SPACEBAR_ALL_DIRECTIONS,
+                KeyItemC(
+                    center = KeyC("t", size = LARGE),
+                    top = KeyC("h"),
+                    right = KeyC("m"),
+                    bottom = KeyC("p"),
+                    topRight = KeyC("b"),
+                    bottomRight = KeyC("w")
+                ),
+                KeyItemC(
+                    center = KeyC("n", size = LARGE),
+                    left = KeyC("g"),
+                    top = KeyC("z"),
+                    bottomLeft = KeyC("v"),
+                    topLeft = KeyC("k"),
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("q", size = LARGE),
+                    swipeType = TWO_WAY_VERTICAL,
+                    top = KeyC("!", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("a", size = LARGE),
+                    top = KeyC("?", color = MUTED),
+                    bottomRight = KeyC("à", color = MUTED),
+                    right = KeyC("ä", color = MUTED),
+                    topRight = KeyC("á", color = MUTED),
+                ),
+                SPACEBAR_ALL_SYMBOLS,
+                KeyItemC(
+                    center = KeyC("r", size = LARGE),
+                    swipeType = TWO_WAY_VERTICAL,
+                    top = KeyC("x"),
+                ),
+                KeyItemC(
+                    center = KeyC("d", size = LARGE),
+                ),
+            ),
+            listOf(
+                NUMERIC_KEY_ITEM_ALT,
+                BACKSPACE_TYPESPLIT_KEY_ITEM,
+                RETURN_KEY_ITEM,
+            ),
+        ),
+    )
+
+val KB_EN_NL_TYPESPLIT_SHIFTED =
+    KeyboardC(
+        listOf(
+            listOf(
+                KeyItemC(
+                    center = KeyC("U", size = LARGE),
+                    bottomLeft = KeyC("Ú", color = MUTED),
+                    left = KeyC("Ü", color = MUTED),
+                    topLeft = KeyC("Ù", color = MUTED),
+                    bottom = KeyC(";", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("O", size = LARGE),
+                    bottomRight = KeyC("Ò", color = MUTED),
+                    right = KeyC("Ö", color = MUTED),
+                    topRight = KeyC("Ó", color = MUTED),
+                    bottom = KeyC(":", color = MUTED),
+                ),
+                EMOJI_KEY_ITEM_ALT,
+                KeyItemC(
+                    center = KeyC("S", size = LARGE),
+                    swipeType = TWO_WAY_VERTICAL,
+                    bottom = KeyC("C"),
+                ),
+                KeyItemC(
+                    center = KeyC("L", size = LARGE),
+                    bottom = KeyC("J"),
+                    bottomLeft = KeyC("F")
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("I", size = LARGE),
+                    bottomLeft = KeyC("Í", color = MUTED),
+                    right = KeyC("Y"),
+                    topLeft = KeyC("Ì", color = MUTED),
+                    left = KeyC("Ï", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("E", size = LARGE),
+                    bottomRight = KeyC("È", color = MUTED),
+                    topRight = KeyC("É", color = MUTED),
+                    right = KeyC("Ë", color = MUTED),
+                ),
+                SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("T", size = LARGE),
+                    top = KeyC("H"),
+                    right = KeyC("M"),
+                    bottom = KeyC("P"),
+                    topRight = KeyC("B"),
+                    bottomRight = KeyC("W")
+                ),
+                KeyItemC(
+                    center = KeyC("N", size = LARGE),
+                    left = KeyC("G"),
+                    top = KeyC("Z"),
+                    bottomLeft = KeyC("V"),
+                    topLeft = KeyC("K"),
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("Q", size = LARGE),
+                    swipeType = TWO_WAY_VERTICAL,
+                    top = KeyC("!", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("A", size = LARGE),
+                    top = KeyC("?", color = MUTED),
+                    bottomRight = KeyC("À", color = MUTED),
+                    right = KeyC("Ä", color = MUTED),
+                    topRight = KeyC("Á", color = MUTED),
+                ),
+                SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("R", size = LARGE),
+                    swipeType = TWO_WAY_VERTICAL,
+                    top = KeyC("X"),
+                ),
+                KeyItemC(
+                    center = KeyC("D", size = LARGE),
+                ),
+            ),
+            listOf(
+                NUMERIC_KEY_ITEM_ALT,
+                BACKSPACE_TYPESPLIT_SHIFTED_KEY_ITEM,
+                RETURN_KEY_ITEM,
+            ),
+        ),
+    )
+
+val KB_EN_NL_TYPESPLIT: KeyboardDefinition =
+    KeyboardDefinition(
+        title = "english nederlands type-split",
+        modes =
+            KeyboardDefinitionModes(
+                main = KB_EN_NL_TYPESPLIT_MAIN,
+                shifted = KB_EN_NL_TYPESPLIT_SHIFTED,
+                numeric = TYPESPLIT_NUMERIC_KEYBOARD,
+            ),
+    )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENNLTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENNLTypeSplit.kt
@@ -31,7 +31,7 @@ val KB_EN_NL_TYPESPLIT_MAIN =
                     center = KeyC("s", size = LARGE),
                     swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("c"),
-                    left = KeyC("ç"),
+                    left = KeyC("ç", color = MUTED),
                 ),
                 KeyItemC(
                     center = KeyC("l", size = LARGE),
@@ -124,7 +124,7 @@ val KB_EN_NL_TYPESPLIT_SHIFTED =
                     center = KeyC("S", size = LARGE),
                     swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("C"),
-                    left = KeyC("Ç"),
+                    left = KeyC("Ç", color = MUTED),
                 ),
                 KeyItemC(
                     center = KeyC("L", size = LARGE),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENNLTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENNLTypeSplit.kt
@@ -124,7 +124,7 @@ val KB_EN_NL_TYPESPLIT_SHIFTED =
                     center = KeyC("S", size = LARGE),
                     swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("C"),
-                    left = KeyC("'Ç"),
+                    left = KeyC("Ç"),
                 ),
                 KeyItemC(
                     center = KeyC("L", size = LARGE),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENNLTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENNLTypeSplit.kt
@@ -29,8 +29,9 @@ val KB_EN_NL_TYPESPLIT_MAIN =
                 EMOJI_KEY_ITEM_ALT,
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
+                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("c"),
+                    left = KeyC("ç"),
                 ),
                 KeyItemC(
                     center = KeyC("l", size = LARGE),
@@ -121,8 +122,9 @@ val KB_EN_NL_TYPESPLIT_SHIFTED =
                 EMOJI_KEY_ITEM_ALT,
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
-                    swipeType = TWO_WAY_VERTICAL,
+                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("C"),
+                    left = KeyC("'Ç"),
                 ),
                 KeyItemC(
                     center = KeyC("L", size = LARGE),

--- a/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
@@ -42,6 +42,7 @@ import com.dessalines.thumbkey.keyboards.KB_EN_MESSAGEASE_TWO_HANDS
 import com.dessalines.thumbkey.keyboards.KB_EN_MESSAGEASE_WRITER
 import com.dessalines.thumbkey.keyboards.KB_EN_MI_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_EN_MI_THUMBKEY_SYMBOLS
+import com.dessalines.thumbkey.keyboards.KB_EN_NL_TYPESPLIT
 import com.dessalines.thumbkey.keyboards.KB_EN_NO_MESSAGEASE_SYMBOLS
 import com.dessalines.thumbkey.keyboards.KB_EN_NO_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_EN_NO_TYPESPLIT
@@ -316,4 +317,5 @@ enum class KeyboardLayout(
     PTENThumbKey(KB_PT_EN_THUMBKEY),
     ENThumbKeyProgrammingExpanded(KB_EN_THUMBKEY_PROGRAMMING_EXPANDED),
     HIThumbKey(KB_HI_THUMBKEY),
+    ENNLTypeSplit(KB_EN_NL_TYPESPLIT),
 }


### PR DESCRIPTION
A layout inspired by `nederlands type-split`, designed to work well for both Dutch and English. I've really been enjoying typing with thumbkey, but I couldn't find a layout that fits my exact needs. So, I decided to try creating one myself and I'm quite pleased with the result. This layout was optimized with code in order the find the highest alternation between thumbs, and the lowest overall thumb travel distance. Thank you so much for creating this amazing app!
![Screenshot_2](https://github.com/user-attachments/assets/7d490b86-be9f-48d2-a814-7124460ebf67)
