### PR TITLE
Keep spacebar consistent when shifted

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/NLTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/NLTypeSplit.kt
@@ -152,7 +152,7 @@ val KB_NL_TYPESPLIT_SHIFTED =
                     bottom = KeyC("C"),
                     right = KeyC("Ë", color = MUTED),
                 ),
-                SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM,
+                SPACEBAR_ALL_DIRECTIONS,
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
                     swipeType = FOUR_WAY_CROSS,
@@ -180,7 +180,7 @@ val KB_NL_TYPESPLIT_SHIFTED =
                     right = KeyC("Ä", color = MUTED),
                     topRight = KeyC("Á", color = MUTED),
                 ),
-                SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
+                SPACEBAR_ALL_SYMBOLS,
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
                     swipeType = TWO_WAY_VERTICAL,


### PR DESCRIPTION
I noticed one minor thing I forgot last time around (#1107): the spacebar in shift mode differs from unshifted, which was confusing me. Fixed that here