### PR TITLE
Swipe-returning on a ghost key will now trigger the action of the ghost key

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericFrench.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericFrench.kt
@@ -75,7 +75,7 @@ val FRENCH_NUMERIC_KEYBOARD =
                 KeyItemC(
                     center = KeyC("8", size = LARGE),
                     topLeft = KeyC("\""),
-                    topRight = KeyC("'"),
+                    topRight = KeyC("'", swipeReturnAction = CommitText("\"")),
                     bottomRight = KeyC("-"),
                     bottom = KeyC("."),
                     bottomLeft = KeyC("*"),

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
@@ -470,9 +470,15 @@ fun KeyboardKey(
                                         ) ?: (
                                             if (dragReturnEnabled) {
                                                 val swipeDirection =
-                                                    swipeDirection(maxOffset.x, maxOffset.y, minSwipeLength, key.swipeType)
+                                                    swipeDirection(
+                                                        maxOffset.x,
+                                                        maxOffset.y,
+                                                        minSwipeLength,
+                                                        if (ghostKey == null) key.swipeType else SwipeNWay.EIGHT_WAY,
+                                                    )
                                                 key.getSwipe(swipeDirection)?.swipeReturnAction
                                                     ?: oppositeCaseKey?.getSwipe(swipeDirection)?.action
+                                                    ?: ghostKey?.getSwipe(swipeDirection)?.swipeReturnAction
                                             } else {
                                                 null
                                             }


### PR DESCRIPTION
Fixes #1157 

The Swipe-return action of a ghost key will now be properly triggered. This only works, of course, if there is no swipe-return action on the actual key.

I have included a change to the French Numeric layout to produce a "-mark when swipe-returning on ', so this will now be produced if swipe-returning on the ghost-'-key. This layout change would have otherwise been submitted by @Raghnarok after this fix was merged.
