### PR TITLE
Add some swipeReturn actions to the french ThumbKey v2 layout

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FRThumbKeyV2.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FRThumbKeyV2.kt
@@ -16,8 +16,8 @@ val KB_FR_THUMBKEY_V2_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("l", size = LARGE),
-                    topLeft = KeyC("«", color = MUTED),
-                    top = KeyC("»", color = MUTED),
+                    topLeft = KeyC("«", color = MUTED, swipeReturnAction=CommitText("{")),
+                    top = KeyC("»", color = MUTED, swipeReturnAction=CommitText("}")),
                     topRight = KeyC("'", color = MUTED),
                     right = KeyC("^", color = MUTED),
                     bottomRight = KeyC("q"),
@@ -35,6 +35,7 @@ val KB_FR_THUMBKEY_V2_MAIN =
                     right = KeyC("î", color = MUTED),
                     bottomRight = KeyC("k"),
                     bottomLeft = KeyC("y"),
+                    bottom = KeyC("x"),
                 ),
                 EMOJI_KEY_ITEM,
             ),
@@ -42,6 +43,7 @@ val KB_FR_THUMBKEY_V2_MAIN =
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
                     left = KeyC("-", color = MUTED),
+                    topLeft = KeyC("(", color = MUTED, swipeReturnAction=CommitText("[")),
                     right = KeyC("v"),
                 ),
                 KeyItemC(
@@ -64,7 +66,7 @@ val KB_FR_THUMBKEY_V2_MAIN =
                             swipeReturnAction = ToggleCurrentWordCapitalization(true),
                             color = MUTED,
                         ),
-                    topRight = KeyC("@", color = MUTED),
+                    topRight = KeyC(")", color = MUTED, swipeReturnAction=CommitText("]")),
                     right = KeyC("â", color = MUTED),
                     bottom =
                         KeyC(
@@ -72,8 +74,9 @@ val KB_FR_THUMBKEY_V2_MAIN =
                             swipeReturnAction = ToggleCurrentWordCapitalization(false),
                         ),
                     bottomRight = KeyC("à", color = MUTED),
-                    bottomLeft = KeyC("æ", color = MUTED),
+                    bottomLeft = KeyC("@", color = MUTED),
                     left = KeyC("d"),
+                    topLeft = KeyC("æ", color = MUTED),
                 ),
                 NUMERIC_KEY_ITEM,
             ),
@@ -88,8 +91,8 @@ val KB_FR_THUMBKEY_V2_MAIN =
                     topLeft = KeyC("ç", color = MUTED),
                     top = KeyC("c"),
                     bottomRight = KeyC("*", color = MUTED),
-                    bottom = KeyC(".", color = MUTED),
-                    bottomLeft = KeyC(",", color = MUTED),
+                    bottom = KeyC(".", color = MUTED, swipeReturnAction=CommitText(":")),
+                    bottomLeft = KeyC(",", color = MUTED, swipeReturnAction=CommitText(";")),
                     right = KeyC("…", color = MUTED),
                 ),
                 KeyItemC(
@@ -165,7 +168,7 @@ val KB_FR_THUMBKEY_V2_SHIFTED =
                             swipeReturnAction = ToggleCurrentWordCapitalization(true),
                             color = MUTED,
                         ),
-                    topRight = KeyC("@", color = MUTED),
+                    topRight = KeyC(")", color = MUTED, swipeReturnAction=CommitText("]")),
                     right = KeyC("Â", color = MUTED),
                     bottomRight = KeyC("À", color = MUTED),
                     bottom =
@@ -175,8 +178,9 @@ val KB_FR_THUMBKEY_V2_SHIFTED =
                             swipeReturnAction = ToggleCurrentWordCapitalization(false),
                             color = MUTED,
                         ),
-                    bottomLeft = KeyC("Æ", color = MUTED),
+                    bottomLeft = KeyC("@", color = MUTED),
                     left = KeyC("D"),
+                    topLeft = KeyC("Æ", color = MUTED),
                 ),
                 NUMERIC_KEY_ITEM,
             ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericFrench.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericFrench.kt
@@ -31,8 +31,8 @@ val FRENCH_NUMERIC_KEYBOARD =
                     topRight = KeyC("´"),
                     right = KeyC("!"),
                     bottomRight = KeyC("\\"),
-                    bottomLeft = KeyC("/"),
-                    left = KeyC("+"),
+                    bottomLeft = KeyC("/", swipeReturnAction=CommitText("\\")),
+                    left = KeyC("+", swipeReturnAction=CommitText("±")),
                 ),
                 KeyItemC(
                     center = KeyC("3", size = LARGE),
@@ -75,7 +75,7 @@ val FRENCH_NUMERIC_KEYBOARD =
                 KeyItemC(
                     center = KeyC("8", size = LARGE),
                     topLeft = KeyC("\""),
-                    topRight = KeyC("'"),
+                    topRight = KeyC("'", swipeReturnAction=CommitText("\"")),
                     bottomRight = KeyC("-"),
                     bottom = KeyC("."),
                     bottomLeft = KeyC("*"),


### PR DESCRIPTION
In addition, I moved the æ to the top left to move @ at the same place as in the numeric layout.
This is not in the relative same place than œ, but I think it’s ok. This gave me a free space to put ) on top-right of A, and a ( on top-left of R, which is usefull when typing.

For the swipeReturn, I added the following :

* [ ] on the added ( ) keys ;
* { } on the already existing « and » ;
* ; on the , and : on the . ;
* \ on the numeric layer /, allowing it to be used on the main layer with the recent patch #1158 of @gitterrost4 ;
* " on the numeric layer ', for the same reason as for \.

This is working now, and will work better with the recents patch #1156 from @gitterrost4.