### PR TITLE
Make the backspace key remove text directly instead of sending a DEL keycode

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/CommonKeys.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/CommonKeys.kt
@@ -144,14 +144,7 @@ val BACKSPACE_KEY_ITEM =
         center =
             KeyC(
                 display = KeyDisplay.IconDisplay(Icons.AutoMirrored.Outlined.KeyboardBackspace),
-                action =
-                    SendEvent(
-                        KeyEvent(
-                            KeyEvent.ACTION_DOWN,
-                            KeyEvent
-                                .KEYCODE_DEL,
-                        ),
-                    ),
+                action = DeleteKeyAction,
                 size = LARGE,
                 color = SECONDARY,
             ),

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
@@ -164,6 +164,8 @@ sealed class KeyAction {
         data object CycleRight : KeyAction()
     }
 
+    data object DeleteKeyAction : KeyAction()
+
     data object DeleteWordBeforeCursor : KeyAction()
 
     data object DeleteWordAfterCursor : KeyAction()

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -361,6 +361,14 @@ fun performKeyAction(
             ime.currentInputConnection.sendKeyEvent(ev)
         }
 
+        is KeyAction.DeleteKeyAction -> {
+            if (ime.currentInputConnection.getSelectedText(0)?.isEmpty() != false) {
+                ime.currentInputConnection.deleteSurroundingText(1, 0)
+            } else {
+                ime.currentInputConnection.commitText("", 0)
+            }
+        }
+
         is KeyAction.DeleteWordBeforeCursor -> {
             Log.d(TAG, "deleting last word")
             deleteWordBeforeCursor(ime)


### PR DESCRIPTION
Changes the behavior of the backspace key to be more text-centered instead of sending a DEL keycode. This ensures compatibility with some apps such as Google Chat.

Fixes #1065 

#986 may also be fixed by this as we are not sending a keydown event anymore, but commiting text. 