### PR TITLE
Fix keyboard overlapping navigation bar on Android 15

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
@@ -10,8 +10,11 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
@@ -352,7 +355,7 @@ fun KeyboardScreen(
             }
             Column(
                 modifier =
-                    Modifier
+                    Modifier.navigationBarsPadding()
                         .then(
                             if (backdropEnabled) {
                                 Modifier.padding(top = backdropPadding)

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
@@ -10,10 +10,8 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -355,7 +353,8 @@ fun KeyboardScreen(
             }
             Column(
                 modifier =
-                    Modifier.navigationBarsPadding()
+                    Modifier
+                        .navigationBarsPadding()
                         .then(
                             if (backdropEnabled) {
                                 Modifier.padding(top = backdropPadding)


### PR DESCRIPTION
closes #1187 

With targetSdk 35 the system forces apps into Edge-to-Edge on phones with at least Android 15. 
To not have elements hidden behind the navigation bars we need to apply the `navigationBarsPadding()` modifier.