### PR TITLE
Add TR split layout

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/TRTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/TRTypeSplit.kt
@@ -1,0 +1,232 @@
+@file:Suppress("ktlint:standard:no-wildcard-imports")
+
+package com.dessalines.thumbkey.keyboards
+
+import com.dessalines.thumbkey.utils.*
+import com.dessalines.thumbkey.utils.ColorVariant.*
+import com.dessalines.thumbkey.utils.FontSizeVariant.*
+import com.dessalines.thumbkey.utils.KeyAction.*
+import com.dessalines.thumbkey.utils.SwipeNWay.*
+
+val KB_TR_TYPESPLIT_MAIN =
+    KeyboardC(
+        listOf(
+            listOf(
+                KeyItemC(
+                    center = KeyC("y", size = LARGE),
+                    swipeType = TWO_WAY_VERTICAL,
+                    bottom = KeyC("h"),
+                ),
+                KeyItemC(
+                    center = KeyC("t", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("v"),
+                    left =
+                        KeyC(
+                            display = null,
+                            action = CommitText("v"),
+                        ),
+                    bottom = KeyC("z"),
+                ),
+                EMOJI_KEY_ITEM_ALT,
+                KeyItemC(
+                    center = KeyC("d", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("b"),
+                    left =
+                        KeyC(
+                            display = null,
+                            action = CommitText("b"),
+                        ),
+                    bottom = KeyC("r"),
+                ),
+                KeyItemC(
+                    center = KeyC("m", size = LARGE),
+                    swipeType = TWO_WAY_VERTICAL,
+                    bottom = KeyC("s"),
+                    top = KeyC("ş"),
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("l", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("j"),
+                    left =
+                        KeyC(
+                            display = null,
+                            action = CommitText("j"),
+                        ),
+                    bottom = KeyC("f"),
+                ),
+                KeyItemC(
+                    center = KeyC("k", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("p"),
+                    left =
+                        KeyC(
+                            display = null,
+                            action = CommitText("p"),
+                        ),
+                    bottom = KeyC("g"),
+                    top = KeyC("ğ"),
+                ),
+                SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("i", size = LARGE),
+                    swipeType = TWO_WAY_VERTICAL,
+                    bottom = KeyC("ı"),
+                ),
+                KeyItemC(
+                    center = KeyC("u", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    bottom = KeyC("ü"),
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("n", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("a", size = LARGE),
+                    swipeType = TWO_WAY_VERTICAL,
+                    bottom = KeyC("o"),
+                    top = KeyC("ö"),
+                ),
+                SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("e", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("r", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("?", color = MUTED),
+                    left = KeyC("!", color = MUTED),
+                    bottom = KeyC(":", color = MUTED),
+                    top = KeyC(";", color = MUTED),
+                ),
+            ),
+            listOf(
+                NUMERIC_KEY_ITEM_ALT,
+                BACKSPACE_TYPESPLIT_KEY_ITEM,
+                RETURN_KEY_ITEM,
+            ),
+        ),
+    )
+
+val KB_TR_TYPESPLIT_SHIFTED =
+    KeyboardC(
+        listOf(
+            listOf(
+                KeyItemC(
+                    center = KeyC("Y", size = LARGE),
+                    swipeType = TWO_WAY_VERTICAL,
+                    bottom = KeyC("H"),
+                ),
+                KeyItemC(
+                    center = KeyC("T", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("V"),
+                    left =
+                        KeyC(
+                            display = null,
+                            action = CommitText("V"),
+                        ),
+                    bottom = KeyC("Z"),
+                ),
+                EMOJI_KEY_ITEM_ALT,
+                KeyItemC(
+                    center = KeyC("D", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("B"),
+                    left =
+                        KeyC(
+                            display = null,
+                            action = CommitText("B"),
+                        ),
+                    bottom = KeyC("R"),
+                ),
+                KeyItemC(
+                    center = KeyC("M", size = LARGE),
+                    swipeType = TWO_WAY_VERTICAL,
+                    bottom = KeyC("S"),
+                    top = KeyC("Ş"),
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("L", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("J"),
+                    left =
+                        KeyC(
+                            display = null,
+                            action = CommitText("J"),
+                        ),
+                    bottom = KeyC("F"),
+                ),
+                KeyItemC(
+                    center = KeyC("K", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("P"),
+                    left =
+                        KeyC(
+                            display = null,
+                            action = CommitText("P"),
+                        ),
+                    bottom = KeyC("G"),
+                    top = KeyC("Ğ"),
+                ),
+                SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("İ", size = LARGE),
+                    swipeType = TWO_WAY_VERTICAL,
+                    bottom = KeyC("I"),
+                ),
+                KeyItemC(
+                    center = KeyC("U", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    bottom = KeyC("Ü"),
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("N", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("A", size = LARGE),
+                    swipeType = TWO_WAY_VERTICAL,
+                    bottom = KeyC("O"),
+                    top = KeyC("Ö"),
+                ),
+                SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("E", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("R", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("?", color = MUTED),
+                    left = KeyC("!", color = MUTED),
+                    bottom = KeyC(":", color = MUTED),
+                    top = KeyC(";", color = MUTED),
+                ),
+            ),
+            listOf(
+                NUMERIC_KEY_ITEM_ALT,
+                BACKSPACE_TYPESPLIT_SHIFTED_KEY_ITEM,
+                RETURN_KEY_ITEM,
+            ),
+        ),
+    )
+
+val KB_TR_TYPESPLIT: KeyboardDefinition =
+    KeyboardDefinition(
+        title = "türkçe type-split",
+        modes =
+            KeyboardDefinitionModes(
+                main = KB_TR_TYPESPLIT_MAIN,
+                shifted = KB_TR_TYPESPLIT_SHIFTED,
+                numeric = TYPESPLIT_NUMERIC_KEYBOARD,
+            ),
+    )

--- a/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
@@ -154,6 +154,7 @@ import com.dessalines.thumbkey.keyboards.KB_T9
 import com.dessalines.thumbkey.keyboards.KB_TOK_SITELEN_THUMBKEY_EMOJI
 import com.dessalines.thumbkey.keyboards.KB_TOK_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_TR_THUMBKEY
+import com.dessalines.thumbkey.keyboards.KB_TR_TYPESPLIT
 import com.dessalines.thumbkey.keyboards.KB_UK_BY_RU_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_UK_MESSAGEASE_SYMBOLS
 import com.dessalines.thumbkey.keyboards.KB_UK_RU_MESSAGEASE_SYMBOLS
@@ -207,6 +208,7 @@ enum class KeyboardLayout(
     FRTypeSplit(KB_FR_TYPESPLIT),
     ITTypeSplit(KB_IT_TYPESPLIT),
     PTTypeSplit(KB_PT_TYPESPLIT),
+    TRTypeSplit(KB_TR_TYPESPLIT),
     PLTypeSplitV2(KB_PL_TYPESPLIT_V2),
     ENTwoHands(KB_EN_TWO_HANDS),
     ENThumbKeyProgrammingWide(KB_EN_THUMBKEY_PROGRAMMING_WIDE),

--- a/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
@@ -208,7 +208,6 @@ enum class KeyboardLayout(
     FRTypeSplit(KB_FR_TYPESPLIT),
     ITTypeSplit(KB_IT_TYPESPLIT),
     PTTypeSplit(KB_PT_TYPESPLIT),
-    TRTypeSplit(KB_TR_TYPESPLIT),
     PLTypeSplitV2(KB_PL_TYPESPLIT_V2),
     ENTwoHands(KB_EN_TWO_HANDS),
     ENThumbKeyProgrammingWide(KB_EN_THUMBKEY_PROGRAMMING_WIDE),
@@ -326,4 +325,5 @@ enum class KeyboardLayout(
     HIThumbKeyExtended(KB_HI_THUMBKEY_EXTENDED),
     FRThumbKeyV3(KB_FR_THUMBKEY_V3),
     DEThumbkeySymNum(KB_DE_THUMBKEY_SYMNUM),
+    TRTypeSplit(KB_TR_TYPESPLIT),
 }


### PR DESCRIPTION
Hello :wave: 

I added a new split layout for Turkish, based on [the letter frequency listed on Wikipedia](https://en.wikipedia.org/wiki/Letter_frequency#Relative_frequencies_of_letters_in_other_languages), as well as personal experience as a Turkish learner.

I tried to stick to the "popular vowels on the right, bottom to top, consonants on the left" guideline, even though I am not sure how well this applies to split layouts. 