### PR TITLE
Added Dvorak style wide keyboard

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDvorakWide.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDvorakWide.kt
@@ -27,7 +27,6 @@ val KB_EN_DVORAK_WIDE_MAIN =
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
                     swipeType = FOUR_WAY_DIAGONAL,
-                    bottomRight = KeyC("z"),
                 ),
                 KeyItemC(
                     center = KeyC("y", size = LARGE),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDvorakWide.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDvorakWide.kt
@@ -1,0 +1,228 @@
+@file:Suppress("ktlint:standard:no-wildcard-imports")
+
+package com.dessalines.thumbkey.keyboards
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.*
+import com.dessalines.thumbkey.utils.*
+import com.dessalines.thumbkey.utils.ColorVariant.*
+import com.dessalines.thumbkey.utils.FontSizeVariant.*
+import com.dessalines.thumbkey.utils.KeyAction.*
+import com.dessalines.thumbkey.utils.SwipeNWay.*
+
+val KB_EN_DVORAK_WIDE_PUNCT_KEY =
+    KeyItemC(
+        center = KeyC("'", size = LARGE),
+        swipeType = FOUR_WAY_DIAGONAL,
+        topLeft = KeyC("!", color = MUTED),
+        topRight = KeyC("?", color = MUTED),
+        bottomRight = KeyC(".", color = MUTED),
+        bottomLeft = KeyC(",", color = MUTED),
+    )
+
+val KB_EN_DVORAK_WIDE_MAIN =
+    KeyboardC(
+        listOf(
+            listOf(
+                KeyItemC(
+                    center = KeyC("a", size = LARGE),
+                    swipeType = FOUR_WAY_DIAGONAL,
+                    bottomRight = KeyC("z"),
+                ),
+                KeyItemC(
+                    center = KeyC("y", size = LARGE),
+                    swipeType = FOUR_WAY_DIAGONAL,
+                    bottomLeft = KeyC("p"),
+                ),
+                EMOJI_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("r", size = LARGE),
+                    swipeType = FOUR_WAY_DIAGONAL,
+                    bottomRight = KeyC("f"),
+                ),
+                KeyItemC(
+                    center = KeyC("s", size = LARGE),
+                    swipeType = FOUR_WAY_DIAGONAL,
+                    bottomLeft = KeyC("g"),
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("o", size = LARGE),
+                    swipeType = TWO_WAY_HORIZONTAL,
+                    right = KeyC("q"),
+                ),
+                KeyItemC(
+                    center = KeyC("u", size = LARGE),
+                    swipeType = TWO_WAY_HORIZONTAL,
+                    left = KeyC("k"),
+                ),
+                KB_EN_DVORAK_WIDE_PUNCT_KEY,
+                KeyItemC(
+                    center = KeyC("d", size = LARGE),
+                    swipeType = TWO_WAY_HORIZONTAL,
+                    left = KeyC("v"),
+                    right = KeyC("c"),
+                ),
+                KeyItemC(
+                    center = KeyC("n", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("l"),
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("e", size = LARGE),
+                    swipeType = FOUR_WAY_DIAGONAL,
+                    topRight = KeyC("j"),
+                ),
+                KeyItemC(
+                    center = KeyC("i", size = LARGE),
+                    swipeType = FOUR_WAY_DIAGONAL,
+                    topLeft = KeyC("x"),
+                ),
+                NUMERIC_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("h", size = LARGE),
+                    swipeType = FOUR_WAY_DIAGONAL,
+                    topRight = KeyC("m"),
+                    topLeft = KeyC("b"),
+                ),
+                KeyItemC(
+                    center = KeyC("t", size = LARGE),
+                    swipeType = FOUR_WAY_DIAGONAL,
+                    topLeft = KeyC("w"),
+                    bottomRight = KeyC("z"),
+                ),
+            ),
+            listOf(
+                BACKSPACE_KEY_ITEM,
+                SPACEBAR_KEY_ITEM,
+                RETURN_KEY_ITEM.copy(
+                    swipeType = TWO_WAY_VERTICAL,
+                    top =
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
+                            action = ToggleShiftMode(true),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(true),
+                            color = SECONDARY,
+                        ),
+                    bottom =
+                        KeyC(
+                            ToggleShiftMode(false),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(false),
+                        ),
+                ),
+            ),
+        ),
+    )
+
+val KB_EN_DVORAK_WIDE_SHIFTED =
+    KeyboardC(
+        listOf(
+            listOf(
+                KeyItemC(
+                    center = KeyC("A", size = LARGE),
+                    swipeType = FOUR_WAY_DIAGONAL,
+                ),
+                KeyItemC(
+                    center = KeyC("Y", size = LARGE),
+                    swipeType = FOUR_WAY_DIAGONAL,
+                    bottomLeft = KeyC("P"),
+                ),
+                EMOJI_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("R", size = LARGE),
+                    swipeType = FOUR_WAY_DIAGONAL,
+                    bottomRight = KeyC("F"),
+                ),
+                KeyItemC(
+                    center = KeyC("S", size = LARGE),
+                    swipeType = FOUR_WAY_DIAGONAL,
+                    bottomLeft = KeyC("G"),
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("O", size = LARGE),
+                    swipeType = TWO_WAY_HORIZONTAL,
+                    right = KeyC("Q"),
+                ),
+                KeyItemC(
+                    center = KeyC("U", size = LARGE),
+                    swipeType = TWO_WAY_HORIZONTAL,
+                    left = KeyC("K"),
+                ),
+                KB_EN_DVORAK_WIDE_PUNCT_KEY,
+                KeyItemC(
+                    center = KeyC("D", size = LARGE),
+                    swipeType = TWO_WAY_HORIZONTAL,
+                    left = KeyC("V"),
+                    right = KeyC("C"),
+                ),
+                KeyItemC(
+                    center = KeyC("N", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("L"),
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("E", size = LARGE),
+                    swipeType = FOUR_WAY_DIAGONAL,
+                    topRight = KeyC("J"),
+                ),
+                KeyItemC(
+                    center = KeyC("I", size = LARGE),
+                    swipeType = FOUR_WAY_DIAGONAL,
+                    topLeft = KeyC("X"),
+                ),
+                NUMERIC_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("H", size = LARGE),
+                    swipeType = FOUR_WAY_DIAGONAL,
+                    topRight = KeyC("M"),
+                    topLeft = KeyC("B"),
+                ),
+                KeyItemC(
+                    center = KeyC("T", size = LARGE),
+                    swipeType = FOUR_WAY_DIAGONAL,
+                    topLeft = KeyC("W"),
+                    bottomRight = KeyC("Z"),
+                ),
+            ),
+            listOf(
+                BACKSPACE_KEY_ITEM,
+                SPACEBAR_KEY_ITEM,
+                RETURN_KEY_ITEM.copy(
+                    swipeType = TWO_WAY_VERTICAL,
+                    top =
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.Outlined.KeyboardCapslock),
+                            capsModeDisplay = KeyDisplay.IconDisplay(Icons.Outlined.Copyright),
+                            action = ToggleCapsLock,
+                            swipeReturnAction = ToggleCurrentWordCapitalization(true),
+                            color = SECONDARY,
+                        ),
+                    bottom =
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
+                            action = ToggleShiftMode(false),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(false),
+                            color = SECONDARY,
+                        ),
+                ),
+            ),
+        ),
+    )
+
+val KB_EN_DVORAK_WIDE: KeyboardDefinition =
+    KeyboardDefinition(
+        title = "english dvorak wide",
+        modes =
+            KeyboardDefinitionModes(
+                main = KB_EN_DVORAK_WIDE_MAIN,
+                shifted = KB_EN_DVORAK_WIDE_SHIFTED,
+                numeric = WIDE_NUMERIC_KEYBOARD,
+            ),
+    )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/TRTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/TRTypeSplit.kt
@@ -1,0 +1,232 @@
+@file:Suppress("ktlint:standard:no-wildcard-imports")
+
+package com.dessalines.thumbkey.keyboards
+
+import com.dessalines.thumbkey.utils.*
+import com.dessalines.thumbkey.utils.ColorVariant.*
+import com.dessalines.thumbkey.utils.FontSizeVariant.*
+import com.dessalines.thumbkey.utils.KeyAction.*
+import com.dessalines.thumbkey.utils.SwipeNWay.*
+
+val KB_TR_TYPESPLIT_MAIN =
+    KeyboardC(
+        listOf(
+            listOf(
+                KeyItemC(
+                    center = KeyC("y", size = LARGE),
+                    swipeType = TWO_WAY_VERTICAL,
+                    bottom = KeyC("h"),
+                ),
+                KeyItemC(
+                    center = KeyC("t", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("v"),
+                    left =
+                        KeyC(
+                            display = null,
+                            action = CommitText("v"),
+                        ),
+                    bottom = KeyC("z"),
+                ),
+                EMOJI_KEY_ITEM_ALT,
+                KeyItemC(
+                    center = KeyC("d", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("b"),
+                    left =
+                        KeyC(
+                            display = null,
+                            action = CommitText("b"),
+                        ),
+                    bottom = KeyC("r"),
+                ),
+                KeyItemC(
+                    center = KeyC("m", size = LARGE),
+                    swipeType = TWO_WAY_VERTICAL,
+                    bottom = KeyC("s"),
+                    top = KeyC("ş"),
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("l", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("j"),
+                    left =
+                        KeyC(
+                            display = null,
+                            action = CommitText("j"),
+                        ),
+                    bottom = KeyC("f"),
+                ),
+                KeyItemC(
+                    center = KeyC("k", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("p"),
+                    left =
+                        KeyC(
+                            display = null,
+                            action = CommitText("p"),
+                        ),
+                    bottom = KeyC("g"),
+                    top = KeyC("ğ"),
+                ),
+                SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("i", size = LARGE),
+                    swipeType = TWO_WAY_VERTICAL,
+                    bottom = KeyC("ı"),
+                ),
+                KeyItemC(
+                    center = KeyC("u", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    bottom = KeyC("ü"),
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("n", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("a", size = LARGE),
+                    swipeType = TWO_WAY_VERTICAL,
+                    bottom = KeyC("o"),
+                    top = KeyC("ö"),
+                ),
+                SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("e", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("r", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("?", color = MUTED),
+                    left = KeyC("!", color = MUTED),
+                    bottom = KeyC(":", color = MUTED),
+                    top = KeyC(";", color = MUTED),
+                ),
+            ),
+            listOf(
+                NUMERIC_KEY_ITEM_ALT,
+                BACKSPACE_TYPESPLIT_KEY_ITEM,
+                RETURN_KEY_ITEM,
+            ),
+        ),
+    )
+
+val KB_TR_TYPESPLIT_SHIFTED =
+    KeyboardC(
+        listOf(
+            listOf(
+                KeyItemC(
+                    center = KeyC("Y", size = LARGE),
+                    swipeType = TWO_WAY_VERTICAL,
+                    bottom = KeyC("H"),
+                ),
+                KeyItemC(
+                    center = KeyC("T", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("V"),
+                    left =
+                        KeyC(
+                            display = null,
+                            action = CommitText("V"),
+                        ),
+                    bottom = KeyC("Z"),
+                ),
+                EMOJI_KEY_ITEM_ALT,
+                KeyItemC(
+                    center = KeyC("D", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("B"),
+                    left =
+                        KeyC(
+                            display = null,
+                            action = CommitText("B"),
+                        ),
+                    bottom = KeyC("R"),
+                ),
+                KeyItemC(
+                    center = KeyC("M", size = LARGE),
+                    swipeType = TWO_WAY_VERTICAL,
+                    bottom = KeyC("S"),
+                    top = KeyC("Ş"),
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("L", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("J"),
+                    left =
+                        KeyC(
+                            display = null,
+                            action = CommitText("J"),
+                        ),
+                    bottom = KeyC("F"),
+                ),
+                KeyItemC(
+                    center = KeyC("K", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("P"),
+                    left =
+                        KeyC(
+                            display = null,
+                            action = CommitText("P"),
+                        ),
+                    bottom = KeyC("G"),
+                    top = KeyC("Ğ"),
+                ),
+                SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("İ", size = LARGE),
+                    swipeType = TWO_WAY_VERTICAL,
+                    bottom = KeyC("I"),
+                ),
+                KeyItemC(
+                    center = KeyC("U", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    bottom = KeyC("Ü"),
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("N", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("A", size = LARGE),
+                    swipeType = TWO_WAY_VERTICAL,
+                    bottom = KeyC("O"),
+                    top = KeyC("Ö"),
+                ),
+                SPACEBAR_TYPESPLIT_BOTTOM_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("E", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("R", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("?", color = MUTED),
+                    left = KeyC("!", color = MUTED),
+                    bottom = KeyC(":", color = MUTED),
+                    top = KeyC(";", color = MUTED),
+                ),
+            ),
+            listOf(
+                NUMERIC_KEY_ITEM_ALT,
+                BACKSPACE_TYPESPLIT_SHIFTED_KEY_ITEM,
+                RETURN_KEY_ITEM,
+            ),
+        ),
+    )
+
+val KB_TR_TYPESPLIT: KeyboardDefinition =
+    KeyboardDefinition(
+        title = "türkçe type-split",
+        modes =
+            KeyboardDefinitionModes(
+                main = KB_TR_TYPESPLIT_MAIN,
+                shifted = KB_TR_TYPESPLIT_SHIFTED,
+                numeric = TYPESPLIT_NUMERIC_KEYBOARD,
+            ),
+    )

--- a/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
@@ -154,6 +154,7 @@ import com.dessalines.thumbkey.keyboards.KB_T9
 import com.dessalines.thumbkey.keyboards.KB_TOK_SITELEN_THUMBKEY_EMOJI
 import com.dessalines.thumbkey.keyboards.KB_TOK_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_TR_THUMBKEY
+import com.dessalines.thumbkey.keyboards.KB_TR_TYPESPLIT
 import com.dessalines.thumbkey.keyboards.KB_UK_BY_RU_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_UK_MESSAGEASE_SYMBOLS
 import com.dessalines.thumbkey.keyboards.KB_UK_RU_MESSAGEASE_SYMBOLS
@@ -324,4 +325,5 @@ enum class KeyboardLayout(
     HIThumbKeyExtended(KB_HI_THUMBKEY_EXTENDED),
     FRThumbKeyV3(KB_FR_THUMBKEY_V3),
     DEThumbkeySymNum(KB_DE_THUMBKEY_SYMNUM),
+    TRTypeSplit(KB_TR_TYPESPLIT),
 }

--- a/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
@@ -25,6 +25,7 @@ import com.dessalines.thumbkey.keyboards.KB_EN_DE_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_EN_DE_THUMBKEY_AE
 import com.dessalines.thumbkey.keyboards.KB_EN_DE_THUMBKEY_V2
 import com.dessalines.thumbkey.keyboards.KB_EN_DOUBLE_SYMBOLS
+import com.dessalines.thumbkey.keyboards.KB_EN_DVORAK_WIDE
 import com.dessalines.thumbkey.keyboards.KB_EN_EE_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_EN_EO_MESSAGEASE_SYMBOLS
 import com.dessalines.thumbkey.keyboards.KB_EN_EO_THUMBKEY
@@ -326,4 +327,5 @@ enum class KeyboardLayout(
     FRThumbKeyV3(KB_FR_THUMBKEY_V3),
     DEThumbkeySymNum(KB_DE_THUMBKEY_SYMNUM),
     TRTypeSplit(KB_TR_TYPESPLIT),
+    ENDvorakWide(KB_EN_DVORAK_WIDE),
 }


### PR DESCRIPTION
Based on the Thumbkey Wide layout but with the orientation flipped (vowels on the left) and the swipe keys moved to their approximately equivalent position (most common consonants on right).