### PR TITLE
Add some missing keys on the shifted layout and ! on numeric ? swipeReturn

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FRThumbKeyV2.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FRThumbKeyV2.kt
@@ -138,6 +138,7 @@ val KB_FR_THUMBKEY_V2_SHIFTED =
                     top = KeyC("Ï", color = MUTED),
                     right = KeyC("Î", color = MUTED),
                     bottomRight = KeyC("K"),
+                    bottom = KeyC("X"),
                     bottomLeft = KeyC("Y"),
                 ),
                 EMOJI_KEY_ITEM,
@@ -147,6 +148,7 @@ val KB_FR_THUMBKEY_V2_SHIFTED =
                     center = KeyC("R", size = LARGE),
                     left = KeyC("-", color = MUTED),
                     right = KeyC("V"),
+                    topLeft = KeyC("(", color = MUTED, swipeReturnAction = CommitText("[")),
                 ),
                 KeyItemC(
                     center = KeyC("N", size = LARGE),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericFrench.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericFrench.kt
@@ -36,7 +36,7 @@ val FRENCH_NUMERIC_KEYBOARD =
                 ),
                 KeyItemC(
                     center = KeyC("3", size = LARGE),
-                    left = KeyC("?"),
+                    left = KeyC("?", swipeReturnAction = CommitText("!")),
                     bottomRight = KeyC("€"),
                     bottomLeft = KeyC("£"),
                     bottom = KeyC("="),


### PR DESCRIPTION
Some keys were missing on the shifted layout, I fixed it.
Also, there was no direct ! on the layout, so I added it as swipeReturn action of the ? key.