### PR TITLE
Fix swipe types of NumericWide

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericWide.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericWide.kt
@@ -55,7 +55,7 @@ val WIDE_NUMERIC_KEYBOARD =
             listOf(
                 KeyItemC(
                     center = KeyC("(", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
+                    swipeType = EIGHT_WAY,
                     top = KeyC("<"),
                     topLeft = KeyC("{"),
                     left =
@@ -124,7 +124,7 @@ val WIDE_NUMERIC_KEYBOARD =
                 ),
                 KeyItemC(
                     center = KeyC("7", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
+                    swipeType = EIGHT_WAY,
                     left = KeyC("@"),
                     top = KeyC("&"),
                     topRight = KeyC("%"),
@@ -140,7 +140,7 @@ val WIDE_NUMERIC_KEYBOARD =
                 ),
                 KeyItemC(
                     center = KeyC("9", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
+                    swipeType = EIGHT_WAY,
                     top = KeyC("~"),
                     bottomLeft = KeyC("\\"),
                     bottomRight = KeyC("/"),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericWide.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericWide.kt
@@ -99,7 +99,7 @@ val WIDE_NUMERIC_KEYBOARD =
                 ),
                 KeyItemC(
                     center = KeyC(")", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
+                    swipeType = EIGHT_WAY,
                     top = KeyC(">"),
                     topRight = KeyC("}"),
                     right =


### PR DESCRIPTION
Using EIGHT_WAY in "(", ")", "7", "9" keys