### PR TITLE
Add Tab, Esc in dvorak-wide

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDvorakWide.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDvorakWide.kt
@@ -92,7 +92,7 @@ val KB_EN_DVORAK_WIDE_MAIN =
                     center = KeyC("t", size = LARGE),
                     swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("w"),
-                    rignt =
+                    right =
                         KeyC(
                             display = KeyDisplay.IconDisplay(Icons.AutoMirrored.Outlined.KeyboardTab),
                             action = CommitText("\t"),
@@ -195,7 +195,7 @@ val KB_EN_DVORAK_WIDE_SHIFTED =
                     center = KeyC("T", size = LARGE),
                     swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("W"),
-                    rignt =
+                    right =
                         KeyC(
                             display = KeyDisplay.IconDisplay(Icons.AutoMirrored.Outlined.KeyboardTab),
                             action = CommitText("\t"),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDvorakWide.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDvorakWide.kt
@@ -3,6 +3,7 @@
 package com.dessalines.thumbkey.keyboards
 
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.*
 import androidx.compose.material.icons.outlined.*
 import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDvorakWide.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDvorakWide.kt
@@ -74,7 +74,7 @@ val KB_EN_DVORAK_WIDE_MAIN =
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
                     swipeType = FOUR_WAY_DIAGONAL,
-                    left = KeyC("\x1b", displayText = "⎋", color = MUTED),
+                    left = KeyC("\u001b", displayText = "⎋", color = MUTED),
                     topRight = KeyC("j"),
                 ),
                 KeyItemC(
@@ -177,7 +177,7 @@ val KB_EN_DVORAK_WIDE_SHIFTED =
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
                     swipeType = FOUR_WAY_DIAGONAL,
-                    left = KeyC("\x1b", displayText = "⎋", color = MUTED),
+                    left = KeyC("\u001b", displayText = "⎋", color = MUTED),
                     topRight = KeyC("J"),
                 ),
                 KeyItemC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDvorakWide.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDvorakWide.kt
@@ -73,6 +73,7 @@ val KB_EN_DVORAK_WIDE_MAIN =
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
                     swipeType = FOUR_WAY_DIAGONAL,
+                    left = KeyC("\x1b", displayText = "⎋", color = MUTED),
                     topRight = KeyC("j"),
                 ),
                 KeyItemC(
@@ -91,6 +92,12 @@ val KB_EN_DVORAK_WIDE_MAIN =
                     center = KeyC("t", size = LARGE),
                     swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("w"),
+                    rignt =
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.AutoMirrored.Outlined.KeyboardTab),
+                            action = CommitText("\t"),
+                            color = MUTED,
+                        ),
                     bottomRight = KeyC("z"),
                 ),
             ),
@@ -169,6 +176,7 @@ val KB_EN_DVORAK_WIDE_SHIFTED =
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
                     swipeType = FOUR_WAY_DIAGONAL,
+                    left = KeyC("\x1b", displayText = "⎋", color = MUTED),
                     topRight = KeyC("J"),
                 ),
                 KeyItemC(
@@ -187,6 +195,12 @@ val KB_EN_DVORAK_WIDE_SHIFTED =
                     center = KeyC("T", size = LARGE),
                     swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("W"),
+                    rignt =
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.AutoMirrored.Outlined.KeyboardTab),
+                            action = CommitText("\t"),
+                            color = MUTED,
+                        ),
                     bottomRight = KeyC("Z"),
                 ),
             ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDvorakWideCompose.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDvorakWideCompose.kt
@@ -78,7 +78,7 @@ val KB_EN_DVORAK_WIDE_COMPOSE_MAIN =
                     topRight =
                         KeyC(
                             display = KeyDisplay.TextDisplay("´"),
-                            action = ComposeLastKey("´"),
+                            action = ComposeLastKey("'"),
                             color = MUTED,
                         ),
                 ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDvorakWideCompose.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDvorakWideCompose.kt
@@ -3,6 +3,7 @@
 package com.dessalines.thumbkey.keyboards
 
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.*
 import androidx.compose.material.icons.outlined.*
 import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDvorakWideCompose.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDvorakWideCompose.kt
@@ -92,7 +92,7 @@ val KB_EN_DVORAK_WIDE_COMPOSE_MAIN =
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
                     swipeType = FOUR_WAY_DIAGONAL,
-                    left = KeyC("\x1b", displayText = "⎋", color = MUTED),
+                    left = KeyC("\u001b", displayText = "⎋", color = MUTED),
                     topRight = KeyC("j"),
                 ),
                 KeyItemC(
@@ -219,7 +219,7 @@ val KB_EN_DVORAK_WIDE_COMPOSE_SHIFTED =
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
                     swipeType = FOUR_WAY_DIAGONAL,
-                    left = KeyC("\x1b", displayText = "⎋", color = MUTED),
+                    left = KeyC("\u001b", displayText = "⎋", color = MUTED),
                     topRight = KeyC("J"),
                 ),
                 KeyItemC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDvorakWideCompose.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDvorakWideCompose.kt
@@ -77,7 +77,7 @@ val KB_EN_DVORAK_WIDE_COMPOSE_MAIN =
                     topRight =
                         KeyC(
                             display = KeyDisplay.TextDisplay("´"),
-                            action = ComposeLastKey("'"),
+                            action = ComposeLastKey("´"),
                             color = MUTED,
                         ),
                 ),
@@ -91,6 +91,7 @@ val KB_EN_DVORAK_WIDE_COMPOSE_MAIN =
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
                     swipeType = FOUR_WAY_DIAGONAL,
+                    left = KeyC("\x1b", displayText = "⎋", color = MUTED),
                     topRight = KeyC("j"),
                 ),
                 KeyItemC(
@@ -115,6 +116,12 @@ val KB_EN_DVORAK_WIDE_COMPOSE_MAIN =
                     center = KeyC("t", size = LARGE),
                     swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("w"),
+                    rignt =
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.AutoMirrored.Outlined.KeyboardTab),
+                            action = CommitText("\t"),
+                            color = MUTED,
+                        ),
                     bottomRight = KeyC("z"),
                 ),
             ),
@@ -211,6 +218,7 @@ val KB_EN_DVORAK_WIDE_COMPOSE_SHIFTED =
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
                     swipeType = FOUR_WAY_DIAGONAL,
+                    left = KeyC("\x1b", displayText = "⎋", color = MUTED),
                     topRight = KeyC("J"),
                 ),
                 KeyItemC(
@@ -235,6 +243,12 @@ val KB_EN_DVORAK_WIDE_COMPOSE_SHIFTED =
                     center = KeyC("T", size = LARGE),
                     swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("W"),
+                    rignt =
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.AutoMirrored.Outlined.KeyboardTab),
+                            action = CommitText("\t"),
+                            color = MUTED,
+                        ),
                     bottomRight = KeyC("Z"),
                 ),
             ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDvorakWideCompose.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDvorakWideCompose.kt
@@ -116,7 +116,7 @@ val KB_EN_DVORAK_WIDE_COMPOSE_MAIN =
                     center = KeyC("t", size = LARGE),
                     swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("w"),
-                    rignt =
+                    right =
                         KeyC(
                             display = KeyDisplay.IconDisplay(Icons.AutoMirrored.Outlined.KeyboardTab),
                             action = CommitText("\t"),
@@ -243,7 +243,7 @@ val KB_EN_DVORAK_WIDE_COMPOSE_SHIFTED =
                     center = KeyC("T", size = LARGE),
                     swipeType = FOUR_WAY_DIAGONAL,
                     topLeft = KeyC("W"),
-                    rignt =
+                    right =
                         KeyC(
                             display = KeyDisplay.IconDisplay(Icons.AutoMirrored.Outlined.KeyboardTab),
                             action = CommitText("\t"),


### PR DESCRIPTION
Adding Tab and Esc keys  for dvorak-wide and dvorak-wide compose layouts