### PR TITLE
Draft: use minSwipeLength setting for DragReturn and Circular detection

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
@@ -448,8 +448,14 @@ fun KeyboardKey(
                         ) {
                             hasSlideMoveCursorTriggered = false
 
-                            val finalOffsetThreshold = keySize.dp.toPx() * 0.71f // magic number found from trial and error
-                            val maxOffsetThreshold = 1.5 * finalOffsetThreshold
+                            // offset where we recognize if the swipe is back to the initial key
+                            // this offset needs to take the minSwipeLength into consideration. Otherwise
+                            // just a little (1px) swipe back would trigger the DragReturn action
+                            val finalOffsetThreshold = minSwipeLength * 0.71f // magic number found from trial and error
+
+                            // offset needed, at which the swipe qualifies for DragReturn or Circular
+                            // depending on minSwipeLength setting to have consistent swipe lengths or circle sizes
+                            val maxOffsetThreshold = minSwipeLength
 
                             val finalOffset = positions.last()
                             // we also consider the final offset small enough if it's kinda big, but
@@ -475,7 +481,7 @@ fun KeyboardKey(
                                                         CircularDragAction.OppositeCase to oppositeCaseKey?.center?.action,
                                                         CircularDragAction.Numeric to numericKey?.center?.action,
                                                     )
-                                                circularDirection(positions, finalOffsetThreshold)?.let {
+                                                circularDirection(positions, finalOffsetThreshold, minSwipeLength)?.let {
                                                     when (it) {
                                                         CircularDirection.Clockwise -> circularDragActions[clockwiseDragAction]
                                                         CircularDirection.Counterclockwise ->


### PR DESCRIPTION
Currently, the DragReturn gesture recognition and the Circular recognition ignore the setting of the minSwipeLength. That leads to inconsistent behaviour:

- if you have a small minSwipeLenght (because I am lazy), swiping normal letters is very smooth and working great
- DragReturn for capital letters require way more movement, because it depends on the keysize, not the setting
- Circular detection only checks for minRadius relative (1/3) to maxRadius, which leads to false positives for small circles (I am lazy and clumsy)

This change tries to modify these behaviours:

- you can drag to minSwipeLength and return for successful DragReturn action (so swipelength is the same for capital letters as for normal letters)
- Circular patterns require to have at least your set minSwipeLength as minRadius, to prevent inaccurated DragReturns recognized as circles

I created this pull request as draft because:

1. its my first contribution to any android project ever (just installed android studio 3 days ago)
2. Discussion topic: Should the minSwipeLength setting be used relative to the key sizes? So maybe minSwipeLength 64 is alwas half a key-width?
3. Circular detection should be ok, if just 3/4 of a circle is drawn, because the user intention is clear at this point. But I do not understand the math/logic to create the right change or values.

I would like to have some feedback on this PR - its my first here, so maybe my changes are not in the intention of the project (I did not search through the changes history). That would be also ok for me, since this is open source, I can just build my own version for me 😄 
