### PR TITLE
add hyper space and minor fixes to hyper

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENHyper.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENHyper.kt
@@ -4,6 +4,7 @@ package com.dessalines.thumbkey.keyboards
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ArrowDropDown
+import androidx.compose.material.icons.outlined.ArrowDropUp
 import androidx.compose.material.icons.outlined.Copyright
 import androidx.compose.material.icons.outlined.KeyboardCapslock
 import com.dessalines.thumbkey.utils.*
@@ -16,7 +17,7 @@ val KB_EN_HYPER_MAIN =
     KeyboardC(
         listOf(
             listOf(
-                BACKSPACE_KEY_ITEM,
+                RETURN_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("u", size = LARGE),
                     swipeType = FOUR_WAY_CROSS,
@@ -41,7 +42,7 @@ val KB_EN_HYPER_MAIN =
                     left = KeyC("@", color = MUTED),
                     bottom = KeyC("y"),
                 ),
-                RETURN_KEY_ITEM,
+                BACKSPACE_KEY_ITEM,
             ),
             listOf(
                 SPACEBAR_SKINNY_KEY_ITEM,
@@ -51,7 +52,7 @@ val KB_EN_HYPER_MAIN =
                     right = KeyC("k"),
                     top =
                         KeyC(
-                            display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
+                            display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
                             action = ToggleShiftMode(true),
                             swipeReturnAction = ToggleCurrentWordCapitalization(true),
                             color = MUTED,
@@ -120,7 +121,7 @@ val KB_EN_HYPER_SHIFTED =
     KeyboardC(
         listOf(
             listOf(
-                BACKSPACE_KEY_ITEM,
+                RETURN_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("U", size = LARGE),
                     swipeType = FOUR_WAY_CROSS,
@@ -145,7 +146,7 @@ val KB_EN_HYPER_SHIFTED =
                     left = KeyC("@", color = MUTED),
                     bottom = KeyC("Y"),
                 ),
-                RETURN_KEY_ITEM,
+                BACKSPACE_KEY_ITEM,
             ),
             listOf(
                 SPACEBAR_SKINNY_KEY_ITEM,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENHyperSpace.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENHyperSpace.kt
@@ -5,7 +5,6 @@ package com.dessalines.thumbkey.keyboards
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ArrowDropDown
 import androidx.compose.material.icons.outlined.ArrowDropUp
-import androidx.compose.material.icons.outlined.ArrowUpward
 import androidx.compose.material.icons.outlined.Copyright
 import androidx.compose.material.icons.outlined.KeyboardCapslock
 import com.dessalines.thumbkey.utils.*
@@ -57,17 +56,17 @@ val KB_EN_HYPER_SPACE_MAIN =
                     swipeType = FOUR_WAY_CROSS,
                     right = KeyC("k"),
                     top =
-                    KeyC(
-                        display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
-                        action = ToggleShiftMode(true),
-                        swipeReturnAction = ToggleCurrentWordCapitalization(true),
-                        color = MUTED,
-                    ),
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
+                            action = ToggleShiftMode(true),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(true),
+                            color = MUTED,
+                        ),
                     bottom =
-                    KeyC(
-                        ToggleShiftMode(false),
-                        swipeReturnAction = ToggleCurrentWordCapitalization(false),
-                    ),
+                        KeyC(
+                            ToggleShiftMode(false),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(false),
+                        ),
                 ),
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
@@ -161,20 +160,20 @@ val KB_EN_HYPER_SPACE_SHIFTED =
                     swipeType = FOUR_WAY_CROSS,
                     right = KeyC("K"),
                     top =
-                    KeyC(
-                        display = KeyDisplay.IconDisplay(Icons.Outlined.KeyboardCapslock),
-                        capsModeDisplay = KeyDisplay.IconDisplay(Icons.Outlined.Copyright),
-                        action = ToggleCapsLock,
-                        swipeReturnAction = ToggleCurrentWordCapitalization(true),
-                        color = MUTED,
-                    ),
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.Outlined.KeyboardCapslock),
+                            capsModeDisplay = KeyDisplay.IconDisplay(Icons.Outlined.Copyright),
+                            action = ToggleCapsLock,
+                            swipeReturnAction = ToggleCurrentWordCapitalization(true),
+                            color = MUTED,
+                        ),
                     bottom =
-                    KeyC(
-                        display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
-                        action = ToggleShiftMode(false),
-                        swipeReturnAction = ToggleCurrentWordCapitalization(false),
-                        color = MUTED,
-                    ),
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
+                            action = ToggleShiftMode(false),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(false),
+                            color = MUTED,
+                        ),
                 ),
                 KeyItemC(
                     center = KeyC("E", size = LARGE),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENHyperSpace.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENHyperSpace.kt
@@ -1,0 +1,241 @@
+@file:Suppress("ktlint:standard:no-wildcard-imports")
+
+package com.dessalines.thumbkey.keyboards
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowDropDown
+import androidx.compose.material.icons.outlined.ArrowDropUp
+import androidx.compose.material.icons.outlined.ArrowUpward
+import androidx.compose.material.icons.outlined.Copyright
+import androidx.compose.material.icons.outlined.KeyboardCapslock
+import com.dessalines.thumbkey.utils.*
+import com.dessalines.thumbkey.utils.ColorVariant.*
+import com.dessalines.thumbkey.utils.FontSizeVariant.*
+import com.dessalines.thumbkey.utils.KeyAction.*
+import com.dessalines.thumbkey.utils.SwipeNWay.*
+
+val KB_EN_HYPER_SPACE_MAIN =
+    KeyboardC(
+        listOf(
+            listOf(
+                RETURN_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("u", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("`", color = MUTED),
+                    bottom = KeyC("x"),
+                ),
+                KeyItemC(
+                    center = KeyC("a", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    bottom = KeyC("!", color = MUTED),
+                    left = KeyC("j"),
+                ),
+                KeyItemC(
+                    center = KeyC("n", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("b"),
+                    bottom = KeyC("d"),
+                ),
+                KeyItemC(
+                    center = KeyC("l", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("@", color = MUTED),
+                    bottom = KeyC("y"),
+                ),
+                BACKSPACE_KEY_ITEM,
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("g", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("z"),
+                    top = KeyC("\"", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("o", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("k"),
+                    top =
+                    KeyC(
+                        display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
+                        action = ToggleShiftMode(true),
+                        swipeReturnAction = ToggleCurrentWordCapitalization(true),
+                        color = MUTED,
+                    ),
+                    bottom =
+                    KeyC(
+                        ToggleShiftMode(false),
+                        swipeReturnAction = ToggleCurrentWordCapitalization(false),
+                    ),
+                ),
+                KeyItemC(
+                    center = KeyC("e", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("?", color = MUTED),
+                    top = KeyC(".", color = MUTED),
+                    bottom = KeyC(",", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("t", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("p"),
+                    bottom = KeyC("w"),
+                    top = KeyC("m"),
+                ),
+                KeyItemC(
+                    center = KeyC("s", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("c"),
+                    bottom = KeyC("q"),
+                    top = KeyC("-", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("r", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("/", color = MUTED),
+                    top = KeyC("#", color = MUTED),
+                ),
+            ),
+            listOf(
+                NUMERIC_KEY_ITEM,
+                SPACEBAR_SKINNY_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("i", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    top = KeyC("'", color = MUTED),
+                    left = KeyC(";", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("h", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("f"),
+                    top = KeyC("v"),
+                ),
+                SPACEBAR_SKINNY_KEY_ITEM,
+                EMOJI_KEY_ITEM,
+            ),
+        ),
+    )
+
+val KB_EN_HYPER_SPACE_SHIFTED =
+    KeyboardC(
+        listOf(
+            listOf(
+                RETURN_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("U", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("~", color = MUTED),
+                    bottom = KeyC("X"),
+                ),
+                KeyItemC(
+                    center = KeyC("A", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    bottom = KeyC("!", color = MUTED),
+                    left = KeyC("J"),
+                ),
+                KeyItemC(
+                    center = KeyC("N", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("B"),
+                    bottom = KeyC("D"),
+                ),
+                KeyItemC(
+                    center = KeyC("L", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("@", color = MUTED),
+                    bottom = KeyC("Y"),
+                ),
+                BACKSPACE_KEY_ITEM,
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("G", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("Z"),
+                    top = KeyC("\"", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("O", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("K"),
+                    top =
+                    KeyC(
+                        display = KeyDisplay.IconDisplay(Icons.Outlined.KeyboardCapslock),
+                        capsModeDisplay = KeyDisplay.IconDisplay(Icons.Outlined.Copyright),
+                        action = ToggleCapsLock,
+                        swipeReturnAction = ToggleCurrentWordCapitalization(true),
+                        color = MUTED,
+                    ),
+                    bottom =
+                    KeyC(
+                        display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
+                        action = ToggleShiftMode(false),
+                        swipeReturnAction = ToggleCurrentWordCapitalization(false),
+                        color = MUTED,
+                    ),
+                ),
+                KeyItemC(
+                    center = KeyC("E", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("?", color = MUTED),
+                    top = KeyC(".", color = MUTED),
+                    bottom = KeyC(",", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("T", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("P"),
+                    top = KeyC("M"),
+                    bottom = KeyC("W"),
+                ),
+                KeyItemC(
+                    center = KeyC("S", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("C"),
+                    top = KeyC("_", color = MUTED),
+                    bottom = KeyC("Q"),
+                ),
+                KeyItemC(
+                    center = KeyC("R", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("/", color = MUTED),
+                    top = KeyC("#", color = MUTED),
+                ),
+            ),
+            listOf(
+                NUMERIC_KEY_ITEM,
+                SPACEBAR_SKINNY_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("I", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC(":", color = MUTED),
+                    top = KeyC("'", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("H", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("F"),
+                    top = KeyC("V"),
+                ),
+                SPACEBAR_SKINNY_KEY_ITEM,
+                EMOJI_KEY_ITEM,
+            ),
+        ),
+    )
+
+val KB_EN_HYPER_SPACE: KeyboardDefinition =
+    KeyboardDefinition(
+        title = "english hyper space",
+        modes =
+            KeyboardDefinitionModes(
+                main = KB_EN_HYPER_SPACE_MAIN,
+                shifted = KB_EN_HYPER_SPACE_SHIFTED,
+                numeric = HYPER_NUMERIC_KEYBOARD,
+            ),
+        settings =
+            KeyboardDefinitionSettings(
+                autoCapitalizers = arrayOf(::autoCapitalizeI, ::autoCapitalizeIApostrophe),
+            ),
+    )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericHyper.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericHyper.kt
@@ -12,7 +12,7 @@ val HYPER_NUMERIC_KEYBOARD =
     KeyboardC(
         listOf(
             listOf(
-                BACKSPACE_KEY_ITEM,
+                RETURN_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("!", size = LARGE),
                 ),
@@ -36,7 +36,7 @@ val HYPER_NUMERIC_KEYBOARD =
                     bottom = KeyC("°"),
                     bottomLeft = KeyC("#"),
                 ),
-                RETURN_KEY_ITEM,
+                BACKSPACE_KEY_ITEM,
             ),
             listOf(
                 KeyItemC(

--- a/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
@@ -36,6 +36,7 @@ import com.dessalines.thumbkey.keyboards.KB_EN_ES_CA_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_EN_FR_MESSAGEASE_SYMBOLS
 import com.dessalines.thumbkey.keyboards.KB_EN_HR_MESSAGEASE
 import com.dessalines.thumbkey.keyboards.KB_EN_HYPER
+import com.dessalines.thumbkey.keyboards.KB_EN_HYPER_SPACE
 import com.dessalines.thumbkey.keyboards.KB_EN_IT_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_EN_LA_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_EN_MESSAGEASE
@@ -168,7 +169,6 @@ import com.dessalines.thumbkey.keyboards.KB_UK_MESSAGEASE_SYMBOLS
 import com.dessalines.thumbkey.keyboards.KB_UK_RU_MESSAGEASE_SYMBOLS
 import com.dessalines.thumbkey.keyboards.KB_UK_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_VN_THUMBKEY
-import com.dessalines.thumbkey.keyboards.KB_EN_HYPER_SPACE
 
 // Make sure new keyboards are added AT THE END of this list, and have a higher index.
 // DO NOT put them in the middle of the list!

--- a/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
@@ -168,6 +168,7 @@ import com.dessalines.thumbkey.keyboards.KB_UK_MESSAGEASE_SYMBOLS
 import com.dessalines.thumbkey.keyboards.KB_UK_RU_MESSAGEASE_SYMBOLS
 import com.dessalines.thumbkey.keyboards.KB_UK_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_VN_THUMBKEY
+import com.dessalines.thumbkey.keyboards.KB_EN_HYPER_SPACE
 
 // Make sure new keyboards are added AT THE END of this list, and have a higher index.
 // DO NOT put them in the middle of the list!
@@ -342,4 +343,5 @@ enum class KeyboardLayout(
     BRFRThumbKeyCompose(KB_BR_FR_THUMBKEY_COMPOSE),
     ENHyper(KB_EN_HYPER),
     ENThumbKeyWordsSymbols(KB_EN_THUMBKEY_WORDS_SYMBOLS),
+    ENHyperSpace(KB_EN_HYPER_SPACE),
 }


### PR DESCRIPTION
**Hyper Space:**
- Sidegrade to [hyper](https://github.com/dessalines/thumb-key/pull/1260) by shifting the space keys to the bottom corners of the 5x4; more traditional / use if sides feel awkward

![Screenshot 2025-02-12 at 21 25 12](https://github.com/user-attachments/assets/8fc149bc-1703-4708-a3c5-42bdeb43b56e)
_Suggestion by stop.png_

**Both:**
- Swapped return and backspace keys to left and right side respectively; fixes highlight backspace
- Shift up now shows an arrow up instead of an arrow down
_Thanks to @KraXen72 for catching both!_