### PR TITLE
Slightly loosen password field definition for disabling animations

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -1148,8 +1148,7 @@ fun isPasswordField(ime: IMEService): Boolean {
         InputType.TYPE_TEXT_VARIATION_PASSWORD,
         InputType.TYPE_TEXT_VARIATION_WEB_PASSWORD,
         InputType.TYPE_NUMBER_VARIATION_PASSWORD,
-    ).contains(inputType) ||
-        ime.currentInputEditorInfo.inputType == EditorInfo.TYPE_NULL
+    ).contains(inputType)
 }
 
 fun deleteWordBeforeCursor(ime: IMEService) {


### PR DESCRIPTION
As discussed in #1279, this seems the way forward for still having animation in input scenario's that weren't password fields.