### PR TITLE
Update Hyper symbol layer and punctuation

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENHyper.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENHyper.kt
@@ -26,7 +26,7 @@ val KB_EN_HYPER_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    swipeType = FOUR_WAY_CROSS,
+                        swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("!", color = MUTED),
                     left = KeyC("j"),
                 ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENHyper.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENHyper.kt
@@ -26,7 +26,7 @@ val KB_EN_HYPER_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                        swipeType = FOUR_WAY_CROSS,
+                    swipeType = FOUR_WAY_CROSS,
                     bottom = KeyC("!", color = MUTED),
                     left = KeyC("j"),
                 ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENHyper.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENHyper.kt
@@ -66,9 +66,9 @@ val KB_EN_HYPER_MAIN =
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
                     swipeType = FOUR_WAY_CROSS,
-                    left = KeyC("?", color = MUTED),
-                    top = KeyC(".", color = MUTED),
-                    bottom = KeyC(",", color = MUTED),
+                    left = KeyC(".", color = MUTED),
+                    top = KeyC(",", color = MUTED),
+                    bottom = KeyC("?", color = MUTED),
                 ),
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
@@ -173,9 +173,9 @@ val KB_EN_HYPER_SHIFTED =
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
                     swipeType = FOUR_WAY_CROSS,
-                    left = KeyC("?", color = MUTED),
-                    top = KeyC(".", color = MUTED),
-                    bottom = KeyC(",", color = MUTED),
+                    left = KeyC(".", color = MUTED),
+                    top = KeyC(",", color = MUTED),
+                    bottom = KeyC("?", color = MUTED),
                 ),
                 KeyItemC(
                     center = KeyC("T", size = LARGE),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENHyperSpace.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENHyperSpace.kt
@@ -71,9 +71,9 @@ val KB_EN_HYPER_SPACE_MAIN =
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
                     swipeType = FOUR_WAY_CROSS,
-                    left = KeyC("?", color = MUTED),
-                    top = KeyC(".", color = MUTED),
-                    bottom = KeyC(",", color = MUTED),
+                    left = KeyC(".", color = MUTED),
+                    top = KeyC(",", color = MUTED),
+                    bottom = KeyC("?", color = MUTED),
                 ),
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
@@ -178,9 +178,9 @@ val KB_EN_HYPER_SPACE_SHIFTED =
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
                     swipeType = FOUR_WAY_CROSS,
-                    left = KeyC("?", color = MUTED),
-                    top = KeyC(".", color = MUTED),
-                    bottom = KeyC(",", color = MUTED),
+                    left = KeyC(".", color = MUTED),
+                    top = KeyC(",", color = MUTED),
+                    bottom = KeyC("?", color = MUTED),
                 ),
                 KeyItemC(
                     center = KeyC("T", size = LARGE),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericHyper.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericHyper.kt
@@ -14,38 +14,31 @@ val HYPER_NUMERIC_KEYBOARD =
             listOf(
                 RETURN_KEY_ITEM,
                 KeyItemC(
-                    center = KeyC("!", size = LARGE),
-                ),
-                KeyItemC(
-                    center = KeyC("7", size = LARGE),
-                    bottomRight = KeyC("?"),
+                    center = KeyC("1", size = LARGE),
                     top = KeyC(":(", size = SMALL),
-                    bottom = KeyC("~"),
-                    left = KeyC("{"),
+                    left = KeyC("["),
+                    bottomRight = KeyC("<"),
+                    right = KeyC("\\"),
                 ),
                 KeyItemC(
-                    center = KeyC("8", size = LARGE),
-                    bottom = KeyC("@"),
-                    topLeft = KeyC("`"),
-                    topRight = KeyC("´"),
+                    center = KeyC("2", size = LARGE),
                 ),
                 KeyItemC(
-                    center = KeyC("9", size = LARGE),
+                    center = KeyC("3", size = LARGE),
                     top = KeyC(":)", size = SMALL),
-                    right = KeyC("}"),
-                    bottom = KeyC("°"),
-                    bottomLeft = KeyC("#"),
+                    left = KeyC("|"),
+                    right = KeyC("]"),
+                    bottomLeft = KeyC(">"),
+                ),
+                KeyItemC(
+                    center = KeyC(".", size = LARGE),
+                    bottom = KeyC(","),
+                    left = KeyC("^"),
                 ),
                 BACKSPACE_KEY_ITEM,
             ),
             listOf(
-                KeyItemC(
-                    center = KeyC(".", size = LARGE),
-                    backgroundColor = SURFACE_VARIANT,
-                ),
-                KeyItemC(
-                    center = KeyC("0", size = LARGE),
-                ),
+                SPACEBAR_SKINNY_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("4", size = LARGE),
                     top = KeyC("\""),
@@ -64,8 +57,33 @@ val HYPER_NUMERIC_KEYBOARD =
                     center = KeyC("6", size = LARGE),
                     top = KeyC("'"),
                     bottom = KeyC(";"),
-                    left = KeyC("^"),
+                    left = KeyC("!"),
                     right = KeyC(")"),
+                ),
+                KeyItemC(
+                    center = KeyC("0", size = LARGE),
+                ),
+                SPACEBAR_SKINNY_KEY_ITEM,
+            ),
+            listOf(
+                ABC_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("7", size = LARGE),
+                    topRight = KeyC("?"),
+                    top = KeyC("~"),
+                    left = KeyC("{"),
+                ),
+                KeyItemC(
+                    center = KeyC("8", size = LARGE),
+                    top = KeyC("@"),
+                    topLeft = KeyC("`"),
+                    topRight = KeyC("´"),
+                ),
+                KeyItemC(
+                    center = KeyC("9", size = LARGE),
+                    right = KeyC("}"),
+                    top = KeyC("°"),
+                    topLeft = KeyC("#"),
                 ),
                 KeyItemC(
                     center = KeyC("="),
@@ -73,30 +91,6 @@ val HYPER_NUMERIC_KEYBOARD =
                     bottom = KeyC("-"),
                     left = KeyC("*"),
                     right = KeyC("/"),
-                    backgroundColor = SURFACE_VARIANT,
-                ),
-            ),
-            listOf(
-                ABC_KEY_ITEM,
-                KeyItemC(
-                    center = KeyC(",", size = LARGE),
-                ),
-                KeyItemC(
-                    center = KeyC("1", size = LARGE),
-                    topLeft = KeyC("["),
-                    bottomLeft = KeyC("<"),
-                ),
-                KeyItemC(
-                    center = KeyC("2", size = LARGE),
-                    top = KeyC("*"),
-                    left = KeyC("/"),
-                    right = KeyC("\\"),
-                ),
-                KeyItemC(
-                    center = KeyC("3", size = LARGE),
-                    left = KeyC("|"),
-                    topRight = KeyC("]"),
-                    bottomRight = KeyC(">"),
                 ),
                 EMOJI_KEY_ITEM,
             ),


### PR DESCRIPTION
Updates Hyper's number/symbol layer with suggestions from @KraXen72 #1283 thanks!
![Screenshot 2025-02-28 at 18 58 14](https://github.com/user-attachments/assets/4be56ebd-34f1-4073-b086-fdf67082df8e)

Reorders punctuation on Hyper/Hyper space slightly to better reflect usage.
![Screenshot 2025-02-28 at 19 00 02](https://github.com/user-attachments/assets/1097c23b-a3cc-4fdc-a3a2-bf043d369ae3)
