### PR TITLE
Smart Quotes „“ Tested

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbKeySymNum.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbKeySymNum.kt
@@ -29,8 +29,8 @@ val KB_DE_THUMBKEY_SYMNUM_MAIN =
                         ),
                     left =
                         KeyC(
-                            display = KeyDisplay.TextDisplay("¿¡"), // mi
-                            action = ComposeLastKey("!"),
+                            display = KeyDisplay.TextDisplay("„“"), // mi
+                            action = SmartQuotes("„", "“"),
                             color = MUTED,
                         ),
                 ),
@@ -165,8 +165,8 @@ val KB_DE_THUMBKEY_SYMNUM_SHIFTED =
                     right = KeyC("-", color = MUTED),
                     left =
                         KeyC(
-                            display = KeyDisplay.TextDisplay("¿¡"), // mi
-                            action = CommitText("!"),
+                            display = KeyDisplay.TextDisplay("„“"), // mi
+                            action = SmartQuotes("„", "“"),
                             color = MUTED,
                         ),
                 ),

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
@@ -150,6 +150,11 @@ sealed class KeyAction {
         val text: String,
     ) : KeyAction()
 
+    class SmartQuotes(
+        val start: String,
+        val end: String,
+    ) : KeyAction()
+
     sealed class MoveKeyboard : KeyAction() {
         class ToPosition(
             val position: KeyboardPosition,

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -398,7 +398,8 @@ fun performKeyAction(
         }
 
         is KeyAction.SmartQuotes -> {
-            val textNew = if (ime.currentInputConnection.getTextBeforeCursor(1, 0).matches(Regex("\\S"))) action.end else action.start
+            val textBeforeCursor = ime.currentInputConnection.getTextBeforeCursor(1, 0)?.toString() ?: ""
+            val textNew = if (textBeforeCursor.matches(Regex("\\S"))) action.end else action.start
             ime.currentInputConnection.commitText(textNew, 1)
         }
 

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -401,7 +401,7 @@ fun performKeyAction(
             val textNew = if (ime.currentInputConnection.getTextBeforeCursor(1, 0).matches(Regex("\\S"))) action.end else action.start
             ime.currentInputConnection.commitText(textNew, 1)
         }
-        
+
         is KeyAction.ComposeLastKey -> {
             Log.d(TAG, "composing last key")
             val text = action.text

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -397,6 +397,11 @@ fun performKeyAction(
             }
         }
 
+        is KeyAction.SmartQuotes -> {
+            val textNew = if (ime.currentInputConnection.getTextBeforeCursor(1, 0).matches(Regex("\\S"))) action.end else action.start
+            ime.currentInputConnection.commitText(textNew, 1)
+        }
+        
         is KeyAction.ComposeLastKey -> {
             Log.d(TAG, "composing last key")
             val text = action.text


### PR DESCRIPTION
I've run this on my phone since December without problems.
It allows to easily add beginning and ending quotes to keyboard layouts and activating it causes it to place the beginning quote or, if the UTF-16 codepoint behind the caret matches non-whitespace (empty string does not match), the ending quote.

Even if a grapheme cluster were to use multiple code points, it seems each individual codepoint it is made up of is either in the whitespace group or the non-whitespace group. It placed “ on all emojis I've tested so far.