### PR TITLE
Add hungarian-optimized engram layout

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/HUngramTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/HUngramTypeSplit.kt
@@ -2,6 +2,9 @@
 
 package com.dessalines.thumbkey.keyboards
 
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.*
 import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
@@ -22,19 +25,23 @@ val KB_HU_HUNGRAM_MAIN =
                 KeyItemC(
                     center = KeyC("z", size = LARGE),
                     swipeType = FOUR_WAY_CROSS,
-                    top = KeyC("c"),
+                    bottom = KeyC("c"),
                     right = KeyC("ó"),
                 ),
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
                     swipeType = FOUR_WAY_CROSS,
-                    top = KeyC("y"),
+                    left = KeyC("&"),
+                    bottom = KeyC("y"),
                     right = KeyC("ú"),
                 ),
                 KeyItemC(
                     center = KeyC("s", size = LARGE),
                     swipeType = FOUR_WAY_CROSS,
-                    top = KeyC("ü"),
+                    bottom = KeyC("ü"),
+                    right = KeyC("+"),
+                    top = KeyC("%"),
+                    left = KeyC("="),
                 ),
                 KeyItemC(
                     center = KeyC("m", size = LARGE),
@@ -61,6 +68,10 @@ val KB_HU_HUNGRAM_MAIN =
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
                     swipeType = FOUR_WAY_CROSS,
+                    top = KeyC("@"),
+                    right = KeyC("\\"),
+                    bottom = KeyC("#"),
+                    left = KeyC("&"),
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
@@ -68,6 +79,7 @@ val KB_HU_HUNGRAM_MAIN =
                     left = KeyC(";"),
                     top = KeyC(":"),
                     right = KeyC("-"),
+                    bottom = KeyC("_"),
                 ),
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
@@ -75,10 +87,25 @@ val KB_HU_HUNGRAM_MAIN =
                     left = KeyC("'"),
                     top = KeyC("\""),
                     right = KeyC("*"),
+                    bottom = KeyC("|"),
                 ),
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
                     swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("/"),
+                    right = KeyC("^"),
+                    top =
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
+                            action = ToggleShiftMode(true),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(true),
+                            color = MUTED,
+                        ),
+                    bottom =
+                        KeyC(
+                            ToggleShiftMode(false),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(false),
+                        ),
                 ),
                 KeyItemC(
                     center = KeyC("l", size = LARGE),
@@ -102,17 +129,19 @@ val KB_HU_HUNGRAM_MAIN =
                     top = KeyC("{"),
                     right = KeyC("["),
                     bottom = KeyC("("),
+                    left = KeyC("<"),
                 ),
                 KeyItemC(
                     center = KeyC("g", size = LARGE),
                     swipeType = FOUR_WAY_CROSS,
                     left = KeyC("]"),
                     top = KeyC("}"),
-                    right = KeyC("v"),
+                    right = KeyC(">"),
                     bottom = KeyC(")"),
                 ),
                 KeyItemC(
                     center = KeyC("f", size = LARGE),
+                    left = KeyC("v"),
                     swipeType = FOUR_WAY_CROSS,
                 ),
                 KeyItemC(
@@ -123,10 +152,11 @@ val KB_HU_HUNGRAM_MAIN =
             ),
             listOf(
                 NUMERIC_KEY_ITEM_ALT,
-                EMOJI_KEY_ITEM_ALT,
-                SPACEBAR_DOUBLE_KEY_ITEM,
-                BACKSPACE_TYPESPLIT_KEY_ITEM,
+                BACKSPACE_KEY_ITEM,
+                SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM.copy(widthMultiplier = 2,
+                 top = KeyC(".", color = MUTED),),
                 RETURN_KEY_ITEM,
+                EMOJI_KEY_ITEM_ALT,
             ),
         ),
     )
@@ -145,19 +175,23 @@ val KB_HU_HUNGRAM_SHIFTED =
                 KeyItemC(
                     center = KeyC("Z", size = LARGE),
                     swipeType = FOUR_WAY_CROSS,
-                    top = KeyC("C"),
+                    bottom = KeyC("C"),
                     right = KeyC("Ó"),
                 ),
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
                     swipeType = FOUR_WAY_CROSS,
-                    top = KeyC("Y"),
+                    left = KeyC("&"),
+                    bottom = KeyC("Y"),
                     right = KeyC("Ú"),
                 ),
                 KeyItemC(
                     center = KeyC("S", size = LARGE),
                     swipeType = FOUR_WAY_CROSS,
-                    top = KeyC("Ü"),
+                    bottom = KeyC("Ü"),
+                    right = KeyC("+"),
+                    top = KeyC("%"),
+                    left = KeyC("="),
                 ),
                 KeyItemC(
                     center = KeyC("M", size = LARGE),
@@ -184,6 +218,10 @@ val KB_HU_HUNGRAM_SHIFTED =
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
                     swipeType = FOUR_WAY_CROSS,
+                    top = KeyC("@"),
+                    right = KeyC("\\"),
+                    bottom = KeyC("#"),
+                    left = KeyC("&"),
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
@@ -191,6 +229,7 @@ val KB_HU_HUNGRAM_SHIFTED =
                     left = KeyC(";"),
                     top = KeyC(":"),
                     right = KeyC("-"),
+                    bottom = KeyC("_"),
                 ),
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
@@ -198,10 +237,25 @@ val KB_HU_HUNGRAM_SHIFTED =
                     left = KeyC("'"),
                     top = KeyC("\""),
                     right = KeyC("*"),
+                    bottom = KeyC("|"),
                 ),
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
                     swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("/"),
+                    right = KeyC("^"),
+                    top =
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
+                            action = ToggleShiftMode(true),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(true),
+                            color = MUTED,
+                        ),
+                    bottom =
+                        KeyC(
+                            ToggleShiftMode(false),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(false),
+                        ),
                 ),
                 KeyItemC(
                     center = KeyC("L", size = LARGE),
@@ -225,17 +279,19 @@ val KB_HU_HUNGRAM_SHIFTED =
                     top = KeyC("{"),
                     right = KeyC("["),
                     bottom = KeyC("("),
+                    left = KeyC("<"),
                 ),
                 KeyItemC(
                     center = KeyC("G", size = LARGE),
                     swipeType = FOUR_WAY_CROSS,
                     left = KeyC("]"),
                     top = KeyC("}"),
-                    right = KeyC("v"),
+                    right = KeyC(">"),
                     bottom = KeyC(")"),
                 ),
                 KeyItemC(
                     center = KeyC("F", size = LARGE),
+                    left = KeyC("V"),
                     swipeType = FOUR_WAY_CROSS,
                 ),
                 KeyItemC(
@@ -247,7 +303,8 @@ val KB_HU_HUNGRAM_SHIFTED =
             listOf(
                 NUMERIC_KEY_ITEM_ALT,
                 BACKSPACE_KEY_ITEM,
-                SPACEBAR_DOUBLE_KEY_ITEM,
+                SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM.copy(widthMultiplier = 2,
+                 top = KeyC(".", color = MUTED),),
                 RETURN_KEY_ITEM,
                 EMOJI_KEY_ITEM_ALT,
             ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/HUngramTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/HUngramTypeSplit.kt
@@ -1,0 +1,266 @@
+@file:Suppress("ktlint:standard:no-wildcard-imports")
+
+package com.dessalines.thumbkey.keyboards
+
+import com.dessalines.thumbkey.utils.*
+import com.dessalines.thumbkey.utils.ColorVariant.*
+import com.dessalines.thumbkey.utils.FontSizeVariant.*
+import com.dessalines.thumbkey.utils.KeyAction.*
+import com.dessalines.thumbkey.utils.SwipeNWay.*
+
+val KB_HU_HUNGRAM_MAIN =
+    KeyboardC(
+        listOf(
+            listOf(
+                KeyItemC(
+                    center = KeyC("á", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    top = KeyC("ő"),
+                    right = KeyC("`"),
+                    bottom = KeyC("ö"),
+                ),
+                KeyItemC(
+                    center = KeyC("z", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    top = KeyC("c"),
+                    right = KeyC("ó"),
+                ),
+                KeyItemC(
+                    center = KeyC("e", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    top = KeyC("y"),
+                    right = KeyC("ú"),
+                ),
+                KeyItemC(
+                    center = KeyC("s", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    top = KeyC("ü"),
+                ),
+                KeyItemC(
+                    center = KeyC("m", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("!"),
+                    top = KeyC("?"),
+                    right = KeyC("x"),
+                    bottom = KeyC("h"),
+                ),
+                KeyItemC(
+                    center = KeyC("r", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("b"),
+                    top = KeyC("ű"),
+                    bottom = KeyC("w"),
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("i", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    top = KeyC("í"),
+                ),
+                KeyItemC(
+                    center = KeyC("o", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                ),
+                KeyItemC(
+                    center = KeyC("a", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC(";"),
+                    top = KeyC(":"),
+                    right = KeyC("-"),
+                ),
+                KeyItemC(
+                    center = KeyC("t", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("'"),
+                    top = KeyC("\""),
+                    right = KeyC("*"),
+                ),
+                KeyItemC(
+                    center = KeyC("n", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                ),
+                KeyItemC(
+                    center = KeyC("l", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    top = KeyC("j"),
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("p", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                ),
+                KeyItemC(
+                    center = KeyC("é", size = LARGE),
+                    swipeType = TWO_WAY_HORIZONTAL,
+                    right = KeyC("u"),
+                ),
+                KeyItemC(
+                    center = KeyC("d", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    top = KeyC("{"),
+                    right = KeyC("["),
+                    bottom = KeyC("("),
+                ),
+                KeyItemC(
+                    center = KeyC("g", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("]"),
+                    top = KeyC("}"),
+                    right = KeyC("v"),
+                    bottom = KeyC(")"),
+                ),
+                KeyItemC(
+                    center = KeyC("f", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                ),
+                KeyItemC(
+                    center = KeyC("k", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    top = KeyC("q"),
+                ),
+            ),
+            listOf(
+                NUMERIC_KEY_ITEM_ALT,
+                EMOJI_KEY_ITEM_ALT,
+                SPACEBAR_DOUBLE_KEY_ITEM,
+                BACKSPACE_TYPESPLIT_KEY_ITEM,
+                RETURN_KEY_ITEM,
+            ),
+        ),
+    )
+
+val KB_HU_HUNGRAM_SHIFTED =
+    KeyboardC(
+        listOf(
+            listOf(
+                KeyItemC(
+                    center = KeyC("Á", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    top = KeyC("Ő"),
+                    right = KeyC("`"),
+                    bottom = KeyC("Ö"),
+                ),
+                KeyItemC(
+                    center = KeyC("Z", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    top = KeyC("C"),
+                    right = KeyC("Ó"),
+                ),
+                KeyItemC(
+                    center = KeyC("E", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    top = KeyC("Y"),
+                    right = KeyC("Ú"),
+                ),
+                KeyItemC(
+                    center = KeyC("S", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    top = KeyC("Ü"),
+                ),
+                KeyItemC(
+                    center = KeyC("M", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("!"),
+                    top = KeyC("?"),
+                    right = KeyC("X"),
+                    bottom = KeyC("H"),
+                ),
+                KeyItemC(
+                    center = KeyC("R", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("B"),
+                    top = KeyC("Ű"),
+                    bottom = KeyC("W"),
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("I", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    top = KeyC("Í"),
+                ),
+                KeyItemC(
+                    center = KeyC("O", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                ),
+                KeyItemC(
+                    center = KeyC("A", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC(";"),
+                    top = KeyC(":"),
+                    right = KeyC("-"),
+                ),
+                KeyItemC(
+                    center = KeyC("T", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("'"),
+                    top = KeyC("\""),
+                    right = KeyC("*"),
+                ),
+                KeyItemC(
+                    center = KeyC("N", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                ),
+                KeyItemC(
+                    center = KeyC("L", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    top = KeyC("J"),
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("P", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                ),
+                KeyItemC(
+                    center = KeyC("É", size = LARGE),
+                    swipeType = TWO_WAY_HORIZONTAL,
+                    right = KeyC("U"),
+                ),
+                KeyItemC(
+                    center = KeyC("D", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    top = KeyC("{"),
+                    right = KeyC("["),
+                    bottom = KeyC("("),
+                ),
+                KeyItemC(
+                    center = KeyC("G", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("]"),
+                    top = KeyC("}"),
+                    right = KeyC("v"),
+                    bottom = KeyC(")"),
+                ),
+                KeyItemC(
+                    center = KeyC("F", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                ),
+                KeyItemC(
+                    center = KeyC("K", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    top = KeyC("Q"),
+                ),
+            ),
+            listOf(
+                NUMERIC_KEY_ITEM_ALT,
+                BACKSPACE_KEY_ITEM,
+                SPACEBAR_DOUBLE_KEY_ITEM,
+                RETURN_KEY_ITEM,
+                EMOJI_KEY_ITEM_ALT,
+            ),
+        ),
+    )
+
+val KB_HU_HUNGRAM: KeyboardDefinition =
+    KeyboardDefinition(
+        title = "hungram",
+        modes =
+            KeyboardDefinitionModes(
+                main = KB_HU_HUNGRAM_MAIN,
+                shifted = KB_HU_HUNGRAM_SHIFTED,
+                numeric = TYPESPLIT_NUMERIC_KEYBOARD,
+            ),
+    )

--- a/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
@@ -120,6 +120,7 @@ import com.dessalines.thumbkey.keyboards.KB_HI_THUMBKEY_EXTENDED
 import com.dessalines.thumbkey.keyboards.KB_HR_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_HR_THUMBKEY_SYMBOLS
 import com.dessalines.thumbkey.keyboards.KB_HR_TWO_HANDS
+import com.dessalines.thumbkey.keyboards.KB_HU_HUNGRAM
 import com.dessalines.thumbkey.keyboards.KB_HU_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_HU_TYPESPLIT
 import com.dessalines.thumbkey.keyboards.KB_ID_THUMBKEY_SYMBOLS_NUMBERS_V1
@@ -356,4 +357,5 @@ enum class KeyboardLayout(
     ENESCAENTwoHands(KB_EN_ES_CA_TWO_HANDS),
     DEThumbKeyWords(KB_DE_THUMBKEY_WORDS),
     RUMessageOwl(KB_RU_MESSAGE_OWL),
+    HUngram(KB_HU_HUNGRAM),
 }


### PR DESCRIPTION
For me the hungarian qwertz layout in this app was really not optimal, so I've took a letter frequency chart, and created this layout in a 3x8 grid, based on my friend's work, who's created a hungarian layout using Arno Klein's work on the Engram layout. I've been using this for a couple of weeks now, and it feels way better than other layouts.

So I've named the layout 'hungram'.