### PR TITLE
Added Keyboard: MessagEase German Left / Inverted Numpad

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEase.kt
@@ -8,7 +8,6 @@ import com.dessalines.thumbkey.utils.*
 import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
-import com.dessalines.thumbkey.utils.SwipeNWay.*
 
 val KB_DE_MESSAGEASE_MAIN =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEaseInvertedNumpad.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEaseInvertedNumpad.kt
@@ -9,7 +9,6 @@ import com.dessalines.thumbkey.utils.KeyboardC
 import com.dessalines.thumbkey.utils.KeyboardDefinition
 import com.dessalines.thumbkey.utils.KeyboardDefinitionModes
 import com.dessalines.thumbkey.utils.getLocalCurrency
-import com.dessalines.thumbkey.utils.lastColKeysToFirst
 
 val KB_DE_MESSAGEASE_INVERTED_NUMPAD_NUMERIC =
     KeyboardC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEaseInvertedNumpad.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEaseInvertedNumpad.kt
@@ -11,11 +11,10 @@ import com.dessalines.thumbkey.utils.KeyboardDefinitionModes
 import com.dessalines.thumbkey.utils.getLocalCurrency
 import com.dessalines.thumbkey.utils.lastColKeysToFirst
 
-val KB_DE_MESSAGEASE_LEFT_NUMERIC =
+val KB_DE_MESSAGEASE_INVERTED_NUMPAD_NUMERIC =
     KeyboardC(
         listOf(
             listOf(
-                EMOJI_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("7", size = LARGE),
                     bottomLeft = KeyC("$"),
@@ -46,9 +45,9 @@ val KB_DE_MESSAGEASE_LEFT_NUMERIC =
                     bottomLeft = KeyC("£"),
                     bottom = KeyC("="),
                 ),
+                EMOJI_KEY_ITEM,
             ),
             listOf(
-                ABC_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("4", size = LARGE),
                     topLeft = KeyC("{"),
@@ -69,9 +68,9 @@ val KB_DE_MESSAGEASE_LEFT_NUMERIC =
                     bottomRight = KeyC("]"),
                     bottomLeft = KeyC("@"),
                 ),
+                ABC_KEY_ITEM,
             ),
             listOf(
-                BACKSPACE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("1", size = LARGE),
                     topLeft = KeyC("~"),
@@ -95,25 +94,26 @@ val KB_DE_MESSAGEASE_LEFT_NUMERIC =
                     bottomLeft = KeyC(";"),
                     left = KeyC("#"),
                 ),
+                BACKSPACE_KEY_ITEM,
             ),
             listOf(
-                RETURN_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("0", size = LARGE),
                     widthMultiplier = 2,
                 ),
                 SPACEBAR_SKINNY_KEY_ITEM,
+                RETURN_KEY_ITEM,
             ),
         ),
     )
 
-val KB_DE_MESSAGEASE_LEFT_INVERTED_KEYPAD: KeyboardDefinition =
+val KB_DE_MESSAGEASE_INVERTED_NUMPAD: KeyboardDefinition =
     KeyboardDefinition(
-        title = "deutsch messagease left-handed, inverted keypad",
+        title = "deutsch messagease, inverted numpad",
         modes =
             KeyboardDefinitionModes(
-                main = lastColKeysToFirst(KB_DE_MESSAGEASE_MAIN),
-                shifted = lastColKeysToFirst(KB_DE_MESSAGEASE_SHIFTED),
-                numeric = KB_DE_MESSAGEASE_LEFT_NUMERIC,
+                main = KB_DE_MESSAGEASE_MAIN,
+                shifted = KB_DE_MESSAGEASE_SHIFTED,
+                numeric = KB_DE_MESSAGEASE_INVERTED_NUMPAD_NUMERIC,
             ),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEaseLeft.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEaseLeft.kt
@@ -2,118 +2,17 @@
 
 package com.dessalines.thumbkey.keyboards
 
-import com.dessalines.thumbkey.utils.FontSizeVariant.LARGE
-import com.dessalines.thumbkey.utils.KeyC
-import com.dessalines.thumbkey.utils.KeyItemC
-import com.dessalines.thumbkey.utils.KeyboardC
 import com.dessalines.thumbkey.utils.KeyboardDefinition
 import com.dessalines.thumbkey.utils.KeyboardDefinitionModes
-import com.dessalines.thumbkey.utils.getLocalCurrency
 import com.dessalines.thumbkey.utils.lastColKeysToFirst
-
-val KB_DE_MESSAGEASE_LEFT_NUMERIC =
-    KeyboardC(
-        listOf(
-            listOf(
-                EMOJI_KEY_ITEM,
-                KeyItemC(
-                    center = KeyC("7", size = LARGE),
-                    bottomLeft = KeyC("$"),
-                    right = KeyC("-"),
-                    bottomRight =
-                        getLocalCurrency()?.let {
-                            if (it !in setOf("$", "£", "€")) {
-                                KeyC(it)
-                            } else {
-                                null
-                            }
-                        },
-                ),
-                KeyItemC(
-                    center = KeyC("8", size = LARGE),
-                    topLeft = KeyC("`"),
-                    top = KeyC("^"),
-                    topRight = KeyC("´"),
-                    right = KeyC("!"),
-                    bottomRight = KeyC("\\"),
-                    bottomLeft = KeyC("/"),
-                    left = KeyC("+"),
-                ),
-                KeyItemC(
-                    center = KeyC("9", size = LARGE),
-                    left = KeyC("?"),
-                    bottomRight = KeyC("€"),
-                    bottomLeft = KeyC("£"),
-                    bottom = KeyC("="),
-                ),
-            ),
-            listOf(
-                ABC_KEY_ITEM,
-                KeyItemC(
-                    center = KeyC("4", size = LARGE),
-                    topLeft = KeyC("{"),
-                    topRight = KeyC("%"),
-                    bottomRight = KeyC("_"),
-                    bottomLeft = KeyC("["),
-                    left = KeyC("("),
-                ),
-                KeyItemC(
-                    center = KeyC("5", size = LARGE),
-                    top = KeyC("¬"),
-                ),
-                KeyItemC(
-                    center = KeyC("6", size = LARGE),
-                    topLeft = KeyC("|"),
-                    topRight = KeyC("}"),
-                    right = KeyC(")"),
-                    bottomRight = KeyC("]"),
-                    bottomLeft = KeyC("@"),
-                ),
-            ),
-            listOf(
-                BACKSPACE_KEY_ITEM,
-                KeyItemC(
-                    center = KeyC("1", size = LARGE),
-                    topLeft = KeyC("~"),
-                    left = KeyC("<"),
-                    right = KeyC("*"),
-                    bottomRight = KeyC("\t", displayText = "⇥"),
-                ),
-                KeyItemC(
-                    center = KeyC("2", size = LARGE),
-                    topLeft = KeyC("\""),
-                    topRight = KeyC("'"),
-                    bottomRight = KeyC(":"),
-                    bottom = KeyC("."),
-                    bottomLeft = KeyC(","),
-                ),
-                KeyItemC(
-                    center = KeyC("3", size = LARGE),
-                    top = KeyC("&"),
-                    topRight = KeyC("°"),
-                    right = KeyC(">"),
-                    bottomLeft = KeyC(";"),
-                    left = KeyC("#"),
-                ),
-            ),
-            listOf(
-                RETURN_KEY_ITEM,
-                KeyItemC(
-                    center = KeyC("0", size = LARGE),
-                    widthMultiplier = 2,
-                ),
-                SPACEBAR_SKINNY_KEY_ITEM,
-            ),
-        ),
-    )
 
 val KB_DE_MESSAGEASE_LEFT: KeyboardDefinition =
     KeyboardDefinition(
         title = "deutsch messagease left-handed",
         modes =
-            KeyboardDefinitionModes(
-                main = lastColKeysToFirst(KB_DE_MESSAGEASE_MAIN),
-                shifted = lastColKeysToFirst(KB_DE_MESSAGEASE_SHIFTED),
-                numeric = KB_DE_MESSAGEASE_LEFT_NUMERIC,
-            ),
+        KeyboardDefinitionModes(
+            main = lastColKeysToFirst(KB_DE_MESSAGEASE_MAIN),
+            shifted = lastColKeysToFirst(KB_DE_MESSAGEASE_SHIFTED),
+            numeric = lastColKeysToFirst(KB_EN_MESSAGEASE_NUMERIC),
+        ),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEaseLeft.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEaseLeft.kt
@@ -10,9 +10,9 @@ val KB_DE_MESSAGEASE_LEFT: KeyboardDefinition =
     KeyboardDefinition(
         title = "deutsch messagease left-handed",
         modes =
-        KeyboardDefinitionModes(
-            main = lastColKeysToFirst(KB_DE_MESSAGEASE_MAIN),
-            shifted = lastColKeysToFirst(KB_DE_MESSAGEASE_SHIFTED),
-            numeric = lastColKeysToFirst(KB_EN_MESSAGEASE_NUMERIC),
-        ),
+            KeyboardDefinitionModes(
+                main = lastColKeysToFirst(KB_DE_MESSAGEASE_MAIN),
+                shifted = lastColKeysToFirst(KB_DE_MESSAGEASE_SHIFTED),
+                numeric = lastColKeysToFirst(KB_EN_MESSAGEASE_NUMERIC),
+            ),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEaseLeft.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEaseLeft.kt
@@ -1,0 +1,119 @@
+@file:Suppress("ktlint:standard:no-wildcard-imports")
+
+package com.dessalines.thumbkey.keyboards
+
+import com.dessalines.thumbkey.utils.FontSizeVariant.LARGE
+import com.dessalines.thumbkey.utils.KeyC
+import com.dessalines.thumbkey.utils.KeyItemC
+import com.dessalines.thumbkey.utils.KeyboardC
+import com.dessalines.thumbkey.utils.KeyboardDefinition
+import com.dessalines.thumbkey.utils.KeyboardDefinitionModes
+import com.dessalines.thumbkey.utils.getLocalCurrency
+import com.dessalines.thumbkey.utils.lastColKeysToFirst
+
+val KB_DE_MESSAGEASE_LEFT_NUMERIC =
+    KeyboardC(
+        listOf(
+            listOf(
+                EMOJI_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("7", size = LARGE),
+                    bottomLeft = KeyC("$"),
+                    right = KeyC("-"),
+                    bottomRight =
+                        getLocalCurrency()?.let {
+                            if (it !in setOf("$", "£", "€")) {
+                                KeyC(it)
+                            } else {
+                                null
+                            }
+                        },
+                ),
+                KeyItemC(
+                    center = KeyC("8", size = LARGE),
+                    topLeft = KeyC("`"),
+                    top = KeyC("^"),
+                    topRight = KeyC("´"),
+                    right = KeyC("!"),
+                    bottomRight = KeyC("\\"),
+                    bottomLeft = KeyC("/"),
+                    left = KeyC("+"),
+                ),
+                KeyItemC(
+                    center = KeyC("9", size = LARGE),
+                    left = KeyC("?"),
+                    bottomRight = KeyC("€"),
+                    bottomLeft = KeyC("£"),
+                    bottom = KeyC("="),
+                ),
+            ),
+            listOf(
+                ABC_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("4", size = LARGE),
+                    topLeft = KeyC("{"),
+                    topRight = KeyC("%"),
+                    bottomRight = KeyC("_"),
+                    bottomLeft = KeyC("["),
+                    left = KeyC("("),
+                ),
+                KeyItemC(
+                    center = KeyC("5", size = LARGE),
+                    top = KeyC("¬"),
+                ),
+                KeyItemC(
+                    center = KeyC("6", size = LARGE),
+                    topLeft = KeyC("|"),
+                    topRight = KeyC("}"),
+                    right = KeyC(")"),
+                    bottomRight = KeyC("]"),
+                    bottomLeft = KeyC("@"),
+                ),
+            ),
+            listOf(
+                BACKSPACE_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("1", size = LARGE),
+                    topLeft = KeyC("~"),
+                    left = KeyC("<"),
+                    right = KeyC("*"),
+                    bottomRight = KeyC("\t", displayText = "⇥"),
+                ),
+                KeyItemC(
+                    center = KeyC("2", size = LARGE),
+                    topLeft = KeyC("\""),
+                    topRight = KeyC("'"),
+                    bottomRight = KeyC(":"),
+                    bottom = KeyC("."),
+                    bottomLeft = KeyC(","),
+                ),
+                KeyItemC(
+                    center = KeyC("3", size = LARGE),
+                    top = KeyC("&"),
+                    topRight = KeyC("°"),
+                    right = KeyC(">"),
+                    bottomLeft = KeyC(";"),
+                    left = KeyC("#"),
+                ),
+            ),
+            listOf(
+                RETURN_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("0", size = LARGE),
+                    widthMultiplier = 2,
+                ),
+                SPACEBAR_SKINNY_KEY_ITEM,
+            ),
+        ),
+    )
+
+val KB_DE_MESSAGEASE_LEFT: KeyboardDefinition =
+    KeyboardDefinition(
+        title = "deutsch messagease left-handed",
+        modes =
+            KeyboardDefinitionModes(
+                main = lastColKeysToFirst(KB_DE_MESSAGEASE_MAIN),
+                shifted = lastColKeysToFirst(KB_DE_MESSAGEASE_SHIFTED),
+                numeric = KB_DE_MESSAGEASE_LEFT_NUMERIC,
+            ),
+    )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEaseLeftInvertedKeypad.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEaseLeftInvertedKeypad.kt
@@ -1,0 +1,119 @@
+@file:Suppress("ktlint:standard:no-wildcard-imports")
+
+package com.dessalines.thumbkey.keyboards
+
+import com.dessalines.thumbkey.utils.FontSizeVariant.LARGE
+import com.dessalines.thumbkey.utils.KeyC
+import com.dessalines.thumbkey.utils.KeyItemC
+import com.dessalines.thumbkey.utils.KeyboardC
+import com.dessalines.thumbkey.utils.KeyboardDefinition
+import com.dessalines.thumbkey.utils.KeyboardDefinitionModes
+import com.dessalines.thumbkey.utils.getLocalCurrency
+import com.dessalines.thumbkey.utils.lastColKeysToFirst
+
+val KB_DE_MESSAGEASE_LEFT_NUMERIC =
+    KeyboardC(
+        listOf(
+            listOf(
+                EMOJI_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("7", size = LARGE),
+                    bottomLeft = KeyC("$"),
+                    right = KeyC("-"),
+                    bottomRight =
+                        getLocalCurrency()?.let {
+                            if (it !in setOf("$", "£", "€")) {
+                                KeyC(it)
+                            } else {
+                                null
+                            }
+                        },
+                ),
+                KeyItemC(
+                    center = KeyC("8", size = LARGE),
+                    topLeft = KeyC("`"),
+                    top = KeyC("^"),
+                    topRight = KeyC("´"),
+                    right = KeyC("!"),
+                    bottomRight = KeyC("\\"),
+                    bottomLeft = KeyC("/"),
+                    left = KeyC("+"),
+                ),
+                KeyItemC(
+                    center = KeyC("9", size = LARGE),
+                    left = KeyC("?"),
+                    bottomRight = KeyC("€"),
+                    bottomLeft = KeyC("£"),
+                    bottom = KeyC("="),
+                ),
+            ),
+            listOf(
+                ABC_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("4", size = LARGE),
+                    topLeft = KeyC("{"),
+                    topRight = KeyC("%"),
+                    bottomRight = KeyC("_"),
+                    bottomLeft = KeyC("["),
+                    left = KeyC("("),
+                ),
+                KeyItemC(
+                    center = KeyC("5", size = LARGE),
+                    top = KeyC("¬"),
+                ),
+                KeyItemC(
+                    center = KeyC("6", size = LARGE),
+                    topLeft = KeyC("|"),
+                    topRight = KeyC("}"),
+                    right = KeyC(")"),
+                    bottomRight = KeyC("]"),
+                    bottomLeft = KeyC("@"),
+                ),
+            ),
+            listOf(
+                BACKSPACE_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("1", size = LARGE),
+                    topLeft = KeyC("~"),
+                    left = KeyC("<"),
+                    right = KeyC("*"),
+                    bottomRight = KeyC("\t", displayText = "⇥"),
+                ),
+                KeyItemC(
+                    center = KeyC("2", size = LARGE),
+                    topLeft = KeyC("\""),
+                    topRight = KeyC("'"),
+                    bottomRight = KeyC(":"),
+                    bottom = KeyC("."),
+                    bottomLeft = KeyC(","),
+                ),
+                KeyItemC(
+                    center = KeyC("3", size = LARGE),
+                    top = KeyC("&"),
+                    topRight = KeyC("°"),
+                    right = KeyC(">"),
+                    bottomLeft = KeyC(";"),
+                    left = KeyC("#"),
+                ),
+            ),
+            listOf(
+                RETURN_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("0", size = LARGE),
+                    widthMultiplier = 2,
+                ),
+                SPACEBAR_SKINNY_KEY_ITEM,
+            ),
+        ),
+    )
+
+val KB_DE_MESSAGEASE_LEFT_INVERTED_KEYPAD: KeyboardDefinition =
+    KeyboardDefinition(
+        title = "deutsch messagease left-handed, inverted keypad",
+        modes =
+            KeyboardDefinitionModes(
+                main = lastColKeysToFirst(KB_DE_MESSAGEASE_MAIN),
+                shifted = lastColKeysToFirst(KB_DE_MESSAGEASE_SHIFTED),
+                numeric = KB_DE_MESSAGEASE_LEFT_NUMERIC,
+            ),
+    )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEaseLeftInvertedNumpad.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEaseLeftInvertedNumpad.kt
@@ -1,0 +1,18 @@
+@file:Suppress("ktlint:standard:no-wildcard-imports")
+
+package com.dessalines.thumbkey.keyboards
+
+import com.dessalines.thumbkey.utils.KeyboardDefinition
+import com.dessalines.thumbkey.utils.KeyboardDefinitionModes
+import com.dessalines.thumbkey.utils.lastColKeysToFirst
+
+val KB_DE_MESSAGEASE_LEFT_INVERTED_NUMPAD: KeyboardDefinition =
+    KeyboardDefinition(
+        title = "deutsch messagease left-handed, inverted numpad",
+        modes =
+            KeyboardDefinitionModes(
+                main = lastColKeysToFirst(KB_DE_MESSAGEASE_MAIN),
+                shifted = lastColKeysToFirst(KB_DE_MESSAGEASE_SHIFTED),
+                numeric = lastColKeysToFirst(KB_DE_MESSAGEASE_INVERTED_NUMPAD_NUMERIC),
+            ),
+    )

--- a/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
@@ -13,6 +13,7 @@ import com.dessalines.thumbkey.keyboards.KB_CZ_MESSAGEASE_PROGRAMMING
 import com.dessalines.thumbkey.keyboards.KB_DA_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_DE_MESSAGEASE
 import com.dessalines.thumbkey.keyboards.KB_DE_MESSAGEASE_LEFT
+import com.dessalines.thumbkey.keyboards.KB_DE_MESSAGEASE_LEFT_INVERTED_KEYPAD
 import com.dessalines.thumbkey.keyboards.KB_DE_MESSAGEASE_SYMBOLS
 import com.dessalines.thumbkey.keyboards.KB_DE_NORDIC_MESSAGEASE
 import com.dessalines.thumbkey.keyboards.KB_DE_THUMBKEY
@@ -366,4 +367,5 @@ enum class KeyboardLayout(
     GRThumbKeyNormal(KB_GRNORM_THUMBKEY),
     GRNormThumbKeySymbols(KB_GRNORM_THUMBKEY_SYMBOLS),
     DEMessagEaseLeft(KB_DE_MESSAGEASE_LEFT),
+    DEMessagEaseLeftInvertedKeypad(KB_DE_MESSAGEASE_LEFT_INVERTED_KEYPAD),
 }

--- a/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
@@ -12,8 +12,9 @@ import com.dessalines.thumbkey.keyboards.KB_CA_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_CZ_MESSAGEASE_PROGRAMMING
 import com.dessalines.thumbkey.keyboards.KB_DA_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_DE_MESSAGEASE
+import com.dessalines.thumbkey.keyboards.KB_DE_MESSAGEASE_INVERTED_NUMPAD
 import com.dessalines.thumbkey.keyboards.KB_DE_MESSAGEASE_LEFT
-import com.dessalines.thumbkey.keyboards.KB_DE_MESSAGEASE_LEFT_INVERTED_KEYPAD
+import com.dessalines.thumbkey.keyboards.KB_DE_MESSAGEASE_LEFT_INVERTED_NUMPAD
 import com.dessalines.thumbkey.keyboards.KB_DE_MESSAGEASE_SYMBOLS
 import com.dessalines.thumbkey.keyboards.KB_DE_NORDIC_MESSAGEASE
 import com.dessalines.thumbkey.keyboards.KB_DE_THUMBKEY
@@ -366,6 +367,7 @@ enum class KeyboardLayout(
     ENThumbkeyFlippedNumpad(KB_EN_THUMBKEY_FLIPPED_NUMPAD),
     GRThumbKeyNormal(KB_GRNORM_THUMBKEY),
     GRNormThumbKeySymbols(KB_GRNORM_THUMBKEY_SYMBOLS),
+    DEMessageEaseInvertedNumpad(KB_DE_MESSAGEASE_INVERTED_NUMPAD),
     DEMessagEaseLeft(KB_DE_MESSAGEASE_LEFT),
-    DEMessagEaseLeftInvertedKeypad(KB_DE_MESSAGEASE_LEFT_INVERTED_KEYPAD),
+    DEMessagEaseLeftInvertedNumpad(KB_DE_MESSAGEASE_LEFT_INVERTED_NUMPAD),
 }

--- a/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
@@ -12,6 +12,7 @@ import com.dessalines.thumbkey.keyboards.KB_CA_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_CZ_MESSAGEASE_PROGRAMMING
 import com.dessalines.thumbkey.keyboards.KB_DA_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_DE_MESSAGEASE
+import com.dessalines.thumbkey.keyboards.KB_DE_MESSAGEASE_LEFT
 import com.dessalines.thumbkey.keyboards.KB_DE_MESSAGEASE_SYMBOLS
 import com.dessalines.thumbkey.keyboards.KB_DE_NORDIC_MESSAGEASE
 import com.dessalines.thumbkey.keyboards.KB_DE_THUMBKEY
@@ -364,4 +365,5 @@ enum class KeyboardLayout(
     ENThumbkeyFlippedNumpad(KB_EN_THUMBKEY_FLIPPED_NUMPAD),
     GRThumbKeyNormal(KB_GRNORM_THUMBKEY),
     GRNormThumbKeySymbols(KB_GRNORM_THUMBKEY_SYMBOLS),
+    DEMessagEaseLeft(KB_DE_MESSAGEASE_LEFT),
 }


### PR DESCRIPTION
Adds three more keyboard layouts for previous users of MessagEase German: 

- MessagEase German - inverted numpad 
- MessagEase German - left-handed (default numpad order)
- MessagEase German - left handed (inverted numpad order)


The inversion of the numpad order (row with 1, 2, 3 is on the bottom rather than on the top) is a setting in MessagEase. In Thumb-Key I had to create separate layouts. 