### PR TITLE
Implement 3-row emoji picker for wide layout keyboards

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENHyper.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENHyper.kt
@@ -236,5 +236,6 @@ val KB_EN_HYPER: KeyboardDefinition =
         settings =
             KeyboardDefinitionSettings(
                 autoCapitalizers = arrayOf(::autoCapitalizeI, ::autoCapitalizeIApostrophe),
+                isThreeRow = true,
             ),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENHyperSpace.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENHyperSpace.kt
@@ -236,5 +236,6 @@ val KB_EN_HYPER_SPACE: KeyboardDefinition =
         settings =
             KeyboardDefinitionSettings(
                 autoCapitalizers = arrayOf(::autoCapitalizeI, ::autoCapitalizeIApostrophe),
+                isThreeRow = true,
             ),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/TRArti.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/TRArti.kt
@@ -426,5 +426,6 @@ val KB_TR_ARTI: KeyboardDefinition =
         settings =
             KeyboardDefinitionSettings(
                 autoCapitalizers = arrayOf(::autoCapitalizeI, ::autoCapitalizeIApostrophe),
+                isThreeRow = true,
             ),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
@@ -167,7 +167,13 @@ fun KeyboardScreen(
     val cornerRadius = (keyRadius / 100.0f) * ((keyWidth + keyHeight) / 4.0f)
 
     if (mode == KeyboardMode.EMOJI) {
-        val controllerKeys = listOf(EMOJI_BACK_KEY_ITEM, NUMERIC_KEY_ITEM, BACKSPACE_KEY_ITEM, RETURN_KEY_ITEM)
+        // Default to 4 rows, but reduce to 3 for wide layouts by ditching the numeric mode toggle
+        val controllerKeys =
+            if (keyboardDefinition.settings.isThreeRow) {
+                listOf(EMOJI_BACK_KEY_ITEM, BACKSPACE_KEY_ITEM, RETURN_KEY_ITEM)
+            } else {
+                listOf(EMOJI_BACK_KEY_ITEM, NUMERIC_KEY_ITEM, BACKSPACE_KEY_ITEM, RETURN_KEY_ITEM)
+            }
         val keyboardHeight = Dp((keyHeight * controllerKeys.size) - (keyPadding * 2))
 
         ctx.currentInputConnection.requestCursorUpdates(0)

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
@@ -22,6 +22,7 @@ data class KeyboardDefinitionModes(
 data class KeyboardDefinitionSettings(
     val autoCapitalizers: AutoCapitalizers = arrayOf(),
     val autoShift: Boolean = true,
+    val isThreeRow: Boolean = false,
 ) {
     companion object {}
 


### PR DESCRIPTION
I don't use the Emoji picker much at all, but it has bothered me when opening it (accidentally or intetionally) that it causes the entire screen layout to jump around because my keyboard layout is 3 rows instead of the typical four. This implements a way to keep the emoji picker the same size as the keyboard.

I noticed this also affected one other keyboard and I implemented it there, but I guess we need a review from user(s) of that layout too.

This could probably be derived from the actual keyboard definition instead of being set explicitly, but I didn't make it that far yet.
