### PR TITLE
Remove mention of the deprecated moving cursor up or down lines from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@ Enabling `Slide gestures` in keyboard settings will enable the following continu
 Enabling `Spacebar: Allow normal swipes to work with slide gestures`, in keyboard settings will enable the following:
 
 - Swipe left and right to move the cursor by a single character.
-- Swipe up and down to move the cursor up or down a line.
 - Allow us to use the other characters on the spacebars in the typesplit layouts.
 
 Enabling `Backspace: Allow normal swipes to work with slide gestures`, in keyboard settings will enable the following:


### PR DESCRIPTION
Hi, thanks a lot for the great work.

If I understand correctly #195 disabled moving the cursor up and down lines by swiping vertically on the space bar, however it is still included in the README.md. If I misunderstood and it is still possible, then I didn't manage to make it work. 