### PR TITLE
adds new layout: english twohands symbols numbers arrows compact.

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENTwoHandsSymbolsNumbersArrowsCompact.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENTwoHandsSymbolsNumbersArrowsCompact.kt
@@ -1,0 +1,448 @@
+@file:Suppress("ktlint:standard:no-wildcard-imports")
+
+package com.dessalines.thumbkey.keyboards
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.*
+import com.dessalines.thumbkey.utils.*
+import com.dessalines.thumbkey.utils.ColorVariant.*
+import com.dessalines.thumbkey.utils.FontSizeVariant.*
+import com.dessalines.thumbkey.utils.KeyAction.*
+import com.dessalines.thumbkey.utils.SwipeNWay.*
+
+val KB_EN_SYMBOLS_NUMBERS_ARROWS_TWO_HANDS_COMPACT_MAIN =
+    KeyboardC(
+        listOf(
+            listOf(
+                KeyItemC(
+                    center = KeyC("s", size = LARGE),
+                    bottomRight = KeyC("w"),
+                    bottomLeft = KeyC("$", color = MUTED),
+                    left = KeyC("1", color = MUTED),
+                    topLeft = KeyC("2", color = MUTED),
+                    top = KeyC("3", color = MUTED),
+                    topRight = KeyC("4", color = MUTED),
+                    right = KeyC("5", color = MUTED),
+                    bottom = KeyC("6", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("r", size = LARGE),
+                    bottom = KeyC("g"),
+                    topLeft = KeyC("`", color = MUTED),
+                    top = KeyC("^", color = MUTED),
+                    topRight = KeyC("´", color = MUTED),
+                    right = KeyC("!", color = MUTED),
+                    bottomRight = KeyC("\\", color = MUTED),
+                    bottomLeft = KeyC("/", color = MUTED),
+                    left = KeyC("+", color = MUTED),
+                ),
+                NUMERIC_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("r", size = LARGE),
+                    bottom = KeyC("g"),
+                    topLeft = KeyC("`", color = MUTED),
+                    top = KeyC("^", color = MUTED),
+                    topRight = KeyC("´", color = MUTED),
+                    right = KeyC("!", color = MUTED),
+                    bottomRight = KeyC("\\", color = MUTED),
+                    bottomLeft = KeyC("/", color = MUTED),
+                    left = KeyC("+", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("o", size = LARGE),
+                    bottomLeft = KeyC("u"),
+                    left = KeyC("?", color = MUTED),
+                    bottomRight = KeyC("€", color = MUTED),
+                    bottom = KeyC("=", color = MUTED),
+                    topLeft = KeyC("7", color = MUTED),
+                    top = KeyC("8", color = MUTED),
+                    topRight = KeyC("8", displayText = "", color = MUTED),
+                    right = KeyC("9", color = MUTED),
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("n", size = LARGE),
+                    right = KeyC("m"),
+                    topLeft = KeyC("{", color = MUTED),
+                    topRight = KeyC("%", color = MUTED),
+                    bottomRight = KeyC("_", color = MUTED),
+                    bottomLeft = KeyC("[", color = MUTED),
+                    left = KeyC("(", color = MUTED),
+                    top = KeyC("0", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("h", size = LARGE),
+                    topLeft = KeyC("j"),
+                    top = KeyC("q"),
+                    topRight = KeyC("b"),
+                    right = KeyC("p"),
+                    bottomRight = KeyC("y"),
+                    bottom = KeyC("x"),
+                    bottomLeft = KeyC("v"),
+                    left = KeyC("k"),
+                ),
+                SPACEBAR_ALL_DIRECTIONS,
+                KeyItemC(
+                    center = KeyC("h", size = LARGE),
+                    topLeft = KeyC("j"),
+                    top = KeyC("q"),
+                    topRight = KeyC("b"),
+                    right = KeyC("p"),
+                    bottomRight = KeyC("y"),
+                    bottom = KeyC("x"),
+                    bottomLeft = KeyC("v"),
+                    left = KeyC("k"),
+                ),
+                KeyItemC(
+                    center = KeyC("a", size = LARGE),
+                    left = KeyC("l"),
+                    top =
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
+                            action = ToggleShiftMode(true),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(true),
+                            color = MUTED,
+                        ),
+                    topLeft = KeyC("|", color = MUTED),
+                    topRight = KeyC("}", color = MUTED),
+                    right = KeyC(")", color = MUTED),
+                    bottom =
+                        KeyC(
+                            ToggleShiftMode(false),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(false),
+                        ),
+                    bottomRight = KeyC("]", color = MUTED),
+                    bottomLeft = KeyC("@", color = MUTED),
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("t", size = LARGE),
+                    swipeType = FOUR_WAY_DIAGONAL,
+                    topRight = KeyC("c"),
+                    topLeft = KeyC("~", color = MUTED),
+                    bottomRight = KeyC(":", color = MUTED),
+                    bottomLeft = KeyC("<", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("i", size = LARGE),
+                    top = KeyC("f"),
+                    right = KeyC("z"),
+                    topLeft = KeyC("\"", color = MUTED),
+                    topRight = KeyC("'", color = MUTED),
+                    bottomRight = KeyC("-", color = MUTED),
+                    bottom = KeyC(".", color = MUTED),
+                    bottomLeft = KeyC("*", color = MUTED),
+                    left = KeyC(",", color = MUTED),
+                ),
+                BACKSPACE_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("i", size = LARGE),
+                    top = KeyC("f"),
+                    right = KeyC("z"),
+                    topLeft = KeyC("\"", color = MUTED),
+                    topRight = KeyC("'", color = MUTED),
+                    bottomRight = KeyC("-", color = MUTED),
+                    bottom = KeyC(".", color = MUTED),
+                    bottomLeft = KeyC("*", color = MUTED),
+                    left = KeyC(",", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("e", size = LARGE),
+                    topLeft = KeyC("d"),
+                    top = KeyC("&", color = MUTED),
+                    topRight = KeyC("°", color = MUTED),
+                    bottomRight = KeyC(">", color = MUTED),
+                    bottomLeft = KeyC(";", color = MUTED),
+                    left = KeyC("#", color = MUTED),
+                ),
+            ),
+            listOf(
+                EMOJI_KEY_ITEM,
+                SPACEBAR_KEY_ITEM,
+                RETURN_KEY_ITEM,
+            ),
+        ),
+    )
+
+val KB_EN_SYMBOLS_NUMBERS_ARROWS_TWO_HANDS_COMPACT_SHIFTED =
+    KeyboardC(
+        listOf(
+            listOf(
+                KeyItemC(
+                    center = KeyC("S", size = LARGE),
+                    bottomRight = KeyC("W"),
+                    bottomLeft = KeyC("$", color = MUTED),
+                    left = KeyC("1", color = MUTED),
+                    topLeft = KeyC("2", color = MUTED),
+                    top = KeyC("3", color = MUTED),
+                    topRight = KeyC("4", color = MUTED),
+                    right = KeyC("5", color = MUTED),
+                    bottom = KeyC("6", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("R", size = LARGE),
+                    bottom = KeyC("G"),
+                    topLeft = KeyC("`", color = MUTED),
+                    top = KeyC("^", color = MUTED),
+                    topRight = KeyC("´", color = MUTED),
+                    right = KeyC("!", color = MUTED),
+                    bottomRight = KeyC("\\", color = MUTED),
+                    bottomLeft = KeyC("/", color = MUTED),
+                    left = KeyC("+", color = MUTED),
+                ),
+                NUMERIC_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("R", size = LARGE),
+                    bottom = KeyC("G"),
+                    topLeft = KeyC("`", color = MUTED),
+                    top = KeyC("^", color = MUTED),
+                    topRight = KeyC("´", color = MUTED),
+                    right = KeyC("!", color = MUTED),
+                    bottomRight = KeyC("\\", color = MUTED),
+                    bottomLeft = KeyC("/", color = MUTED),
+                    left = KeyC("+", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("O", size = LARGE),
+                    bottomLeft = KeyC("U"),
+                    left = KeyC("?", color = MUTED),
+                    bottomRight = KeyC("€", color = MUTED),
+                    bottom = KeyC("=", color = MUTED),
+                    topLeft = KeyC("7", color = MUTED),
+                    top = KeyC("8", color = MUTED),
+                    topRight = KeyC("8", displayText = "", color = MUTED),
+                    right = KeyC("9", color = MUTED),
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("N", size = LARGE),
+                    right = KeyC("M"),
+                    topLeft = KeyC("{", color = MUTED),
+                    topRight = KeyC("%", color = MUTED),
+                    bottomRight = KeyC("_", color = MUTED),
+                    bottomLeft = KeyC("[", color = MUTED),
+                    left = KeyC("(", color = MUTED),
+                    top = KeyC("0", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("H", size = LARGE),
+                    topLeft = KeyC("J"),
+                    top = KeyC("Q"),
+                    topRight = KeyC("B"),
+                    right = KeyC("P"),
+                    bottomRight = KeyC("Y"),
+                    bottom = KeyC("X"),
+                    bottomLeft = KeyC("V"),
+                    left = KeyC("K"),
+                ),
+                SPACEBAR_ALL_DIRECTIONS,
+                KeyItemC(
+                    center = KeyC("H", size = LARGE),
+                    topLeft = KeyC("J"),
+                    top = KeyC("Q"),
+                    topRight = KeyC("B"),
+                    right = KeyC("P"),
+                    bottomRight = KeyC("Y"),
+                    bottom = KeyC("X"),
+                    bottomLeft = KeyC("V"),
+                    left = KeyC("K"),
+                ),
+                KeyItemC(
+                    center = KeyC("A", size = LARGE),
+                    left = KeyC("L"),
+                    top =
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.Outlined.KeyboardCapslock),
+                            capsModeDisplay = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
+                            action = ToggleCapsLock,
+                            swipeReturnAction = ToggleCurrentWordCapitalization(true),
+                            color = MUTED,
+                        ),
+                    bottom =
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
+                            action = ToggleShiftMode(false),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(false),
+                            color = MUTED,
+                        ),
+                    topLeft = KeyC("|", color = MUTED),
+                    topRight = KeyC("}", color = MUTED),
+                    right = KeyC(")", color = MUTED),
+                    bottomRight = KeyC("]", color = MUTED),
+                    bottomLeft = KeyC("@", color = MUTED),
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("T", size = LARGE),
+                    swipeType = FOUR_WAY_DIAGONAL,
+                    topRight = KeyC("C"),
+                    topLeft = KeyC("~", color = MUTED),
+                    bottomRight = KeyC(":", color = MUTED),
+                    bottomLeft = KeyC("<", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("I", size = LARGE),
+                    top = KeyC("F"),
+                    right = KeyC("Z"),
+                    topLeft = KeyC("\"", color = MUTED),
+                    topRight = KeyC("'", color = MUTED),
+                    bottomRight = KeyC("-", color = MUTED),
+                    bottom = KeyC(".", color = MUTED),
+                    bottomLeft = KeyC("*", color = MUTED),
+                    left = KeyC(",", color = MUTED),
+                ),
+                BACKSPACE_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("I", size = LARGE),
+                    top = KeyC("F"),
+                    right = KeyC("Z"),
+                    topLeft = KeyC("\"", color = MUTED),
+                    topRight = KeyC("'", color = MUTED),
+                    bottomRight = KeyC("-", color = MUTED),
+                    bottom = KeyC(".", color = MUTED),
+                    bottomLeft = KeyC("*", color = MUTED),
+                    left = KeyC(",", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("E", size = LARGE),
+                    topLeft = KeyC("D"),
+                    top = KeyC("&", color = MUTED),
+                    topRight = KeyC("°", color = MUTED),
+                    bottomRight = KeyC(">", color = MUTED),
+                    bottomLeft = KeyC(";", color = MUTED),
+                    left = KeyC("#", color = MUTED),
+                ),
+            ),
+            listOf(
+                EMOJI_KEY_ITEM,
+                SPACEBAR_KEY_ITEM,
+                RETURN_KEY_ITEM,
+            ),
+        ),
+    )
+val TWO_HANDS_NUMERIC_ARROWS_COMPACT_KEYBOARD =
+    KeyboardC(
+        listOf(
+            listOf(
+                KeyItemC(
+                    center = KeyC("1", size = LARGE),
+                    bottomLeft = KeyC("$"),
+                ),
+                KeyItemC(
+                    center = KeyC("2", size = LARGE),
+                    topLeft = KeyC("`"),
+                    top = KeyC("^"),
+                    topRight = KeyC("´"),
+                    right = KeyC("!"),
+                    bottomRight = KeyC("\\"),
+                    bottomLeft = KeyC("/"),
+                    left = KeyC("+"),
+                ),
+                KeyItemC(
+                    center = KeyC("3", size = LARGE),
+                    left = KeyC("?"),
+                    bottomRight = KeyC("€"),
+                    bottomLeft = KeyC("£"),
+                    bottom = KeyC("="),
+                ),
+                ABC_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("\u0301", displayText = "◌́", size = LARGE),
+                    swipeType = EIGHT_WAY,
+                    topLeft = KeyC("/"),
+                    top = KeyC("*"),
+                    topRight = KeyC("-"),
+                    right = KeyC("+"),
+                    bottomRight = KeyC("="),
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("4", size = LARGE),
+                    topLeft = KeyC("{"),
+                    topRight = KeyC("%"),
+                    bottomRight = KeyC("_"),
+                    bottomLeft = KeyC("["),
+                    left = KeyC("("),
+                ),
+                KeyItemC(
+                    center = KeyC("5", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("6", size = LARGE),
+                    topLeft = KeyC("|"),
+                    topRight = KeyC("}"),
+                    right = KeyC(")"),
+                    bottomRight = KeyC("]"),
+                    bottomLeft = KeyC("@"),
+                ),
+                SPACEBAR_ALL_DIRECTIONS,
+                KeyItemC(
+                    center = KeyC("\u0308", displayText = "◌̈", size = LARGE),
+                    swipeType = EIGHT_WAY,
+                    topRight = KeyC("}"),
+                    right = KeyC(")"),
+                    bottomRight = KeyC("]"),
+                    bottomLeft = KeyC("\""),
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("7", size = LARGE),
+                    topLeft = KeyC("~"),
+                    bottomRight = KeyC(":"),
+                    bottomLeft = KeyC("<"),
+                ),
+                KeyItemC(
+                    center = KeyC("8", size = LARGE),
+                    topLeft = KeyC("\""),
+                    topRight = KeyC("'"),
+                    bottomRight = KeyC("-"),
+                    bottom = KeyC("."),
+                    bottomLeft = KeyC("*"),
+                    left = KeyC(","),
+                ),
+                KeyItemC(
+                    center = KeyC("9", size = LARGE),
+                    top = KeyC("&"),
+                    topRight = KeyC("°"),
+                    bottomRight = KeyC(">"),
+                    bottomLeft = KeyC(";"),
+                    left = KeyC("#"),
+                ),
+                BACKSPACE_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("\u0300", displayText = "◌̀", size = LARGE),
+                    swipeType = EIGHT_WAY,
+                    left = KeyC("?"),
+                    bottomRight = KeyC(">"),
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("0", size = LARGE),
+                ),
+                SPACEBAR_KEY_ITEM,
+                RETURN_KEY_ITEM,
+            ),
+        ),
+    )
+
+val KB_EN_SYMBOLS_NUMBERS_ARROWS_TWO_HANDS_COMPACT: KeyboardDefinition =
+    KeyboardDefinition(
+        title = "english symbols-numbers-arrows two-hands",
+        modes =
+            KeyboardDefinitionModes(
+                main = KB_EN_SYMBOLS_NUMBERS_ARROWS_TWO_HANDS_COMPACT_MAIN,
+                shifted = KB_EN_SYMBOLS_NUMBERS_ARROWS_TWO_HANDS_COMPACT_SHIFTED,
+                numeric = TWO_HANDS_NUMERIC_ARROWS_COMPACT_KEYBOARD,
+            ),
+        settings =
+            KeyboardDefinitionSettings(
+                autoCapitalizers = arrayOf(::autoCapitalizeI, ::autoCapitalizeIApostrophe),
+            ),
+    )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENTwoHandsSymbolsNumbersArrowsCompact.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENTwoHandsSymbolsNumbersArrowsCompact.kt
@@ -434,7 +434,7 @@ val TWO_HANDS_NUMERIC_ARROWS_COMPACT_KEYBOARD =
 
 val KB_EN_SYMBOLS_NUMBERS_ARROWS_TWO_HANDS_COMPACT: KeyboardDefinition =
     KeyboardDefinition(
-        title = "english symbols-numbers-arrows two-hands",
+        title = "english symbols-numbers-arrows two-hands compact",
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_SYMBOLS_NUMBERS_ARROWS_TWO_HANDS_COMPACT_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
@@ -75,6 +75,7 @@ import com.dessalines.thumbkey.keyboards.KB_EN_RSINOA
 import com.dessalines.thumbkey.keyboards.KB_EN_SK_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_EN_SV_THUMBKEY_PROGRAMMING
 import com.dessalines.thumbkey.keyboards.KB_EN_SYMBOLS_NUMBERS_ARROWS_TWO_HANDS
+import com.dessalines.thumbkey.keyboards.KB_EN_SYMBOLS_NUMBERS_ARROWS_TWO_HANDS_COMPACT
 import com.dessalines.thumbkey.keyboards.KB_EN_SYMBOLS_NUMBERS_TWO_HANDS
 import com.dessalines.thumbkey.keyboards.KB_EN_SYMBOLS_TWO_HANDS
 import com.dessalines.thumbkey.keyboards.KB_EN_THUMBKEY
@@ -386,4 +387,5 @@ enum class KeyboardLayout(
     ENThumbKeyWordsSymbolsDual(KB_EN_THUMBKEY_WORDS_SYMBOLS_DUAL),
     RUArti(KB_RU_ARTI),
     DAThumbKeyMultiLingual(KB_DA_THUMBKEY_MULTILINGUAL),
+    ENSymbolsNumbersArrowsTwoHandsCompact(KB_EN_SYMBOLS_NUMBERS_ARROWS_TWO_HANDS_COMPACT),
 }


### PR DESCRIPTION
Adds a new layout: English twohanded symbols numbers arrows compact. It forgoes two columns. It's a hybrid between a full two-handed layout, and a typesplit solution. 