### PR TITLE
ENMessagEaseSymbolsModifiers: Add "up" and "down" keys

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseSymbolsModifiers.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseSymbolsModifiers.kt
@@ -175,7 +175,7 @@ val KB_EN_MESSAGEASE_SYMBOLS_MODIFIERS_MAIN =
                 BACKSPACE_KEY_ITEM,
             ),
             listOf(
-                SPACEBAR_KEY_ITEM,
+                SPACEBAR_PROGRAMMING_KEY_ITEM,
                 RETURN_KEY_ITEM,
             ),
         ),
@@ -289,7 +289,7 @@ val KB_EN_MESSAGEASE_SYMBOLS_MODIFIERS_SHIFTED =
                 BACKSPACE_KEY_ITEM,
             ),
             listOf(
-                SPACEBAR_KEY_ITEM,
+                SPACEBAR_PROGRAMMING_KEY_ITEM,
                 KeyItemC(
                     center =
                         keyCModifier(
@@ -382,7 +382,7 @@ val KB_EN_MESSAGEASE_SYMBOLS_MODIFIERS_CTRLED =
                 BACKSPACE_KEY_ITEM,
             ),
             listOf(
-                SPACEBAR_KEY_ITEM,
+                SPACEBAR_PROGRAMMING_KEY_ITEM,
                 KeyItemC(
                     center =
                         keyCModifier(
@@ -475,7 +475,7 @@ val KB_EN_MESSAGEASE_SYMBOLS_MODIFIERS_ALTED =
                 BACKSPACE_KEY_ITEM,
             ),
             listOf(
-                SPACEBAR_KEY_ITEM,
+                SPACEBAR_PROGRAMMING_KEY_ITEM,
                 KeyItemC(
                     center =
                         keyCModifier(


### PR DESCRIPTION
The layout already features almost everything the thumb-key programmer layouts feature (there is no separate programming layout for the MessagEase layouts except for Czech. It is currently lacking the up and down keys, so I propose to add them to the existing layout instead of adding an additional layout.