### PR TITLE
Adds Korean Thumb-Key layout

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/KRThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/KRThumbKey.kt
@@ -1,0 +1,207 @@
+@file:Suppress("ktlint:standard:no-wildcard-imports")
+
+package com.dessalines.thumbkey.keyboards
+
+import android.view.KeyEvent
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.*
+import com.dessalines.thumbkey.textprocessors.KoreanTextProcessor
+import com.dessalines.thumbkey.utils.*
+import com.dessalines.thumbkey.utils.ColorVariant.*
+import com.dessalines.thumbkey.utils.FontSizeVariant.*
+import com.dessalines.thumbkey.utils.KeyAction.*
+import com.dessalines.thumbkey.utils.SwipeNWay.*
+
+val KB_KR_THUMBKEY_MAIN =
+    KeyboardC(
+        listOf(
+            listOf(
+                KeyItemC(
+                    center = KeyC("ㅣ", size = LARGE),
+                    swipeType = FOUR_WAY_DIAGONAL,
+                    bottomRight = KeyC("ㅎ"),
+                ),
+                KeyItemC(
+                    center = KeyC("ㅅ", size = LARGE),
+                    swipeType = TWO_WAY_VERTICAL,
+                    bottom = KeyC("ㅈ"),
+                ),
+                KeyItemC(
+                    center = KeyC("ㄱ", size = LARGE),
+                    swipeType = FOUR_WAY_DIAGONAL,
+                    bottomLeft = KeyC("ㄷ"),
+                ),
+                EMOJI_KEY_ITEM,
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("ㅓ", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("ㅔ"),
+                    top = KeyC("₩", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("ㅇ", size = LARGE),
+                    swipeType = TWO_WAY_VERTICAL,
+                    topLeft = KeyC("ㅋ"),
+                    topRight = KeyC("ㅌ"),
+                    bottomRight = KeyC("ㅍ"),
+                    bottomLeft = KeyC("ㅊ"),
+                ),
+                KeyItemC(
+                    center = KeyC("ㅏ", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("ㅐ"),
+                    top =
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
+                            action = ToggleShiftMode(true),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(true),
+                            color = MUTED,
+                        ),
+                    bottom =
+                        KeyC(
+                            ToggleShiftMode(false),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(false),
+                        ),
+                ),
+                NUMERIC_KEY_ITEM,
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("ㄴ", size = LARGE),
+                    topRight = KeyC("ㄹ"),
+                    bottom = KeyC(",", color = MUTED),
+                    bottomRight = KeyC("!", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("ㅗ", size = LARGE),
+                    top = KeyC("ㅁ"),
+                    topRight = KeyC("'", color = MUTED),
+                    right = KeyC("ㅂ"),
+                    left = KeyC("?", color = MUTED),
+                    bottomRight = KeyC("-", color = MUTED),
+                    bottom = KeyC(".", color = MUTED),
+                    bottomLeft = KeyC("*", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("ㅡ", size = LARGE),
+                    right = KeyC("~", color = MUTED),
+                    topLeft = KeyC("ㅜ"),
+                    bottomLeft = KeyC(";", color = MUTED),
+                    bottom = KeyC(":", color = MUTED),
+                ),
+                BACKSPACE_KEY_ITEM,
+            ),
+            listOf(
+                SPACEBAR_KEY_ITEM,
+                RETURN_KEY_ITEM,
+            ),
+        ),
+    )
+
+val KB_KR_THUMBKEY_SHIFTED =
+    KeyboardC(
+        listOf(
+            listOf(
+                KeyItemC(
+                    center = KeyC("ㅣ", size = LARGE),
+                    swipeType = FOUR_WAY_DIAGONAL,
+                    bottomRight = KeyC("ㅎ"),
+                ),
+                KeyItemC(
+                    center = KeyC("ㅆ", size = LARGE),
+                    swipeType = TWO_WAY_VERTICAL,
+                    bottom = KeyC("ㅉ"),
+                ),
+                KeyItemC(
+                    center = KeyC("ㄲ", size = LARGE),
+                    swipeType = FOUR_WAY_DIAGONAL,
+                    bottomLeft = KeyC("ㄸ"),
+                ),
+                EMOJI_KEY_ITEM,
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("ㅕ", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("ㅖ"),
+                    top = KeyC("₩", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("ㅇ", size = LARGE),
+                    swipeType = TWO_WAY_VERTICAL,
+                    topLeft = KeyC("ㅋ"),
+                    topRight = KeyC("ㅌ"),
+                    bottomRight = KeyC("ㅍ"),
+                    bottomLeft = KeyC("ㅊ"),
+                ),
+                KeyItemC(
+                    center = KeyC("ㅑ", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("ㅒ"),
+                    bottom =
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
+                            action = ToggleShiftMode(false),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(false),
+                            color = MUTED,
+                        ),
+                    top =
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.Outlined.KeyboardCapslock),
+                            capsModeDisplay = KeyDisplay.IconDisplay(Icons.Outlined.Copyright),
+                            action = ToggleCapsLock,
+                            swipeReturnAction = ToggleCurrentWordCapitalization(true),
+                            color = MUTED,
+                        ),
+                ),
+                NUMERIC_KEY_ITEM,
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("ㄴ", size = LARGE),
+                    topRight = KeyC("ㄹ"),
+                    bottom = KeyC(",", color = MUTED),
+                    bottomRight = KeyC("!", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("ㅛ", size = LARGE),
+                    top = KeyC("ㅁ"),
+                    topRight = KeyC("'", color = MUTED),
+                    right = KeyC("ㅃ"),
+                    left = KeyC("?", color = MUTED),
+                    bottomRight = KeyC("-", color = MUTED),
+                    bottom = KeyC(".", color = MUTED),
+                    bottomLeft = KeyC("*", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("ㅡ", size = LARGE),
+                    right = KeyC("~", color = MUTED),
+                    topLeft = KeyC("ㅠ"),
+                    bottomLeft = KeyC(";", color = MUTED),
+                    bottom = KeyC(":", color = MUTED),
+                ),
+                BACKSPACE_KEY_ITEM,
+            ),
+            listOf(
+                SPACEBAR_KEY_ITEM,
+                RETURN_KEY_ITEM,
+            ),
+        ),
+    )
+
+val KB_KR_THUMBKEY: KeyboardDefinition =
+    KeyboardDefinition(
+        title = "한국어 thumb-key",
+        modes =
+            KeyboardDefinitionModes(
+                main = KB_KR_THUMBKEY_MAIN,
+                shifted = KB_KR_THUMBKEY_SHIFTED,
+                numeric = NUMERIC_KEYBOARD,
+            ),
+        settings =
+            KeyboardDefinitionSettings(
+                textProcessor = KoreanTextProcessor(),
+            ),
+    )

--- a/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
@@ -147,6 +147,7 @@ import com.dessalines.thumbkey.keyboards.KB_JA_KANA_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_JA_KATAKANA_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_JA_KATAKANA_TYPESPLIT
 import com.dessalines.thumbkey.keyboards.KB_KA_THUMBKEY
+import com.dessalines.thumbkey.keyboards.KB_KR_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_KR_TYPESPLIT
 import com.dessalines.thumbkey.keyboards.KB_KZ_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_LT_THUMBKEY
@@ -392,4 +393,5 @@ enum class KeyboardLayout(
     ENSymbolsNumbersArrowsTwoHandsCompact(KB_EN_SYMBOLS_NUMBERS_ARROWS_TWO_HANDS_COMPACT),
     ENLVThumbKey(KB_ENLV_THUMBKEY),
     KRTypeSplit(KB_KR_TYPESPLIT),
+    KRThumbKey(KB_KR_THUMBKEY),
 }


### PR DESCRIPTION
Keeping in-line with the excellent changes provided in #1534, I've implemented a Thumb-Key-style Hangul layout!

This layout provides the same punctuation as the TypeSplit version, and uses the shift layer for diphthongs and emphatic consonants.

The layout is based on letter usage statistics, but I'm currently only *in the process* of learning Korean, so feedback from actual speakers would be helpful.

<img width="480" height="854" src="https://github.com/user-attachments/assets/4cf9383a-11c2-4a6a-83af-d9b7f40e2bca" />
<img width="480" height="854" src="https://github.com/user-attachments/assets/c790ed3d-77c9-456f-9a60-225e05e5d889" />
