### PR TITLE
switch language resets to main

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -364,7 +365,10 @@ fun KeyboardScreen(
                                         }
                                     }
                                 },
-                                onSwitchLanguage = onSwitchLanguage,
+                                onSwitchLanguage = {
+                                    onSwitchLanguage()
+                                    mode = KeyboardMode.MAIN
+                                },
                                 onChangePosition = onChangePosition,
                                 onKeyEvent = {
                                     when (mode) {
@@ -535,7 +539,10 @@ fun KeyboardScreen(
                                                 }
                                             }
                                         },
-                                        onSwitchLanguage = onSwitchLanguage,
+                                        onSwitchLanguage = {
+                                            onSwitchLanguage()
+                                            mode = KeyboardMode.MAIN
+                                        },
                                         onChangePosition = onChangePosition,
                                         oppositeCaseKey =
                                             when (mode) {


### PR DESCRIPTION
When switching languages, the mode of the keyboard is reset to main mode instead of staying in numeric or whichever other mode it was in.

Currently, this change introduces a bug where the screen flickers slightly when switching languages from numeric mode.


https://github.com/user-attachments/assets/cbbc7f21-ee90-4d0d-87b6-d11699825df0



resolves #1585