### PR TITLE
fix: korean composition breaking when switching layouts

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/ComposeKeyboardView.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ComposeKeyboardView.kt
@@ -57,6 +57,10 @@ class ComposeKeyboardView(
                                         ?.textProcessor
                                         ?.handleFinishInput(ctx)
                                     ctx.currentKeyboardDefinition = (layouts[nextIndex].keyboardDefinition)
+                                    ctx.currentKeyboardDefinition
+                                        ?.settings
+                                        ?.textProcessor
+                                        ?.updateCursorPosition(ctx)
 
                                     // Display the new layout's name on the screen
                                     if (s.showToastOnLayoutSwitch.toBool()) {

--- a/app/src/main/java/com/dessalines/thumbkey/textprocessors/KoreanTextProcessor.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/textprocessors/KoreanTextProcessor.kt
@@ -2,6 +2,7 @@ package com.dessalines.thumbkey.textprocessors
 
 import android.util.Log
 import android.view.KeyEvent
+import android.view.inputmethod.ExtractedTextRequest
 import android.view.inputmethod.InputConnection
 import com.dessalines.thumbkey.IMEService
 import com.dessalines.thumbkey.utils.TAG
@@ -234,6 +235,12 @@ class KoreanTextProcessor : TextProcessor {
         if (state != CompositionState.EMPTY) {
             handleFinishInput(ime)
         }
+    }
+
+    override fun updateCursorPosition(ime: IMEService) {
+        val extracted = ime.currentInputConnection.getExtractedText(ExtractedTextRequest(), 0)
+        selectionStart = extracted.selectionStart
+        selectionEnd = extracted.selectionEnd
     }
 
     private fun resetState() {

--- a/app/src/main/java/com/dessalines/thumbkey/textprocessors/TextProcessor.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/textprocessors/TextProcessor.kt
@@ -27,4 +27,7 @@ interface TextProcessor {
         newSelStart: Int,
         newSelEnd: Int,
     )
+
+    // manually update position after switching layouts
+    fun updateCursorPosition(ime: IMEService)
 }


### PR DESCRIPTION
Fixes #1620 

When switching layouts `onUpdateCursorAnchorInfo()` isn't triggered and the `TextProcessor` still holds previous selection values, so the update that occurs after committing the first character is mistakenly interpreted as cursor movement and prematurely finalizing ongoing composition.

I tried smarter methods, like calling `ic.requestCursorUpdate()` and checking if `ime.onCursorUpdate()` fires, but it didn't work as well. As a workaround, I added a new function that retrieves the cursor position by manually calling `getExtractedText()`. I was also thinking about making `selectionStart` and `selectionEnd` variables from the `IMEService` public and call already existing `handleCursorUpdate()` in `onSwitchLanguage`, but I wasn't sure if that actually would be a better way to solve that.