### PR TITLE
fix: follow title format for FAThumbKey.kt

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FAThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FAThumbKey.kt
@@ -99,7 +99,7 @@ val KB_FA_THUMBKEY_MAIN =
 
 val KB_FA_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
-        title = "thumb-key فارسی",
+        title = "فارسی thumb-key",
         modes =
             KeyboardDefinitionModes(
                 main = KB_FA_THUMBKEY_MAIN,


### PR DESCRIPTION
The current title is in format `[base] [language]` which doesn't follow `[languages] [base] [qualifiers]? [version]?` format and doesn't get sorted currectly