### PR TITLE
fix numeric wide underscore

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericWide.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/NumericWide.kt
@@ -25,7 +25,7 @@ val WIDE_NUMERIC_KEYBOARD =
                             display = KeyDisplay.TextDisplay(""),
                             action = CommitText("¹"),
                         ),
-                    bottom = KeyC("_"),
+                    bottomLeft = KeyC("_"),
                     bottomRight = KeyC("|"),
                 ),
                 KeyItemC(


### PR DESCRIPTION
The cause of the bug was that `swipeType` was set
to `FOUR_WAY_DIAGONAL` instead of `EIGHT_WAY`.
However, instead of changing the `swipeType`,
I decided to adopt @a6-webm 's solution and shift
the underscore to `bottomLeft` so that it the key
positions matches the rest of the this wide
numeric layout.

fixes #1597