### PR TITLE
Changed Korean thumb-key layout with optimization.

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/KROneThumb.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/KROneThumb.kt
@@ -1,0 +1,146 @@
+@file:Suppress("ktlint:standard:no-wildcard-imports")
+
+package com.dessalines.thumbkey.keyboards
+
+import android.view.KeyEvent
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.*
+import com.dessalines.thumbkey.textprocessors.KoreanTextProcessor
+import com.dessalines.thumbkey.utils.*
+import com.dessalines.thumbkey.utils.ColorVariant.*
+import com.dessalines.thumbkey.utils.FontSizeVariant.*
+import com.dessalines.thumbkey.utils.KeyAction.*
+import com.dessalines.thumbkey.utils.SwipeNWay.*
+
+val KB_KR_ONETHUMB_MAIN =
+    KeyboardC(
+        listOf(
+            listOf(
+                KeyItemC(
+                    topLeft = KeyC("{", color = MUTED),
+                    top = KeyC("[", color = MUTED),
+                    topRight = KeyC("<", color = MUTED),
+                    left = KeyC("@", color = MUTED),
+                    center = KeyC("ㅅ", size = LARGE),
+                    right = KeyC("*", color = MUTED),
+                    bottomLeft = KeyC("°", color = MUTED),
+                    bottom = KeyC("0", color = MUTED),
+                    bottomRight = KeyC("ㅃ"),
+                ),
+                KeyItemC(
+                    topLeft = KeyC("^", color = MUTED),
+                    top = KeyC(";", color = MUTED),
+                    topRight = KeyC("?", color = MUTED),
+                    left = KeyC("#", color = MUTED),
+                    center = KeyC("ㅗ", size = LARGE),
+                    right = KeyC("/", color = MUTED),
+                    bottomLeft = KeyC("~", color = MUTED),
+                    bottom = KeyC("ㅍ"),
+                    bottomRight = KeyC("ㅊ"),
+                ),
+                KeyItemC(
+                    topLeft = KeyC("€", color = MUTED),
+                    top = KeyC("§", color = MUTED),
+                    topRight = KeyC("+", color = MUTED),
+                    left = KeyC("&", color = MUTED),
+                    center = KeyC("ㄱ", size = LARGE),
+                    right = KeyC("$", color = MUTED),
+                    bottomLeft = KeyC("ㅖ"),
+                    bottom = KeyC("ㄸ"),
+                    bottomRight = KeyC("|", color = MUTED),
+                ),
+                EMOJI_KEY_ITEM,
+            ),
+            listOf(
+                KeyItemC(
+                    topLeft = KeyC("1", color = MUTED),
+                    top = KeyC("2", color = MUTED),
+                    topRight = KeyC("3", color = MUTED),
+                    left = KeyC("%", color = MUTED),
+                    center = KeyC("ㄹ", size = LARGE),
+                    right = KeyC("ㄲ"),
+                    bottomLeft = KeyC("4", color = MUTED),
+                    bottom = KeyC("5", color = MUTED),
+                    bottomRight = KeyC("6", color = MUTED),
+                ),
+                KeyItemC(
+                    topLeft = KeyC("ㅔ"),
+                    top = KeyC("ㅛ"),
+                    topRight = KeyC("ㅑ"),
+                    left = KeyC("ㅠ"),
+                    center = KeyC("ㅇ", size = LARGE),
+                    right = KeyC("ㅎ"),
+                    bottomLeft = KeyC("ㅋ"),
+                    bottom = KeyC("ㅕ"),
+                    bottomRight = KeyC("ㅜ"),
+                ),
+                KeyItemC(
+                    topLeft = KeyC(".", color = MUTED),
+                    top = KeyC("ㅒ"),
+                    topRight = KeyC("`", color = MUTED),
+                    left = KeyC("ㅐ"),
+                    center = KeyC("ㅏ", size = LARGE),
+                    right = KeyC("\\", color = MUTED),
+                    bottomLeft = KeyC("ㅓ"),
+                    bottom = KeyC("\"", color = MUTED),
+                    bottomRight = KeyC("!", color = MUTED),
+                ),
+                NUMERIC_KEY_ITEM,
+            ),
+            listOf(
+                KeyItemC(
+                    topLeft = KeyC("7", color = MUTED),
+                    top = KeyC("8", color = MUTED),
+                    topRight = KeyC("9", color = MUTED),
+                    left = KeyC("=", color = MUTED),
+                    center = KeyC("ㅡ", size = LARGE),
+                    right = KeyC("'", color = MUTED),
+                    bottomLeft = KeyC("}", color = MUTED),
+                    bottom = KeyC("]", color = MUTED),
+                    bottomRight = KeyC(">", color = MUTED),
+                ),
+                KeyItemC(
+                    topLeft = KeyC("(", color = MUTED),
+                    top = KeyC("ㅂ"),
+                    topRight = KeyC("ㄷ"),
+                    left = KeyC("ㅌ"),
+                    center = KeyC("ㄴ", size = LARGE),
+                    right = KeyC("ㅉ"),
+                    bottomLeft = KeyC(")", color = MUTED),
+                    bottom = KeyC(",", color = MUTED),
+                    bottomRight = KeyC("-", color = MUTED),
+                ),
+                KeyItemC(
+                    topLeft = KeyC("ㅁ"),
+                    top = KeyC("ㅈ"),
+                    topRight = KeyC("₩", color = MUTED),
+                    left = KeyC("ㅆ"),
+                    center = KeyC("ㅣ", size = LARGE),
+                    right = KeyC("_", color = MUTED),
+                    bottomLeft = KeyC(":", color = MUTED),
+                    bottom = KeyC("´", color = MUTED),
+                    bottomRight = KeyC("…", color = MUTED),
+                ),
+                BACKSPACE_KEY_ITEM,
+            ),
+            listOf(
+                SPACEBAR_KEY_ITEM,
+                RETURN_KEY_ITEM,
+            ),
+        ),
+    )
+
+val KB_KR_ONETHUMB: KeyboardDefinition =
+    KeyboardDefinition(
+        title = "한국어 one-thumb",
+        modes =
+            KeyboardDefinitionModes(
+                main = KB_KR_ONETHUMB_MAIN,
+                shifted = KB_KR_ONETHUMB_MAIN,
+                numeric = NUMERIC_KEYBOARD,
+            ),
+        settings =
+            KeyboardDefinitionSettings(
+                textProcessor = KoreanTextProcessor(),
+            ),
+    )

--- a/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
@@ -149,6 +149,7 @@ import com.dessalines.thumbkey.keyboards.KB_JA_KATAKANA_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_JA_KATAKANA_TYPESPLIT
 import com.dessalines.thumbkey.keyboards.KB_KA_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_KN_THUMBKEY
+import com.dessalines.thumbkey.keyboards.KB_KR_ONETHUMB
 import com.dessalines.thumbkey.keyboards.KB_KR_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_KR_TYPESPLIT
 import com.dessalines.thumbkey.keyboards.KB_KZ_THUMBKEY
@@ -410,4 +411,5 @@ enum class KeyboardLayout(
     THThumbKey(KB_TH_THUMBKEY), // ภาษาไทย thai thumb-key
     THThumbKeyKhamChueam(KB_TH_THUMBKEY_KHAM_CHUEAM), // ภาษาไทย thai thumb-key คำเชื่อม",
     NOThumbKeyDataDriven(KB_NO_THUMBKEY_DATADRIVEN), // norsk thumb-key datadrevet
+    KROneThumb(KB_KR_ONETHUMB), // 한국어 one-thumb
 }


### PR DESCRIPTION
I designed a new thumb-key layout for Korean. My main issue with the first version is that 11 of the 33 keys are on the shifted layer, which makes them cumbersome to reach considering that there is plenty space on the main layer to not have to use the shifted one. See the next paragraph for the goal of the layout design. This patch replaces the existing layout, if this is not wanted, I can instead change the patch to introduce a new one. Would be interested what @Hate9 thinks.

<img width="180" height="181" alt="grafik" src="https://github.com/user-attachments/assets/55dab22c-8c12-4bc4-8376-956de1160da3" />

I will detail the process I followed below, some of it will be Korean specific, but most of it will be quite general and could be used to improve other layouts too. First, however, I want to state that this layout was created with an optimizer and I was specifically targetting single thumb usage and trying to stay close to what typical thumb-key layouts look like (most frequent letters as taps and then the optimizer prefered to-/from-center swipes without explicitly putting the next most frequent ones there). As the layout is targetting single-thumb/single-hand, I ignore the alternating between consonants and vowels as [suggested by the readme](https://github.com/dessalines/thumb-key/?tab=readme-ov-file#thumb-key-letter-positions). However, I did prioritize the bottom right side of the keyboard. Notably, I did not consider learnability of the layout, which means that similar vowels and consonants which would be at similar positions logically are placed without any such consideration and therefore make the layout look a bit chaotic. Instead, I ran the optimizer to make sure that bigrams can be typed as easily as possible by being able to type as many bigrams as possible while staying on the same key. This can be seen, for example, by looking at [the most frequent bigrams 하 or 해](https://ftp.kref.altervista.org/kreffrequency.html) which can be typed by swiping from the center to the right and then tapping there or swiping back to the center. I also filled up any empty spots with symbols and removed the shifting functionality as it is not necessary anymore.

-----

I am using a [quite powerful existing keyboard layout optimization software](https://github.com/dariogoetz/keyboard_layout_optimizer), originally developed for hardware keyboards, and extended it a bit with new metrics to [support designing thumb-key layouts](https://github.com/neXyon/keyboard_layout_optimizer/tree/thumbkey). In order to develop these new metrics and used them to create a new layout, I did some perparatory steps.

First, I needed n-gram files, i.e., 1-gram, 2-gram and 3-gram files for the optimizer to work with. Since it doesn't include any for Korean, I had to create them myself. The first dataset I found for it was [3i4K](https://github.com/warnikchow/3i4k), but I then found a bigger one, [CC-100](https://data.statmt.org/cc-100/), that has more languages available and which my n-gram files are based on.

Korean specific: since Korean is written in syllables made up of letters, there exist [a few different encodings](https://en.wikipedia.org/wiki/Hangul#Hangul_and_computers). I wrote a python script that transforms all these into the same encoding and splits double-vowels and double-consonants that don't exist as such on the Korean dubeolsik keyboard before then counting unigrams, bigrams and trigrams.

My first idea was to simply compute distances within bigrams to represent the cost of finger movement: for each letter (tap or swipe) I would compute the starting and end position (same as start for taps, or the neighboring key for swipes in the respective direction) and each bigram gets the distance between first letter end position and second letter starting position plus the distance between second letter starting position and second letter end position. That should cover the whole movement if you consider a whole text split up into bigrams, except for the movement of the very first letter, which, however, is negligible. Minimizing this movement would lead to an optimal layout, I thought.

Optimizing with this metric only, where, e.g., for the 26 English letters most of the typing is concentrated on four keys plus four side keys, ignoring the 9th key all together:

```
┌─────┬─────┬─────┐
│     │     │     │
│  f j│  o k│y l  │
│     │  u w│  m  │
├─────┼─────┼─────┤
│     │  c b│q ⇧  │
│  s p│g n r│a e  │
│     │  t z│x ⇣  │
├─────┼─────┼─────┤
│     │  i  │  v  │
│     │  h  │  d  │
│     │     │     │
├─────┴─────┴─────┤
│                 │
│                 │
│                 │
└─────────────────┘
```

Not for Korean, but at least for English, it also put out thumb-key like layouts:

```
┌─────┬─────┬─────┐
│     │     │     │
│  k  │g n  │  d  │
│    z│  c  │v    │
├─────┼─────┼─────┤
│     │  i  │  ⇧  │
│  t h│s e a│r l  │
│    q│  m x│j ⇣  │
├─────┼─────┼─────┤
│    w│  u  │b p  │
│  f  │  o  │  y  │
│     │     │     │
├─────┴─────┴─────┤
│                 │
│                 │
│                 │
└─────────────────┘
```

Every run was different and I was not satisfied with the result and I had no idea, if my idealistic metrics made any sense, so I set out to do some more data collection.

In order to do so, I implemented a [thumb-key extension that works a little bit like a game](https://github.com/neXyon/thumb-key/tree/trainer): it shows you a 3x3 grid and within that grid a symbol, either a circle to tap or an arrow with the swipe direction. A big and red symbol means that is what you should type right now and smaller, grey symbol is the next one upcoming. Doing this, I recorded a bit more than 6000 sample inputs that I evaluated in terms of errors and speed. Unfortunately, I realized that in order to get enough data for 81 possible inputs, or 81*81=6561 possible bigrams, I would need quite a lot more data to get values that have meaningful and statistically significant differences in order to use them for training a model. This would require many hours of input, which I am not willing to invest, especially since it then would be trained for me and the data is not perfect either, as it is not fully equal to real typing (errors and speed also include parsing the visual input/interpreting the circle and arrows correctly). Such an avenue could be persued further, but then I think logging of actual typing of many users would produce better data than this. However, playing with the data I had, I extracted insights that will probably surprise nobody, but informed my next steps: tapping is faster than swiping, for me about 100 ms faster. When the next starting position is where the end position of the previous key was, I am also faster, about 25 ms. What is interesting as well is what I could not get out of the data: What I could not see conclusively, due to the low amount of data, is whether there are differences between the keys or the swipe directions. However, the difference seems to be rather small. As I observed myself typing I noticed one thing: if I swipe in one direction, e.g., to the right, even if my next key is two further to the right, I stop planar movement to lift up the finger and then restart planar movement to the next starting position. Maybe that is just me, but my conclusion of this is that if I swipe right and my next key is the direct right neighbor, I can speed up things, but if it would be the second right neighbor, I do not get any benefit. I would be curious if other people observe the same behavior or if it's different?

<img width="180" height="400" alt="grafik" src="https://github.com/user-attachments/assets/b9f0214f-ba9f-42ac-904f-212a8d4173f2" />

So far, I was thinking only about single-hand input, but I also started to think about two-handed input. Obviously, the left thumb would type the left column's keys and the right thumb the right column's keys, but what about the center? Ideally, fingers would alternate so that you can type fastest and while one finger is typing the other one can already move to the next key's position. Collisions between the two thumbs would slow you down though. If center column keys can be typed by either left or right thumb, then determining which one types it would depend on the keys before and after, i.e., which side is used to type them and whether collisions are possible. I developed an algorithm that assigns left or right to the center keys within trigrams based on collisions between the keys: same side in case of collision, different in case of none under the assumption that its faster to use the same finger again in case of a collision. With that I then developed a trigram metric for the optimizer that determines the sides for the center columns, gives penalties for swiping instead of tapping, a bonus if the same finger is used on a key where it stops (end position = next start position again), a bonus for switching fingers and a penalty for collisions between different sides or a collision within an alternating trigram as the finger of the first key in the trigram moves to the third key, colliding with the finger typing the second. Here are a few keyboard layouts for English that this metric created:

```
┌─────┬─────┬─────┐
│     │  g k│  m v│
│  o  │  t d│  r  │
│  u  │    b│  w x│
├─────┼─────┼─────┤
│     │  f  │  ⇧ j│
│  a  │  s  │  l h│
│     │  p  │  ⇣ z│
├─────┼─────┼─────┤
│     │  y  │  c  │
│  e  │  i  │  n  │
│     │  q  │     │
├─────┴─────┴─────┤
│                 │
│                 │
│                 │
└─────────────────┘

┌─────┬─────┬─────┐
│     │     │     │
│  s  │  o  │  e  │
│q b  │  p  │     │
├─────┼─────┼─────┤
│  w  │  h  │  ⇧ u│
│  l  │  t  │  a  │
│z f  │  k y│  ⇣  │
├─────┼─────┼─────┤
│  m  │g c  │     │
│x r  │  n  │  i  │
│  v  │j d  │     │
├─────┴─────┴─────┤
│                 │
│                 │
│                 │
└─────────────────┘
```

Interestingly, the sides get quite separated, leading me to the conclusion that such a 3x3 layout is not really ideal for two finger typing and the type-split layouts that thumb-key have might be a better fit for two-handed typing.

I also noticed that this trigram metric is way too complicated and the various penalties and bonuses feel impossible to tune. It also is implemented only for three columns and other configurations are not supported due to the side assignment. Therefore, I decided to simplify things and implement easier metrics that are easier to work with and easier to be interpreted, mostly [based on or similar to the work](https://github.com/dessalines/thumb-key/issues/169#issuecomment-1519001557) of @domportera. For side assignment it doesn't consider the my complicated trigram metric, but it uses a fixed assignment per key/tap/swipe through the functionality already present in the optimizer.

1. the optimizer's existing **key costs** can be used to assign a cost to each tap/swipe which allows to control *position preferences*, *preferred swipe directions* and *prefer tapping over swiping*.
2. a **bigram distance metric** measures the distance between the two keys of the bigram if they are typed by the same side (pretty much the same as my first bigram metric). A configurable weight can control whether the movement of swiping should be considered.
3. a **trigram distance metric** does the same for alternating trigrams between first and third key.
4. a **bigram same-key metric** that gives a bonus if the same side is used and the end position of the first key equals the start position of the next key. That is a simplified version of my first bigram metric.
5. a **trigram same-key metric** that is again similar as the above for side-alternating trigrams.
6. a **bigram hand switches metric** that gives a bonus for bigrams that switch sides.
7. a **hand disbalance metric** that measures how balanced the two-handed layout is by giving a penalty for a devition from a 50:50 load between the two thumbs. This one was not considered by @domportera but was already present in the optimizer.

As you can see, most of these are for two-handed typing, while only metrics 1, 2 and 4 make sense for a single thumb key.

I also added the space key at this time to the layout to include it in the optimization. If you do that and run for example my first, distance metric, you get layouts that move to the bottom and ignore the upper row completely:

```
┌─────┬─────┬─────┐
│     │     │     │
│     │     │     │
│     │     │     │
├─────┼─────┼─────┤
│     │     │  ⇧  │
│  l v│p e x│g n  │
│     │  r q│d ⇣  │
├─────┼─────┼─────┤
│     │b h w│m u  │
│  a k│c t i│f o  │
│    y│  s j│  z  │
├─────┴─────┴─────┤
│                 │
│                 │
│                 │
└─────────────────┘
```

This would mean you can drop the top row. With considering taps better than swipes, it still focuses on the bottom half, e.g.:

```
┌─────┬─────┬─────┐
│     │     │     │
│  l  │  i  │  c  │
│     │  z  │     │
├─────┼─────┼─────┤
│     │     │  ⇧  │
│  s  │k t  │  n  │
│  v  │h g q│  ⇣  │
├─────┼─────┼─────┤
│    x│b w j│     │
│  e m│r a p│u o  │
│    y│  d  │  f  │
├─────┴─────┴─────┤
│                 │
│                 │
│                 │
└─────────────────┘
```

This brings me to another observation I had, one that I would be curious about what other people think and something I would like to try out in future layouts: the dogma of having a separate key for space and return. I would like to try simply treating these like any other character. Given that, space would be placed on a tap being the most frequent unigram and return would probably turn into a swipe, not wasting the space of a whole key anymore.

Similarly, I also like to not waste space for unused swipes in the layouts, so I prefer to fill them up with symbols for which there is plenty space in the 3x3 layouts. This usually also means that there is no urgent need for having the number layer as a tap and in the future, I would like to combine the number layer key with the backspace key (swiping/sliding left/right is free there so that should still work?) and moving the number layer to a swipe on the emoji key. That would reduce the special keys to two when space and return are treated as other characters and the sliding for moving the cursor could also be integrated with another key, moving it away from space as this allows better bigram/trigram optimization with the space character.

So, I might design some two handed 4x3 or 6x3 layouts in the future with all these thoughts for which I would love input, but for now lets get back to this PR. As the 3x3 layout is not optimal for two-handed input, I decided to go single handed with this to get a layout that's similar to the other thumb-key layouts and the Korean one I wanted to improve upon. With the metrics and information I gathered so far, I designed the layout in this PR with the following final process:

0. I disabled considering the space key in the optimization to not pull the layout towards the bottom and keep it similar to other thumb-key layouts.
1. prefering 2x2 keys in the bottom right corner, I placed the 4 most frequent unigrams there and put the next 5 on the remaining 5 taps. I already did this with some weighted keys and the optimizer to not hinder future optimization.
2. With the first 9 keys fixed, I change optimizer settings to focus more on the same-key metric as it seemed more important than the distance metric based on my data analysis. I played around with different key weights and the weight for the distance metric but ended up disabling these altogether as they seemed to make the results just worse and I had no basis to put the weights, i.e., no data that would support these metrics.
3. I fixed all the letters and added the symbols to be optimized for the same metric as well. Here I did some finetuning by manually replacing the numbers and various bracket types to not make all the symbols too chaotic looking but still consider optimizations that the optimizer found, e.g., space following closing brackets or numbers typically following an opening round bracket.

Would be super curious for any feedback about anything I wrote!
