### PR TITLE
Restore MessagEase compatibility for deutsch + æøå

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEaseNordic.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEaseNordic.kt
@@ -46,7 +46,7 @@ val KB_DE_NORDIC_MESSAGEASE_MAIN =
             listOf(
                 KeyItemC(
                     center = KeyC("h", size = LARGE),
-                    top = KeyC("ü"),
+                    top = KeyC("æ"),
                     topLeft = KeyC("{", color = MUTED),
                     left = KeyC("(", color = MUTED),
                     bottomLeft = KeyC("[", color = MUTED),
@@ -97,7 +97,6 @@ val KB_DE_NORDIC_MESSAGEASE_MAIN =
                     right = KeyC("*", color = MUTED),
                     topRight = KeyC("y"),
                     top = KeyC("ø"),
-                    bottom = KeyC("ß"),
                     bottomRight =
                         KeyC(
                             display = KeyDisplay.IconDisplay(Icons.AutoMirrored.Outlined.KeyboardTab),
@@ -109,7 +108,6 @@ val KB_DE_NORDIC_MESSAGEASE_MAIN =
                     center = KeyC("e", size = LARGE),
                     top = KeyC("w"),
                     topLeft = KeyC("\"", color = MUTED),
-                    left = KeyC("æ"),
                     bottomLeft = KeyC(",", color = SECONDARY),
                     bottom = KeyC(".", color = SECONDARY),
                     bottomRight = KeyC(":", color = SECONDARY),
@@ -169,7 +167,7 @@ val KB_DE_NORDIC_MESSAGEASE_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("H", size = LARGE),
-                    top = KeyC("Ü"),
+                    top = KeyC("Æ"),
                     topLeft = KeyC("{", color = MUTED),
                     left = KeyC("(", color = MUTED),
                     bottomLeft = KeyC("[", color = MUTED),
@@ -223,7 +221,6 @@ val KB_DE_NORDIC_MESSAGEASE_SHIFTED =
                     right = KeyC("*", color = MUTED),
                     topRight = KeyC("Y"),
                     top = KeyC("Ø"),
-                    bottom = KeyC("ẞ"),
                     bottomRight =
                         KeyC(
                             display = KeyDisplay.IconDisplay(Icons.AutoMirrored.Outlined.KeyboardTab),
@@ -235,7 +232,6 @@ val KB_DE_NORDIC_MESSAGEASE_SHIFTED =
                     center = KeyC("E", size = LARGE),
                     top = KeyC("W"),
                     topLeft = KeyC("\"", color = MUTED),
-                    left = KeyC("Æ"),
                     bottomLeft = KeyC(",", color = SECONDARY),
                     bottom = KeyC(".", color = SECONDARY),
                     bottomRight = KeyC(":", color = SECONDARY),


### PR DESCRIPTION
In pull request #832, merged as commit 77e058f, the layout "deutsch+æøå" was introduced for compatibility to the similarily named layout "German+ÆØÅ" in MessagEase.

In the commit message of that change, it was explicitly noted the differences between this and the "deutsch" layout, notably:

- (2) Top swipe on center left key H is Æ instead of Ü
- (4) Top swipe on lower left key in numeric keyboard is umlaut/diaeresis
- (5) Bottom swipe on lower left key T does not show eszett

In issue #1027/pull request #1028, merged as commit 5458d36, user @MarvinBaral undid these points. No comment was solicited from the author of the original, nor was there any discussion of these changes.

In the issue it was simply stated that the characters ü and ß was "missing" and that their omission is a "mistake".

However, these differences were quite intentional, as the variant is not intended to be German with some funny characters added. Rather, its entire rationale is that the Scandinavian branch of North-Germanic languages (i.e. Norwegian, Swedish, Danish) have a lot of phonology in common with German, but with some distinct differences. In particular ü is used only in foreign proper names, and ß is never used. Conversely, æ, ø and å is heavily used in Scandinavian but not present as characters in regular German at all. If there is any error, it is in not naming the variant "Scandinavian" or "Nordic" instead.

In this light, the changes in #1028 seems scantly motivated, as they changed the "deutsch + æøå" variant into something for which there is little demand other than perhaps allowing the author to write both Norwegian and German with the same layout.

A lot of research went into the MessagEase layouts to make sure that phonemes should be easily tapped in the target languages. I think that the bar for breaking this should be higher than a single user's personal preferences, in particular one that changes the layout for everyone else.

This patch changes the layout back to as it was originally submitted.