### PR TITLE
Navigation bar to follow keyboard background color

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/ComposeKeyboardView.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ComposeKeyboardView.kt
@@ -42,13 +42,13 @@ class ComposeKeyboardView(
             settings = settings,
         ) {
             val colorScheme = MaterialTheme.colorScheme
-            val darkTheme = when(ThemeMode.entries[settings?.theme ?: 0]) {
-                ThemeMode.System -> isSystemInDarkTheme()
-                ThemeMode.Light -> false
-                ThemeMode.Dark -> true
-            }
+            val darkTheme =
+                when (ThemeMode.entries[settings?.theme ?: 0]) {
+                    ThemeMode.System -> isSystemInDarkTheme()
+                    ThemeMode.Light -> false
+                    ThemeMode.Dark -> true
+                }
             CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
-
                 KeyboardScreen(
                     settings = settings,
                     onSwitchLanguage = {
@@ -110,13 +110,15 @@ class ComposeKeyboardView(
                     },
                 )
                 SideEffect {
-                    ctx.window?.window?.apply{
+                    ctx.window?.window?.apply {
                         /*
                         deprecated, but cannot find the proper way... Also, this feels a lot like
                         a workaround, not a proper solution. Still, it seems to work.
                          */
+                        @Suppress("DEPRECATION")
                         navigationBarColor = colorScheme.background.toArgb()
-                        WindowCompat.getInsetsController(this, decorView)
+                        WindowCompat
+                            .getInsetsController(this, decorView)
                             .isAppearanceLightNavigationBars = !darkTheme
                     }
                 }


### PR DESCRIPTION
I noticed that on my Samsung S20FE (API 33) the navigation bar would not respect the keyboard background colour. I decided to fork the project and implement a fix.

Unfortunately I could only make it work with a deprecated method, but in the free time I had today and with my limited knowledge of Jetpack Compose, that's the most I can do. 

Feel free to pull if you think it could be useful in the main project as well.