### PR TITLE
Correct a mistake in JAKanaStandard.kt

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/JAKanaStandard.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/JAKanaStandard.kt
@@ -157,7 +157,7 @@ val KB_JA_KANA_STANDARD_KATAKANA =
                 KeyItemC(
                     center = KeyC("サ", size = LARGE),
                     swipeType = FOUR_WAY_CROSS,
-                    left = KeyC("ソ"),
+                    left = KeyC("シ"),
                     top = KeyC("ス"),
                     right = KeyC("セ"),
                     bottom = KeyC("ソ"),


### PR DESCRIPTION
The key that should be サ・シ・ス・セ・ソ was サ・ソ・ス・セ・ソ（no シ, double ソ）.