### PR TITLE
Add keyboard position padding for horizontal positioning

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/db/AppDb.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/db/AppDb.kt
@@ -33,6 +33,7 @@ const val DEFAULT_KEY_HEIGHT = DEFAULT_KEY_WIDTH
 const val DEFAULT_ANIMATION_SPEED = 250
 const val DEFAULT_ANIMATION_HELPER_SPEED = 250
 const val DEFAULT_POSITION = 0
+const val DEFAULT_POSITION_PADDING = 0
 const val DEFAULT_AUTO_CAPITALIZE = 1
 const val DEFAULT_KEYBOARD_LAYOUT = 0
 const val DEFAULT_THEME = 0
@@ -318,6 +319,11 @@ data class AppSettings(
         defaultValue = DEFAULT_CLIPBOARD_MAX_SIZE.toString(),
     )
     val clipboardMaxSize: Int,
+    @ColumnInfo(
+        name = "position_padding",
+        defaultValue = DEFAULT_POSITION_PADDING.toString(),
+    )
+    val positionPadding: Int,
 )
 
 data class LayoutsUpdate(
@@ -422,6 +428,10 @@ data class LookAndFeelUpdate(
         name = "vibrate_on_slide",
     )
     val vibrateOnSlide: Int,
+    @ColumnInfo(
+        name = "position_padding",
+    )
+    val positionPadding: Int,
 )
 
 data class BehaviorUpdate(
@@ -571,7 +581,7 @@ class AppSettingsRepository(
 }
 
 @Database(
-    version = 23,
+    version = 24,
     entities = [AppSettings::class],
     exportSchema = true,
 )
@@ -616,6 +626,7 @@ abstract class AppDB : RoomDatabase() {
                             MIGRATION_20_21,
                             MIGRATION_21_22,
                             MIGRATION_22_23,
+                            MIGRATION_23_24,
                         )
                         // Necessary because it can't insert data on creation
                         .addCallback(

--- a/app/src/main/java/com/dessalines/thumbkey/db/Migrations.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/db/Migrations.kt
@@ -266,3 +266,12 @@ val MIGRATION_22_23 =
             )
         }
     }
+
+val MIGRATION_23_24 =
+    object : Migration(23, 24) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL(
+                "ALTER TABLE AppSettings ADD COLUMN position_padding INTEGER NOT NULL DEFAULT $DEFAULT_POSITION_PADDING",
+            )
+        }
+    }

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
@@ -62,6 +62,7 @@ import com.dessalines.thumbkey.db.DEFAULT_KEY_WIDTH
 import com.dessalines.thumbkey.db.DEFAULT_MIN_SWIPE_LENGTH
 import com.dessalines.thumbkey.db.DEFAULT_NON_SQUARE_KEYS
 import com.dessalines.thumbkey.db.DEFAULT_POSITION
+import com.dessalines.thumbkey.db.DEFAULT_POSITION_PADDING
 import com.dessalines.thumbkey.db.DEFAULT_PUSHUP_SIZE
 import com.dessalines.thumbkey.db.DEFAULT_SLIDE_BACKSPACE_DEADZONE_ENABLED
 import com.dessalines.thumbkey.db.DEFAULT_SLIDE_CURSOR_MOVEMENT_MODE
@@ -185,6 +186,8 @@ fun KeyboardScreen(
             settings?.position
                 ?: DEFAULT_POSITION,
         ]
+
+    val positionPadding = settings?.positionPadding ?: DEFAULT_POSITION_PADDING
 
     val pushupSizeDp = (settings?.pushupSize ?: DEFAULT_PUSHUP_SIZE).dp
     val ignoreBottomPadding = (settings?.ignoreBottomPadding ?: DEFAULT_IGNORE_BOTTOM_PADDING).toBool()
@@ -560,7 +563,13 @@ fun KeyboardScreen(
             Log.d(TAG, "request for cursor updates failed, cursor updates will not be provided")
         }
 
-        val drawKeyboard = @Composable { alignment: Alignment, drawBackdrop: Boolean ->
+        val drawKeyboard = @Composable { alignment: Alignment, drawBackdrop: Boolean, positionPadding: Int ->
+            val modifierPositionPadding =
+                if (positionPadding > 0) {
+                    Modifier.padding(start = positionPadding.dp)
+                } else {
+                    Modifier.padding(end = -positionPadding.dp)
+                }
             Box(
                 contentAlignment = alignment,
                 modifier =
@@ -587,7 +596,7 @@ fun KeyboardScreen(
                                 .background(color = MaterialTheme.colorScheme.surfaceVariant),
                     )
                 }
-                Column {
+                Column(modifier = modifierPositionPadding) {
                     keyboard.arr.forEachIndexed { i, row ->
                         Row {
                             row.forEachIndexed { j, key ->
@@ -756,9 +765,9 @@ fun KeyboardScreen(
             }
         }
 
-        drawKeyboard(keyboardPositionToAlignment(position), backdropEnabled)
+        drawKeyboard(keyboardPositionToAlignment(position), backdropEnabled, positionPadding)
         if (position == KeyboardPosition.Dual) {
-            drawKeyboard(keyboardPositionToAlignment(KeyboardPosition.Right), false)
+            drawKeyboard(keyboardPositionToAlignment(KeyboardPosition.Right), false, positionPadding)
         }
     }
 }

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/backupandrestore/BackupAndRestoreScreen.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/backupandrestore/BackupAndRestoreScreen.kt
@@ -64,6 +64,7 @@ import com.dessalines.thumbkey.db.DEFAULT_KEY_WIDTH
 import com.dessalines.thumbkey.db.DEFAULT_MIN_SWIPE_LENGTH
 import com.dessalines.thumbkey.db.DEFAULT_NON_SQUARE_KEYS
 import com.dessalines.thumbkey.db.DEFAULT_POSITION
+import com.dessalines.thumbkey.db.DEFAULT_POSITION_PADDING
 import com.dessalines.thumbkey.db.DEFAULT_PUSHUP_SIZE
 import com.dessalines.thumbkey.db.DEFAULT_SHOW_TOAST_ON_LAYOUT_SWITCH
 import com.dessalines.thumbkey.db.DEFAULT_SLIDE_BACKSPACE_DEADZONE_ENABLED
@@ -238,6 +239,7 @@ private fun resetAppSettingsToDefault(appSettingsViewModel: AppSettingsViewModel
             slideSensitivity = DEFAULT_SLIDE_SENSITIVITY,
             soundOnTap = DEFAULT_SOUND_ON_TAP,
             position = DEFAULT_POSITION,
+            positionPadding = DEFAULT_POSITION_PADDING,
             pushupSize = DEFAULT_PUSHUP_SIZE,
             minSwipeLength = DEFAULT_MIN_SWIPE_LENGTH,
             keyboardLayout = DEFAULT_KEYBOARD_LAYOUT,

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/lookandfeel/LookAndFeelScreen.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/lookandfeel/LookAndFeelScreen.kt
@@ -62,6 +62,7 @@ import com.dessalines.thumbkey.db.DEFAULT_KEY_RADIUS
 import com.dessalines.thumbkey.db.DEFAULT_KEY_WIDTH
 import com.dessalines.thumbkey.db.DEFAULT_NON_SQUARE_KEYS
 import com.dessalines.thumbkey.db.DEFAULT_POSITION
+import com.dessalines.thumbkey.db.DEFAULT_POSITION_PADDING
 import com.dessalines.thumbkey.db.DEFAULT_PUSHUP_SIZE
 import com.dessalines.thumbkey.db.DEFAULT_SHOW_TOAST_ON_LAYOUT_SWITCH
 import com.dessalines.thumbkey.db.DEFAULT_SOUND_ON_TAP
@@ -124,6 +125,9 @@ fun LookAndFeelScreen(
 
     var positionState = KeyboardPosition.entries[settings?.position ?: DEFAULT_POSITION]
 
+    var positionPaddingState = (settings?.positionPadding ?: DEFAULT_POSITION_PADDING).toFloat()
+    var positionPaddingSliderState by remember { mutableFloatStateOf(positionPaddingState) }
+
     var vibrateOnTapState = (settings?.vibrateOnTap ?: DEFAULT_VIBRATE_ON_TAP).toBool()
     var vibrateOnSlideState = (settings?.vibrateOnSlide ?: DEFAULT_VIBRATE_ON_SLIDE).toBool()
     var soundOnTapState = (settings?.soundOnTap ?: DEFAULT_SOUND_ON_TAP).toBool()
@@ -144,6 +148,7 @@ fun LookAndFeelScreen(
                 animationSpeed = animationSpeedState.toInt(),
                 animationHelperSpeed = animationHelperSpeedState.toInt(),
                 position = positionState.ordinal,
+                positionPadding = positionPaddingState.toInt(),
                 vibrateOnTap = vibrateOnTapState.toInt(),
                 vibrateOnSlide = vibrateOnSlideState.toInt(),
                 soundOnTap = soundOnTapState.toInt(),
@@ -251,6 +256,33 @@ fun LookAndFeelScreen(
                         },
                         title = {
                             Text(stringResource(R.string.position))
+                        },
+                        icon = {
+                            Icon(
+                                imageVector = Icons.Outlined.LinearScale,
+                                contentDescription = null,
+                            )
+                        },
+                    )
+
+                    SliderPreference(
+                        value = positionPaddingState,
+                        sliderValue = positionPaddingSliderState,
+                        onValueChange = {
+                            positionPaddingState = it
+                            updateLookAndFeel()
+                        },
+                        onSliderValueChange = {
+                            positionPaddingSliderState = it
+                        },
+                        valueRange = -200f..200f,
+                        title = {
+                            val positionPaddingStr =
+                                stringResource(
+                                    R.string.position_padding,
+                                    positionPaddingSliderState.toInt().toString(),
+                                )
+                            Text(positionPaddingStr)
                         },
                         icon = {
                             Icon(
@@ -520,7 +552,7 @@ fun LookAndFeelScreen(
                             updateLookAndFeel()
                         },
                         onSliderValueChange = { pushupSizeSliderState = it },
-                        valueRange = 0f..200f,
+                        valueRange = 0f..250f,
                         title = {
                             val bottomOffsetStr = stringResource(R.string.bottom_offset, pushupSizeSliderState.toInt().toString())
                             Text(bottomOffsetStr)

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -39,6 +39,7 @@
     <string name="theme">Thème</string>
     <string name="theme_color">Couleur du thème</string>
     <string name="position">Position</string>
+    <string name="position_padding">Décalage ajouté à la position: %1$s</string>
     <string name="vibrate_on_tap">Vibration au toucher</string>
     <string name="vibrate_warning">Nécessite d’activer Vibrer à l’appui dans les paramètres du téléphone</string>
     <string name="play_sound_on_tap">Son au toucher</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,6 +40,7 @@
     <string name="theme">Theme</string>
     <string name="theme_color">Theme color</string>
     <string name="position">Position</string>
+    <string name="position_padding">Position padding: %1$s</string>
     <string name="vibrate_on_tap">Vibrate on tap</string>
     <string name="vibrate_warning">Requires touch feedback to be enabled in system settings</string>
     <string name="vibrate_on_slide">Vibrate for slide gestures</string>


### PR DESCRIPTION
Fixes #783 

- Add _position padding_ parameter in _look and feel_ parameters. It allows to adjust the lateral position of the keyboard by adding a padding on its left or right.

- Increase _bottom offset_ maximum value from 200 to 250 as I’m using 200 currently and would benefit from adjusting to a higher value

Let me know if this looks good for you, this might be a bad way to do it, I’m not used to phone app development.

Tested on my phone as center / left / right. This can move the keyboard to any lateral position as expected.

If the padding is too important in one direction, the keyboard is "crushed" on one side, but that can be fixed by setting a correct value in the settings.

If we want to avoid that, not sure if some more logic would be useful for this, or just lower max values?