### PR TITLE
fix debug app name override by translations

### DIFF
--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">Thumb-Key (Debug)</string>
+    <string name="app_name" translatable="false">Thumb-Key (Debug)</string>
 </resources>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -3,7 +3,6 @@
     <string name="counterclockwise_drag_action">إجراء السحب عكس اتجاه عقارب الساعة</string>
     <string name="whats_new">ما الجديد</string>
     <string name="copy">تم نسخ النص المحدد</string>
-    <string name="app_name">مفتاح الإبهام</string>
     <string name="dynamic">ديناميكي</string>
     <string name="green">أخضر</string>
     <string name="pink">وردي</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Thumb-Key</string>
     <string name="settings">Настройки</string>
     <string name="system">Системна</string>
     <string name="light">Светла</string>

--- a/app/src/main/res/values-br/strings.xml
+++ b/app/src/main/res/values-br/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Thumb-Key</string>
     <string name="settings">Arventennoù</string>
     <string name="system">Reizhiad</string>
     <string name="light">Sklaer</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Thumb-Key</string>
     <string name="settings">Arranjament</string>
     <string name="system">Sistema</string>
     <string name="light">Clar</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Tommeltast</string>
     <string name="settings">Indstillinger</string>
     <string name="system">System</string>
     <string name="light">Lys</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Thumb-Key</string>
     <string name="settings">Einstellungen</string>
     <string name="system">System</string>
     <string name="light">Hell</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Thumb-Key</string>
     <string name="settings">Ajustes</string>
     <string name="system">Sistema</string>
     <string name="light">Claro</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Thumb-Key</string>
     <string name="settings">تنظیمات</string>
     <string name="system">سیستم</string>
     <string name="light">روشن</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Thumb-Key</string>
     <string name="settings">Paramètres</string>
     <string name="system">Système</string>
     <string name="light">Clair</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Thumb-Key</string>
     <string name="settings">Parametri</string>
     <string name="system">Sistema</string>
     <string name="light">Chiaro</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -50,7 +50,6 @@
     <string name="restore_database">データベースの復元</string>
     <string name="restore_database_warning">警告: これにより現在のデータベースが消去されます</string>
     <string name="vibrate_warning">システム設定でタッチフィードバックを有効にする必要があります</string>
-    <string name="app_name">Thumb-Key</string>
     <string name="source_code">ソースコード</string>
     <string name="position">位置</string>
     <string name="vibrate_on_tap">タップ時に振動</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="support">Wsparcie</string>
     <string name="version">Wersja %1$s</string>
-    <string name="app_name">Thumb-Key</string>
     <string name="settings">Ustawienia</string>
     <string name="system">System</string>
     <string name="light">Jasny</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Thumb Key</string>
     <string name="settings">Настройки</string>
     <string name="system">Системная</string>
     <string name="light">Светлая</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Thumb-Key</string>
     <string name="settings">Nastavenia</string>
     <string name="system">Systém</string>
     <string name="light">Svetlá</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Thumb-Key</string>
     <string name="settings">Nastavitve</string>
     <string name="system">Sistem</string>
     <string name="light">Svetli</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -54,7 +54,6 @@
     <string name="database_restored">Veriler Geri Döndürüldü.</string>
     <string name="database_backed_up">Veriler Yedeklendi.</string>
     <string name="backup_and_restore">Yedekleme</string>
-    <string name="app_name">Thumb-Key</string>
     <string name="dark">Karanlık</string>
     <string name="center">Merkez</string>
     <string name="right">Sağ</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Thumb-Key</string>
     <string name="settings">Налаштування</string>
     <string name="system">Системна</string>
     <string name="light">Світла</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Thumb-Key</string>
     <string name="settings">设置</string>
     <string name="system">系统</string>
     <string name="light">亮色</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">Thumb-Key</string>
+    <string name="app_name" translatable="false">Thumb-Key</string>
     <string name="settings">Settings</string>
     <string name="system">System</string>
     <string name="light">Light</string>


### PR DESCRIPTION
Fixes an issue where when using the debug build type on a phone whose locale is not English, the translated app name overrides the debug app name.

fixes #1754