### PR TITLE
Add private clipboard option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@
     - [Example 4](#example-4)
     - [Example 5](#example-5)
     - [Example 6](#example-6)
+  - [Clipboard](#clipboard)
+    - [Clipboard history](#clipboard-history)
+    - [Private clipboard](#private-clipboard)
   - [Other](#other)
 - [Thumb-Key Design](#thumb-key-design)
   - [A History of Phone Keyboards](#a-history-of-phone-keyboards)
@@ -350,6 +353,22 @@ ENThumbKey:
 ```
 
 The attributes `swipeReturnText` and `swipeReturnAction` allow defining swipe-return behaviour. Possible values for `swipeReturnAction` are the same as the ones for `keyAction`.
+
+### Clipboard
+
+#### Clipboard history
+
+This feature retains the latest text clips that were copied/cut, so that you can select an older one. It’s enabled in the parameters and accessible through a swipe-return on the _paste_ slide action.
+
+#### Private clipboard
+
+Once enabled, text copied or cut through the copy/cut actions in ThumbKey won’t be shared with the system clipboard of Android.
+Instead, it will be stored in the app’s memory and pasted from there instead of from the system clipboard.
+
+Note that using cut/copy/paste controls from outside the keyboard will use the standard system clipboard and not ThumbKey’s private one.
+
+This ensures more privacy, as data added to the system clipboard can actually be accessed by any app.
+In some Android devices such as _samsung_ devices, it is also automatically retrieved and stored by a proprietary application, without any option to disable it.
 
 ### Other
 

--- a/app/src/main/java/com/dessalines/thumbkey/IMEService.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/IMEService.kt
@@ -15,7 +15,9 @@ import androidx.savedstate.SavedStateRegistry
 import androidx.savedstate.SavedStateRegistryController
 import androidx.savedstate.SavedStateRegistryOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
+import com.dessalines.thumbkey.db.DEFAULT_CLIPBOARD_HISTORY_ENABLED
 import com.dessalines.thumbkey.db.DEFAULT_DISABLE_FULLSCREEN_EDITOR
+import com.dessalines.thumbkey.db.DEFAULT_USE_PRIVATE_CLIPBOARD
 import com.dessalines.thumbkey.utils.KeyboardDefinition
 import com.dessalines.thumbkey.utils.KeyboardLayout
 import com.dessalines.thumbkey.utils.TAG
@@ -154,4 +156,18 @@ class IMEService :
     private val savedStateRegistryController = SavedStateRegistryController.create(this)
     override val savedStateRegistry: SavedStateRegistry =
         savedStateRegistryController.savedStateRegistry
+
+    fun clipboardUsePrivate(): Boolean {
+        val settingsRepo = (application as ThumbkeyApplication).appSettingsRepository
+        val settings = settingsRepo.appSettings.getValue()
+        val clipboardHistoryEnabled = (settings?.clipboardHistoryEnabled ?: DEFAULT_CLIPBOARD_HISTORY_ENABLED).toBool()
+        val usePrivateClipboard = (settings?.usePrivateClipboard ?: DEFAULT_USE_PRIVATE_CLIPBOARD).toBool()
+        return clipboardHistoryEnabled && usePrivateClipboard
+    }
+
+    fun clipboardAddPrivateClip(text: String): Unit? = clipboardManager?.addPrivateClip(text) ?: null
+
+    fun clipboardIsLastCopySystem(): Boolean = clipboardManager?.isLastCopySystem() ?: true
+
+    fun clipboardGetLastClip(): String? = clipboardManager?.getLastClip()
 }

--- a/app/src/main/java/com/dessalines/thumbkey/IMEService.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/IMEService.kt
@@ -165,9 +165,9 @@ class IMEService :
         return clipboardHistoryEnabled && usePrivateClipboard
     }
 
-    fun clipboardAddPrivateClip(text: String): Unit? = clipboardManager?.addPrivateClip(text) ?: null
+    fun clipboardAddPrivateClip(text: String): Unit? = clipboardManager?.addPrivateClip(text)
 
-    fun clipboardIsLastCopySystem(): Boolean = clipboardManager?.isLastCopySystem() ?: true
+    fun clipboardWasLastCopyDoneViaSystem(): Boolean = clipboardManager?.wasLastCopyOperationDoneViaSystem() ?: true
 
     fun clipboardGetLastClip(): String? = clipboardManager?.getLastClip()
 }

--- a/app/src/main/java/com/dessalines/thumbkey/db/AppDb.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/db/AppDb.kt
@@ -72,6 +72,7 @@ const val DEFAULT_CLIPBOARD_SIZE_LIMIT_ENABLED = 1
 const val DEFAULT_CLIPBOARD_MAX_SIZE = 20
 const val MIN_CLIPBOARD_MAX_SIZE = 2
 const val MAX_CLIPBOARD_MAX_SIZE = 100
+const val DEFAULT_USE_PRIVATE_CLIPBOARD = 0
 
 @Entity
 data class AppSettings(
@@ -324,6 +325,11 @@ data class AppSettings(
         defaultValue = DEFAULT_POSITION_PADDING.toString(),
     )
     val positionPadding: Int,
+    @ColumnInfo(
+        name = "use_private_clipboard",
+        defaultValue = DEFAULT_USE_PRIVATE_CLIPBOARD.toString(),
+    )
+    val usePrivateClipboard: Int,
 )
 
 data class LayoutsUpdate(
@@ -484,6 +490,10 @@ data class ClipboardSettingsUpdate(
     val clipboardSizeLimitEnabled: Int,
     @ColumnInfo(name = "clipboard_max_size")
     val clipboardMaxSize: Int,
+    @ColumnInfo(
+        name = "use_private_clipboard",
+    )
+    val usePrivateClipboard: Int,
 )
 
 @Dao
@@ -581,7 +591,7 @@ class AppSettingsRepository(
 }
 
 @Database(
-    version = 24,
+    version = 25,
     entities = [AppSettings::class],
     exportSchema = true,
 )
@@ -627,6 +637,7 @@ abstract class AppDB : RoomDatabase() {
                             MIGRATION_21_22,
                             MIGRATION_22_23,
                             MIGRATION_23_24,
+                            MIGRATION_24_25,
                         )
                         // Necessary because it can't insert data on creation
                         .addCallback(

--- a/app/src/main/java/com/dessalines/thumbkey/db/Migrations.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/db/Migrations.kt
@@ -275,3 +275,12 @@ val MIGRATION_23_24 =
             )
         }
     }
+
+val MIGRATION_24_25 =
+    object : Migration(24, 25) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL(
+                "ALTER TABLE AppSettings ADD COLUMN use_private_clipboard INTEGER NOT NULL DEFAULT $DEFAULT_USE_PRIVATE_CLIPBOARD",
+            )
+        }
+    }

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/backupandrestore/BackupAndRestoreScreen.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/backupandrestore/BackupAndRestoreScreen.kt
@@ -76,6 +76,7 @@ import com.dessalines.thumbkey.db.DEFAULT_SOUND_ON_TAP
 import com.dessalines.thumbkey.db.DEFAULT_SPACEBAR_MULTITAPS
 import com.dessalines.thumbkey.db.DEFAULT_THEME
 import com.dessalines.thumbkey.db.DEFAULT_THEME_COLOR
+import com.dessalines.thumbkey.db.DEFAULT_USE_PRIVATE_CLIPBOARD
 import com.dessalines.thumbkey.db.DEFAULT_VIBRATE_ON_SLIDE
 import com.dessalines.thumbkey.db.DEFAULT_VIBRATE_ON_TAP
 import com.dessalines.thumbkey.utils.SimpleTopAppBar
@@ -276,6 +277,7 @@ private fun resetAppSettingsToDefault(appSettingsViewModel: AppSettingsViewModel
             clipboardCleanupAfterMinutes = DEFAULT_CLIPBOARD_CLEANUP_AFTER_MINUTES,
             clipboardSizeLimitEnabled = DEFAULT_CLIPBOARD_SIZE_LIMIT_ENABLED,
             clipboardMaxSize = DEFAULT_CLIPBOARD_MAX_SIZE,
+            usePrivateClipboard = DEFAULT_USE_PRIVATE_CLIPBOARD,
         ),
     )
 }

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/clipboard/ClipboardSettingsScreen.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/clipboard/ClipboardSettingsScreen.kt
@@ -266,6 +266,7 @@ fun ClipboardSettingsScreen(
                             usePrivateClipboardState = it
                             updateClipboardSettings()
                         },
+                        enabled = clipboardHistoryEnabledState,
                         title = {
                             Text(stringResource(R.string.use_private_clipboard))
                         },

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/clipboard/ClipboardSettingsScreen.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/clipboard/ClipboardSettingsScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material.icons.outlined.History
 import androidx.compose.material.icons.outlined.HourglassEmpty
 import androidx.compose.material.icons.outlined.HourglassTop
 import androidx.compose.material.icons.outlined.Numbers
+import androidx.compose.material.icons.outlined.VisibilityOff
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -43,6 +44,7 @@ import com.dessalines.thumbkey.db.DEFAULT_CLIPBOARD_CLEANUP_AFTER_MINUTES
 import com.dessalines.thumbkey.db.DEFAULT_CLIPBOARD_HISTORY_ENABLED
 import com.dessalines.thumbkey.db.DEFAULT_CLIPBOARD_MAX_SIZE
 import com.dessalines.thumbkey.db.DEFAULT_CLIPBOARD_SIZE_LIMIT_ENABLED
+import com.dessalines.thumbkey.db.DEFAULT_USE_PRIVATE_CLIPBOARD
 import com.dessalines.thumbkey.db.MAX_CLIPBOARD_MAX_SIZE
 import com.dessalines.thumbkey.db.MIN_CLIPBOARD_MAX_SIZE
 import com.dessalines.thumbkey.utils.SimpleTopAppBar
@@ -105,6 +107,8 @@ fun ClipboardSettingsScreen(
     var clipboardMaxSizeState =
         (settings?.clipboardMaxSize ?: DEFAULT_CLIPBOARD_MAX_SIZE).toFloat()
     var clipboardMaxSizeSliderState by remember { mutableFloatStateOf(clipboardMaxSizeState) }
+    var usePrivateClipboardState =
+        (settings?.usePrivateClipboard ?: DEFAULT_USE_PRIVATE_CLIPBOARD).toBool()
 
     val snackbarHostState = remember { SnackbarHostState() }
     val scrollState = rememberScrollState()
@@ -118,6 +122,7 @@ fun ClipboardSettingsScreen(
                 clipboardCleanupAfterMinutes = clipboardCleanupDuration.minutes,
                 clipboardSizeLimitEnabled = clipboardSizeLimitEnabledState.toInt(),
                 clipboardMaxSize = clipboardMaxSizeState.toInt(),
+                usePrivateClipboard = usePrivateClipboardState.toInt(),
             ),
         )
         // Enforce size limit after updating settings
@@ -251,6 +256,25 @@ fun ClipboardSettingsScreen(
                         icon = {
                             Icon(
                                 imageVector = Icons.Outlined.DataArray,
+                                contentDescription = null,
+                            )
+                        },
+                    )
+                    SwitchPreference(
+                        value = usePrivateClipboardState,
+                        onValueChange = {
+                            usePrivateClipboardState = it
+                            updateClipboardSettings()
+                        },
+                        title = {
+                            Text(stringResource(R.string.use_private_clipboard))
+                        },
+                        summary = {
+                            Text(stringResource(R.string.use_private_clipboard_description))
+                        },
+                        icon = {
+                            Icon(
+                                imageVector = Icons.Outlined.VisibilityOff,
                                 contentDescription = null,
                             )
                         },

--- a/app/src/main/java/com/dessalines/thumbkey/utils/ThumbKeyClipboardManager.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/ThumbKeyClipboardManager.kt
@@ -18,7 +18,11 @@ class ThumbKeyClipboardManager(
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private var isListening = false
     private var lastClipText: String? = null
-    private var isLastCopySystem: Boolean = true
+
+// Used to manage data with a non-text MEME type, when private clipboard is enabled
+// When copying data with a MEME type different than a text, e.g. a picture, it is not added to the history, as it’s not a text. With standard paste it’s not an issue as the paste will still paste it.
+// However if we paste from the internal clipboard, it will paste the latest string in the history, and not the picture that was only in the system clipboard.
+    private var wasLastCopyOperationDoneViaSystem: Boolean = true
 
     private fun addToClipboardRepo(text: String) {
         if (text.isBlank() || text == lastClipText) return@addToClipboardRepo
@@ -35,7 +39,7 @@ class ThumbKeyClipboardManager(
             if (clip == null || clip.itemCount == 0) return@OnPrimaryClipChangedListener
             val text = clip.getItemAt(0).coerceToText(context).toString()
             addToClipboardRepo(text)
-            isLastCopySystem = true
+            wasLastCopyOperationDoneViaSystem = true
         }
 
     fun startListening() {
@@ -60,10 +64,10 @@ class ThumbKeyClipboardManager(
 
     fun addPrivateClip(text: String) {
         addToClipboardRepo(text)
-        isLastCopySystem = false
+        wasLastCopyOperationDoneViaSystem = false
     }
 
-    fun isLastCopySystem(): Boolean = isLastCopySystem
+    fun wasLastCopyOperationDoneViaSystem(): Boolean = wasLastCopyOperationDoneViaSystem
 
     fun getLastClip(): String? = lastClipText
 }

--- a/app/src/main/java/com/dessalines/thumbkey/utils/ThumbKeyClipboardManager.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/ThumbKeyClipboardManager.kt
@@ -20,7 +20,7 @@ class ThumbKeyClipboardManager(
     private var lastClipText: String? = null
 
 // Used to manage data with a non-text MEME type, when private clipboard is enabled
-// When copying data with a MEME type different than a text, e.g. a picture, it is not added to the history, as it’s not a text. With standard paste it’s not an issue as the paste will still paste it.
+// When copying data with a MIME type different than a text, e.g. a picture, it is not added to the history, as it’s not a text. With standard paste it’s not an issue as the paste will still paste it.
 // However if we paste from the internal clipboard, it will paste the latest string in the history, and not the picture that was only in the system clipboard.
     private var wasLastCopyOperationDoneViaSystem: Boolean = true
 

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -1251,12 +1251,8 @@ fun performKeyAction(
                     val text = ime.currentInputConnection.getSelectedText(0).toString()
                     ime.clipboardAddPrivateClip(text)?.let {
                         ime.currentInputConnection.commitText("", 1)
-                        val message = ime.getString(R.string.private_cut)
-                        Toast.makeText(ime, message, Toast.LENGTH_SHORT).show()
                     } ?: {
-                        ime.currentInputConnection.performContextMenuAction(android.R.id.cut)
-                        val message = ime.getString(R.string.private_cut_error)
-                        Toast.makeText(ime, message, Toast.LENGTH_SHORT).show()
+                        Toast.makeText(ime, "Error: private cut failed", Toast.LENGTH_SHORT).show()
                     }
                 } else {
                     ime.currentInputConnection.performContextMenuAction(android.R.id.cut)
@@ -1286,9 +1282,7 @@ fun performKeyAction(
                         val message = ime.getString(R.string.private_copy)
                         Toast.makeText(ime, message, Toast.LENGTH_SHORT).show()
                     } ?: {
-                        ime.currentInputConnection.performContextMenuAction(android.R.id.copy)
-                        val message = ime.getString(R.string.private_copy_error)
-                        Toast.makeText(ime, message, Toast.LENGTH_SHORT).show()
+                        Toast.makeText(ime, "Error: private copy failed", Toast.LENGTH_SHORT).show()
                     }
                 } else {
                     ime.currentInputConnection.performContextMenuAction(android.R.id.copy)
@@ -1315,9 +1309,7 @@ fun performKeyAction(
             if (ime.clipboardUsePrivate() && !ime.clipboardIsLastCopySystem()) {
                 val text = ime.clipboardGetLastClip()
                 if (text.isNullOrEmpty()) {
-                    ime.currentInputConnection.performContextMenuAction(android.R.id.paste)
-                    val message = ime.getString(R.string.private_paste_error)
-                    Toast.makeText(ime, message, Toast.LENGTH_SHORT).show()
+                    Toast.makeText(ime, "Error: private paste failed", Toast.LENGTH_SHORT).show()
                 } else {
                     ime.currentInputConnection.commitText(text, 1)
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -139,6 +139,5 @@
     <string name="clipboard_go_to_settings">Go to clipboard settings</string>
     <string name="clipboard_characters">%1$d characters</string>
     <string name="use_private_clipboard">Use private clipboard</string>
-    <string name="use_private_clipboard_description">Use internal app clipboard instead of system clipboard</string>
-    <string name="private_copy">Copied selected text privately</string>
+    <string name="use_private_clipboard_description">Copy into internal clipboard instead of system clipboard"</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -141,8 +141,4 @@
     <string name="use_private_clipboard">Use private clipboard</string>
     <string name="use_private_clipboard_description">Use internal app clipboard instead of system clipboard</string>
     <string name="private_copy">Copied selected text privately</string>
-    <string name="private_cut">Cut selected text privately</string>
-    <string name="private_copy_error">Private clipboard error, copied selected text to system clipboard</string>
-    <string name="private_cut_error">Private clipboard error, cut selected test to system clipboard</string>
-    <string name="private_paste_error">Private clipboard error, pasted from system clipboard</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -138,4 +138,11 @@
     <string name="clipboard_disabled">Clipboard history is disabled</string>
     <string name="clipboard_go_to_settings">Go to clipboard settings</string>
     <string name="clipboard_characters">%1$d characters</string>
+    <string name="use_private_clipboard">Use private clipboard</string>
+    <string name="use_private_clipboard_description">Use internal app clipboard instead of system clipboard</string>
+    <string name="private_copy">Copied selected text privately</string>
+    <string name="private_cut">Cut selected text privately</string>
+    <string name="private_copy_error">Private clipboard error, copied selected text to system clipboard</string>
+    <string name="private_cut_error">Private clipboard error, cut selected test to system clipboard</string>
+    <string name="private_paste_error">Private clipboard error, pasted from system clipboard</string>
 </resources>


### PR DESCRIPTION
_Private clipboard_ allows to bypass the system clipboard and only store the copied text in thumbkey’s new clipboard history.

Motivation behind this is Samsung’s devices pasting the info to Samsung Keyboard without an option to disable it. I suspect other devices have similar behaviors.

That also can prevent other apps to read it unless explicitely pasting it with thumbkey. 

Text or images copied the standard way will continue to be handled the same way as before, and thus do not break functionality.