### PR TITLE
Revert "Spellcheck locale fix"

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/ComposeKeyboardView.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ComposeKeyboardView.kt
@@ -8,9 +8,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.AbstractComposeView
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.LayoutDirection
@@ -36,8 +33,6 @@ class ComposeKeyboardView(
         val settingsState = settingsRepo.appSettings.observeAsState()
         val settings by settingsState
         val ctx = context as IMEService
-
-        var currentLocaleIndex by remember { mutableStateOf(0) }
 
         ThumbkeyTheme(
             settings = settings,
@@ -72,30 +67,15 @@ class ComposeKeyboardView(
                                         ?.textProcessor
                                         ?.updateCursorPosition(ctx)
 
-                                    // Notify the system of the new locale for spellchecking
-                                    ctx.updateInputLocale()
-
                                     // Display the new layout's name on the screen
                                     if (s.showToastOnLayoutSwitch.toBool()) {
                                         val layoutName = layout.keyboardDefinition.title
-                                        val localeCode = layout.keyboardDefinition.locales?.firstOrNull() ?: ""
-                                        val message = if (localeCode.isNotEmpty()) "$layoutName: $localeCode" else layoutName
-                                        Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+                                        Toast
+                                            .makeText(context, layoutName, Toast.LENGTH_SHORT)
+                                            .show()
                                     }
                                 }
                             }
-                        }
-                    },
-                    onCycleLocale = {
-                        val locales = ctx.currentKeyboardDefinition?.locales ?: return@KeyboardScreen
-                        if (locales.size > 0) {
-                            currentLocaleIndex = (currentLocaleIndex + 1) % locales.size
-                            val localeCode = locales[currentLocaleIndex]
-                            ctx.setLocale(localeCode)
-
-                            val layoutName = ctx.currentKeyboardDefinition?.title ?: ""
-                            val message = if (localeCode.isNotEmpty()) "$layoutName: $localeCode" else localeCode
-                            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
                         }
                     },
                     onChangePosition = { f ->

--- a/app/src/main/java/com/dessalines/thumbkey/IMEService.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/IMEService.kt
@@ -1,13 +1,9 @@
 package com.dessalines.thumbkey
 
-import android.content.Context
 import android.inputmethodservice.InputMethodService
-import android.os.Build
 import android.util.Log
 import android.view.inputmethod.CursorAnchorInfo
 import android.view.inputmethod.EditorInfo
-import android.view.inputmethod.InputMethodManager
-import android.view.inputmethod.InputMethodSubtype
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
@@ -71,43 +67,6 @@ class IMEService :
         super.onStartInput(attribute, restarting)
         val view = this.setupView()
         this.setInputView(view)
-        updateInputLocale()
-    }
-
-    fun updateInputLocale() {
-        val locales = currentKeyboardDefinition?.locales
-        if (!locales.isNullOrEmpty()) {
-            setLocale(locales.first())
-        }
-    }
-
-    fun setLocale(locale: String) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            try {
-                val imm = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-                val imeId = "$packageName/${IMEService::class.java.name}"
-
-                val subtype =
-                    InputMethodSubtype
-                        .InputMethodSubtypeBuilder()
-                        .setSubtypeLocale(locale)
-                        .setLanguageTag(locale)
-                        .setSubtypeMode("keyboard")
-                        .setIsAuxiliary(false)
-                        .setOverridesImplicitlyEnabledSubtype(true)
-                        .build()
-
-                imm.setAdditionalInputMethodSubtypes(imeId, arrayOf(subtype))
-
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                    switchInputMethod(imeId, subtype)
-                }
-
-                Log.d(TAG, "Updated input locale to: $locale")
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to update input locale: ${e.message}")
-            }
-        }
     }
 
     // Lifecycle Methods

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ARThumbKeyLevant.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ARThumbKeyLevant.kt
@@ -95,5 +95,4 @@ val KB_AR_THUMBKEY_LEVANT: KeyboardDefinition =
                 shifted = KB_AR_THUMBKEY_LEVANT_MAIN,
                 numeric = ARABIC_NUMERIC_KEYBOARD,
             ),
-        locales = listOf("ar"),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/BGMessagEasePhoneticSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/BGMessagEasePhoneticSymbols.kt
@@ -256,5 +256,4 @@ val KB_BG_MESSAGEASE_PHONETIC_SYMBOLS: KeyboardDefinition =
             KeyboardDefinitionSettings(
                 autoCapitalizers = arrayOf(::autoCapitalizeI, ::autoCapitalizeIApostrophe),
             ),
-        locales = listOf("bg"),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/BGThumbKeySymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/BGThumbKeySymbols.kt
@@ -259,5 +259,4 @@ val KB_BG_THUMBKEY_SYMBOLS: KeyboardDefinition =
                 shifted = KB_GB_THUMBKEY_SYMBOLS_SHIFTED,
                 numeric = NUMERIC_KEYBOARD,
             ),
-        locales = listOf("bg"),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/BRFRThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/BRFRThumbKey.kt
@@ -227,7 +227,6 @@ val KB_BR_FR_THUMBKEY_SHIFTED =
 val KB_BR_FR_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "brezhoneg français thumb-key",
-        locales = listOf("br", "fr"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_BR_FR_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/BRFRThumbKeyCompose.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/BRFRThumbKeyCompose.kt
@@ -355,5 +355,4 @@ val KB_BR_FR_THUMBKEY_COMPOSE: KeyboardDefinition =
                 shifted = KB_BR_FR_THUMBKEY_COMPOSE_SHIFTED,
                 numeric = FRENCH_NUMERIC_KEYBOARD,
             ),
-        locales = listOf("br", "fr"),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/BRFRThumbKeyV3.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/BRFRThumbKeyV3.kt
@@ -278,5 +278,4 @@ val KB_BR_FR_THUMBKEY_V3: KeyboardDefinition =
                 shifted = KB_BR_FR_THUMBKEY_V3_SHIFTED,
                 numeric = FRENCH_NUMERIC_KEYBOARD,
             ),
-        locales = listOf("br", "fr"),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/BYThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/BYThumbKey.kt
@@ -206,5 +206,4 @@ val KB_BY_THUMBKEY: KeyboardDefinition =
                 shifted = KB_BY_THUMBKEY_SHIFTED,
                 numeric = NUMERIC_KEYBOARD,
             ),
-        locales = listOf("be"),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/BYThumbKeySymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/BYThumbKeySymbols.kt
@@ -256,5 +256,4 @@ val KB_BY_THUMBKEY_SYMBOLS: KeyboardDefinition =
                 shifted = KB_BY_THUMBKEY_SYMBOLS_SHIFTED,
                 numeric = NUMERIC_KEYBOARD,
             ),
-        locales = listOf("be"),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/CAThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/CAThumbKey.kt
@@ -247,5 +247,4 @@ val KB_CA_THUMBKEY: KeyboardDefinition =
                 shifted = KB_CA_THUMBKEY_SHIFTED,
                 numeric = NUMERIC_KEYBOARD,
             ),
-        locales = listOf("cr"),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/CZProgrammerMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/CZProgrammerMessagEase.kt
@@ -315,5 +315,4 @@ val KB_CZ_MESSAGEASE_PROGRAMMING: KeyboardDefinition =
                 shifted = KB_CZ_MESSAGEASE_PROGRAMMING_SHIFTED,
                 numeric = KB_EN_MESSAGEASE_NUMERIC,
             ),
-        locales = listOf("cs"),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/CommonKeys.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/CommonKeys.kt
@@ -72,7 +72,6 @@ val SWITCH_LANGUAGE_KEYC =
     KeyC(
         display = KeyDisplay.IconDisplay(Icons.Outlined.Language),
         action = SwitchLanguage,
-        swipeReturnAction = CycleLocale,
         color = MUTED,
     )
 val MOVE_KEYBOARD_CYCLE_RIGHT_KEYC =

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DAThumbKeyMultiLingual.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DAThumbKeyMultiLingual.kt
@@ -204,7 +204,6 @@ val KB_DA_THUMBKEY_MULTILINGUAL_SHIFTED =
 val KB_DA_THUMBKEY_MULTILINGUAL: KeyboardDefinition =
     KeyboardDefinition(
         title = "dansk thumb-key",
-        locales = listOf("da", "en", "de", "sv", "no"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_DA_THUMBKEY_MULTILINGUAL_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DAThumbKeyV3.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DAThumbKeyV3.kt
@@ -192,7 +192,6 @@ val KB_DA_THUMBKEY_SHIFTED =
 val KB_DA_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "dansk thumb-key",
-        locales = listOf("da"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_DA_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEENAEThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEENAEThumbKey.kt
@@ -263,5 +263,4 @@ val KB_EN_DE_THUMBKEY_AE =
                 shifted = KB_EN_DE_THUMBKEY_AE_SHIFTED,
                 numeric = NUMERIC_KEYBOARD,
             ),
-        locales = listOf("en", "de"),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEase.kt
@@ -230,5 +230,4 @@ val KB_DE_MESSAGEASE: KeyboardDefinition =
                 shifted = KB_DE_MESSAGEASE_SHIFTED,
                 numeric = KB_EN_MESSAGEASE_NUMERIC,
             ),
-        locales = listOf("de"),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEaseInvertedNumpad.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEaseInvertedNumpad.kt
@@ -109,7 +109,6 @@ val KB_DE_MESSAGEASE_INVERTED_NUMPAD_NUMERIC =
 val KB_DE_MESSAGEASE_INVERTED_NUMPAD: KeyboardDefinition =
     KeyboardDefinition(
         title = "deutsch messagease, inverted numpad",
-        locales = listOf("de"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_DE_MESSAGEASE_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEaseLeft.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEaseLeft.kt
@@ -15,5 +15,4 @@ val KB_DE_MESSAGEASE_LEFT: KeyboardDefinition =
                 shifted = lastColKeysToFirst(KB_DE_MESSAGEASE_SHIFTED),
                 numeric = lastColKeysToFirst(KB_EN_MESSAGEASE_NUMERIC),
             ),
-        locales = listOf("de"),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEaseLeftInvertedNumpad.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEaseLeftInvertedNumpad.kt
@@ -9,7 +9,6 @@ import com.dessalines.thumbkey.utils.lastColKeysToFirst
 val KB_DE_MESSAGEASE_LEFT_INVERTED_NUMPAD: KeyboardDefinition =
     KeyboardDefinition(
         title = "deutsch messagease left-handed, inverted numpad",
-        locales = listOf("de"),
         modes =
             KeyboardDefinitionModes(
                 main = lastColKeysToFirst(KB_DE_MESSAGEASE_MAIN),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEaseNordic.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEaseNordic.kt
@@ -263,7 +263,6 @@ val KB_DE_NORDIC_MESSAGEASE_SHIFTED =
 val KB_DE_NORDIC_MESSAGEASE: KeyboardDefinition =
     KeyboardDefinition(
         title = "deutsch messagease +åæø",
-        locales = listOf("de"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_DE_NORDIC_MESSAGEASE_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEaseSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEMessagEaseSymbols.kt
@@ -253,7 +253,6 @@ val KB_DE_MESSAGEASE_SYMBOLS_SHIFTED =
 val KB_DE_MESSAGEASE_SYMBOLS: KeyboardDefinition =
     KeyboardDefinition(
         title = "deutsch symbols messagease",
-        locales = listOf("de"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_DE_MESSAGEASE_SYMBOLS_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbKey.kt
@@ -201,7 +201,6 @@ val KB_DE_THUMBKEY_SHIFTED =
 val KB_DE_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "deutsch thumb-key",
-        locales = listOf("de"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_DE_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbKeyMultiLingual.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbKeyMultiLingual.kt
@@ -239,7 +239,6 @@ val KB_DE_THUMBKEY_MULTILINGUAL_SHIFTED =
 val KB_DE_THUMBKEY_MULTILINGUAL: KeyboardDefinition =
     KeyboardDefinition(
         title = "deutsch multilingual thumb-key",
-        locales = listOf("de", "en", "fr", "es", "it", "pt", "nl"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_DE_THUMBKEY_MULTILINGUAL_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbKeySymNum.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbKeySymNum.kt
@@ -289,7 +289,6 @@ val KB_DE_THUMBKEY_SYMNUM_SHIFTED =
 val KB_DE_THUMBKEY_SYMNUM: KeyboardDefinition =
     KeyboardDefinition(
         title = "deutsch thumb-key symnum",
-        locales = listOf("de"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_DE_THUMBKEY_SYMNUM_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbkeySymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbkeySymbols.kt
@@ -308,7 +308,6 @@ val KB_DE_THUMBKEY_SYMBOLS_SHIFTED =
 val KB_DE_THUMBKEY_SYMBOLS: KeyboardDefinition =
     KeyboardDefinition(
         title = "deutsch thumb-key symbols",
-        locales = listOf("de"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_DE_THUMBKEY_SYMBOLS_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbkeyWords.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DEThumbkeyWords.kt
@@ -307,7 +307,6 @@ val KB_DE_THUMBKEY_WORDS_SHIFTED =
 val KB_DE_THUMBKEY_WORDS: KeyboardDefinition =
     KeyboardDefinition(
         title = "deutsch thumb-key words",
-        locales = listOf("de"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_DE_THUMBKEY_WORDS_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DETypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DETypeSplit.kt
@@ -267,7 +267,6 @@ val KB_DE_TYPESPLIT_SHIFTED =
 val KB_DE_TYPESPLIT: KeyboardDefinition =
     KeyboardDefinition(
         title = "deutsch type-split",
-        locales = listOf("de"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_DE_TYPESPLIT_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/DETypeSplitImproved.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/DETypeSplitImproved.kt
@@ -706,7 +706,6 @@ val KB_DE_TYPESPLIT_IMPROVED_NUMERIC =
 val KB_DE_TYPESPLIT_IMPROVED: KeyboardDefinition =
     KeyboardDefinition(
         title = "deutsch type-split improved",
-        locales = listOf("de"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_DE_TYPESPLIT_IMPROVED_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENCZThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENCZThumbKey.kt
@@ -213,7 +213,6 @@ val KB_EN_CZ_THUMBKEY_SHIFTED =
 val KB_EN_CZ_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "english čeština thumb-key",
-        locales = listOf("en", "cs"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_CZ_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENColumnar.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENColumnar.kt
@@ -198,7 +198,6 @@ val KB_EN_COLUMNAR_SHIFTED =
 val KB_EN_COLUMNAR: KeyboardDefinition =
     KeyboardDefinition(
         title = "english qwerty-columnar",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_COLUMNAR_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENColumnarQuick.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENColumnarQuick.kt
@@ -198,7 +198,6 @@ val KB_EN_COLUMNAR_QUICK_SHIFTED =
 val KB_EN_COLUMNAR_QUICK: KeyboardDefinition =
     KeyboardDefinition(
         title = "english qwerty-columnar quick",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_COLUMNAR_QUICK_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDAThumbKeySymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDAThumbKeySymbols.kt
@@ -247,7 +247,6 @@ val KB_EN_DA_THUMBKEY_SYMBOLS_SHIFTED =
 val KB_EN_DA_THUMBKEY_SYMBOLS: KeyboardDefinition =
     KeyboardDefinition(
         title = "english dansk thumb-key symbols",
-        locales = listOf("en", "da"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_DA_THUMBKEY_SYMBOLS_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDENLThumbkey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDENLThumbkey.kt
@@ -215,7 +215,6 @@ val KB_EN_DE_NL_THUMBKEY_SHIFTED =
 val KB_EN_DE_NL_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "english deutsch nederlands thumb-key",
-        locales = listOf("en", "de", "nl"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_DE_NL_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDEThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDEThumbKey.kt
@@ -190,7 +190,6 @@ val KB_EN_DE_THUMBKEY_SHIFTED =
 val KB_EN_DE_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "english deutsch thumb-key",
-        locales = listOf("en", "de"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_DE_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDEThumbKeyV2.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDEThumbKeyV2.kt
@@ -190,7 +190,6 @@ val KB_EN_DE_THUMBKEY_V2_SHIFTED =
 val KB_EN_DE_THUMBKEY_V2: KeyboardDefinition =
     KeyboardDefinition(
         title = "english deutsch thumb-key v2",
-        locales = listOf("en", "de"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_DE_THUMBKEY_V2_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDoubleSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDoubleSymbols.kt
@@ -429,7 +429,6 @@ val KB_EN_DOUBLE_SYMBOLS_SHIFTED =
 val KB_EN_DOUBLE_SYMBOLS: KeyboardDefinition =
     KeyboardDefinition(
         title = "english double symbols",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_DOUBLE_SYMBOLS_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDvorakWide.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDvorakWide.kt
@@ -233,7 +233,6 @@ val KB_EN_DVORAK_WIDE_SHIFTED =
 val KB_EN_DVORAK_WIDE: KeyboardDefinition =
     KeyboardDefinition(
         title = "english dvorak wide",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_DVORAK_WIDE_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDvorakWideCompose.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENDvorakWideCompose.kt
@@ -281,7 +281,6 @@ val KB_EN_DVORAK_WIDE_COMPOSE_SHIFTED =
 val KB_EN_DVORAK_WIDE_COMPOSE: KeyboardDefinition =
     KeyboardDefinition(
         title = "english dvorak wide compose",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_DVORAK_WIDE_COMPOSE_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENEEThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENEEThumbKey.kt
@@ -200,7 +200,6 @@ val KB_EN_EE_THUMBKEY_SHIFTED =
 val KB_EN_EE_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "english eegbe thumb-key",
-        locales = listOf("en", "ee"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_EE_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENEOMessagEaseSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENEOMessagEaseSymbols.kt
@@ -274,7 +274,6 @@ val KB_EN_EO_MESSAGEASE_SYMBOLS_SHIFTED =
 val KB_EN_EO_MESSAGEASE_SYMBOLS: KeyboardDefinition =
     KeyboardDefinition(
         title = "english esperanto messagease symbols",
-        locales = listOf("en", "eo"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_EO_MESSAGEASE_SYMBOLS_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENEOThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENEOThumbKey.kt
@@ -207,7 +207,6 @@ val KB_EN_EO_THUMBKEY_SHIFTED =
 val KB_EN_EO_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "english esperanto thumb-key",
-        locales = listOf("en", "eo"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_EO_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENESCAThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENESCAThumbKey.kt
@@ -214,7 +214,6 @@ val KB_EN_ES_CA_HUMBKEY_SHIFTED =
 val KB_EN_ES_CA_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "english español català thumb-key",
-        locales = listOf("en", "es", "ca"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_ES_CA_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENESCATwoHands.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENESCATwoHands.kt
@@ -383,7 +383,6 @@ val KB_EN_ES_CA_TWO_HANDS_SHIFTED =
 val KB_EN_ES_CA_TWO_HANDS: KeyboardDefinition =
     KeyboardDefinition(
         title = "english español català two-hands",
-        locales = listOf("en", "es", "ca"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_ES_CA_TWO_HANDS_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENFRMessagEaseSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENFRMessagEaseSymbols.kt
@@ -351,7 +351,6 @@ val KB_EN_FR_NUMERIC =
 val KB_EN_FR_MESSAGEASE_SYMBOLS: KeyboardDefinition =
     KeyboardDefinition(
         title = "english français messagease symbols",
-        locales = listOf("en", "fr"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_FR_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENHRMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENHRMessagEase.kt
@@ -192,7 +192,6 @@ val KB_EN_HR_MESSAGEASE_SHIFTED =
 val KB_EN_HR_MESSAGEASE: KeyboardDefinition =
     KeyboardDefinition(
         title = "english hrvatski messagease",
-        locales = listOf("en", "hr"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_HR_MESSAGEASE_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENHyper.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENHyper.kt
@@ -227,7 +227,6 @@ val KB_EN_HYPER_SHIFTED =
 val KB_EN_HYPER: KeyboardDefinition =
     KeyboardDefinition(
         title = "english hyper",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_HYPER_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENHyperSpace.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENHyperSpace.kt
@@ -227,7 +227,6 @@ val KB_EN_HYPER_SPACE_SHIFTED =
 val KB_EN_HYPER_SPACE: KeyboardDefinition =
     KeyboardDefinition(
         title = "english hyper space",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_HYPER_SPACE_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENITThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENITThumbKey.kt
@@ -204,7 +204,6 @@ val KB_EN_IT_THUMBKEY_SHIFTED =
 val KB_EN_IT_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "english italiano thumb-key",
-        locales = listOf("en", "it"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_IT_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENLAThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENLAThumbKey.kt
@@ -200,7 +200,6 @@ val KB_EN_LA_THUMBKEY_SHIFTED =
 val KB_EN_LA_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "english latina thumb-key",
-        locales = listOf("en", "la"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_LA_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENLVThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENLVThumbKey.kt
@@ -206,7 +206,6 @@ val KB_ENLV_THUMBKEY_SHIFTED =
 val KB_ENLV_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "latviešu valoda english thumb-key",
-        locales = listOf("en", "lv"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_ENLV_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMIThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMIThumbKey.kt
@@ -199,7 +199,6 @@ val KB_EN_MI_THUMBKEY_SHIFTED =
 val KB_EN_MI_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "english te reo māori thumb-key",
-        locales = listOf("en", "mi"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_MI_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMIThumbKeySymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMIThumbKeySymbols.kt
@@ -253,7 +253,6 @@ val KB_EN_MI_THUMBKEY_SYMBOLS_SHIFTED =
 val KB_EN_MI_THUMBKEY_SYMBOLS: KeyboardDefinition =
     KeyboardDefinition(
         title = "english te reo māori symbols thumb-key",
-        locales = listOf("en", "mi"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_MI_THUMBKEY_SYMBOLS_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEase.kt
@@ -188,7 +188,6 @@ val KB_EN_MESSAGEASE_SHIFTED =
 val KB_EN_MESSAGEASE: KeyboardDefinition =
     KeyboardDefinition(
         title = "english messagease",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_MESSAGEASE_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseCompose.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseCompose.kt
@@ -339,7 +339,6 @@ val KB_EN_MESSAGEASE_COMPOSED_SHIFTED =
 val KB_EN_MESSAGEASE_COMPOSE: KeyboardDefinition =
     KeyboardDefinition(
         title = "english messagease compose",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_MESSAGEASE_COMPOSED_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseLeft.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseLeft.kt
@@ -11,7 +11,6 @@ import com.dessalines.thumbkey.utils.SwipeNWay.*
 val KB_EN_MESSAGEASE_LEFT: KeyboardDefinition =
     KeyboardDefinition(
         title = "english messagease left-handed",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = lastColKeysToFirst(KB_EN_MESSAGEASE_MAIN),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseLeftSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseLeftSymbols.kt
@@ -11,7 +11,6 @@ import com.dessalines.thumbkey.utils.SwipeNWay.*
 val KB_EN_MESSAGEASE_LEFT_SYMBOLS: KeyboardDefinition =
     KeyboardDefinition(
         title = "english messagease left-handed symbols",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = lastColKeysToFirst(KB_EN_MESSAGEASE_SYMBOLS_MAIN),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseSymbols.kt
@@ -238,7 +238,6 @@ val KB_EN_MESSAGEASE_SYMBOLS_SHIFTED =
 val KB_EN_MESSAGEASE_SYMBOLS: KeyboardDefinition =
     KeyboardDefinition(
         title = "english messagease symbols",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_MESSAGEASE_SYMBOLS_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseSymbolsModifiers.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseSymbolsModifiers.kt
@@ -496,7 +496,6 @@ val KB_EN_MESSAGEASE_SYMBOLS_MODIFIERS_ALTED =
 val KB_EN_MESSAGEASE_SYMBOLS_MODIFIERS: KeyboardDefinition =
     KeyboardDefinition(
         title = "english messagease symbols modifiers",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_MESSAGEASE_SYMBOLS_MODIFIERS_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseSymbolsTwoHands.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseSymbolsTwoHands.kt
@@ -54,7 +54,6 @@ val NUMERIC_KEYBOARD_MESSAGEASE_TWO_HANDS =
 val KB_EN_MESSAGEASE_SYMBOLS_TWO_HANDS: KeyboardDefinition =
     KeyboardDefinition(
         title = "english messagease symbols two-hands",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_MESSAGEASE_SYMBOLS_TWO_HANDS_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseTwoHands.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseTwoHands.kt
@@ -331,7 +331,6 @@ val KB_EN_MESSAGEASE_TWO_HANDS_SHIFTED =
 val KB_EN_MESSAGEASE_TWO_HANDS: KeyboardDefinition =
     KeyboardDefinition(
         title = "english messagease two-hands",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_MESSAGEASE_TWO_HANDS_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseWriter.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseWriter.kt
@@ -252,7 +252,6 @@ val KB_EN_MESSAGEASE_WRITER_SHIFTED =
 val KB_EN_MESSAGEASE_WRITER: KeyboardDefinition =
     KeyboardDefinition(
         title = "english messagease writer",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_MESSAGEASE_WRITER_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENNLTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENNLTypeSplit.kt
@@ -197,7 +197,6 @@ val KB_EN_NL_TYPESPLIT_SHIFTED =
 val KB_EN_NL_TYPESPLIT: KeyboardDefinition =
     KeyboardDefinition(
         title = "english nederlands type-split",
-        locales = listOf("en", "nl"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_NL_TYPESPLIT_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENNOMessagEaseSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENNOMessagEaseSymbols.kt
@@ -243,7 +243,6 @@ val KB_EN_NO_MESSAGEASE_SYMBOLS_SHIFTED =
 val KB_EN_NO_MESSAGEASE_SYMBOLS: KeyboardDefinition =
     KeyboardDefinition(
         title = "english norsk messagease symbols",
-        locales = listOf("en", "no"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_NO_MESSAGEASE_SYMBOLS_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENNOThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENNOThumbKey.kt
@@ -200,7 +200,6 @@ val KB_EN_NO_THUMBKEY_SHIFTED =
 val KB_EN_NO_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "english norsk thumb-key",
-        locales = listOf("en", "no"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_NO_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENNOTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENNOTypeSplit.kt
@@ -237,7 +237,6 @@ val KB_EN_NO_TYPESPLIT_SHIFTED =
 val KB_EN_NO_TYPESPLIT: KeyboardDefinition =
     KeyboardDefinition(
         title = "english norsk type-split",
-        locales = listOf("en", "no"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_NO_TYPESPLIT_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENPHMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENPHMessagEase.kt
@@ -188,7 +188,6 @@ val KB_EN_PH_MESSAGEASE_SHIFTED =
 val KB_EN_PH_MESSAGEASE: KeyboardDefinition =
     KeyboardDefinition(
         title = "english wikang tagalog messagease",
-        locales = listOf("en", "tl"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_PH_MESSAGEASE_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENPLThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENPLThumbKey.kt
@@ -192,7 +192,6 @@ val KB_EN_PL_THUMBKEY_SHIFTED =
 val KB_EN_PL_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "english polski thumb-key",
-        locales = listOf("en", "pl"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_PL_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENQBased.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENQBased.kt
@@ -197,7 +197,6 @@ val KB_EN_QBASED_SHIFTED =
 val KB_EN_QBASED: KeyboardDefinition =
     KeyboardDefinition(
         title = "english qbased",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_QBASED_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENQBasedLeft.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENQBasedLeft.kt
@@ -11,7 +11,6 @@ import com.dessalines.thumbkey.utils.SwipeNWay.*
 val KB_EN_QBASED_LEFT: KeyboardDefinition =
     KeyboardDefinition(
         title = "english qbased left-handed",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = lastColKeysToFirst(KB_EN_QBASED_MAIN),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENQwertEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENQwertEase.kt
@@ -186,7 +186,6 @@ val KB_EN_QWERTEASE_SHIFTED =
 val KB_EN_QWERTEASE: KeyboardDefinition =
     KeyboardDefinition(
         title = "english qwertease",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_QWERTEASE_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENQwertEaseTwoHands.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENQwertEaseTwoHands.kt
@@ -327,7 +327,6 @@ val KB_EN_QWERTEASE_TWO_HANDS_SHIFTED =
 val KB_EN_QWERTEASE_TWO_HANDS: KeyboardDefinition =
     KeyboardDefinition(
         title = "english qwertease two-hands",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_QWERTEASE_TWO_HANDS_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENQwertyfour.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENQwertyfour.kt
@@ -200,7 +200,6 @@ val KB_EN_QWERTYFOUR_SHIFTED =
 val KB_EN_QWERTYFOUR: KeyboardDefinition =
     KeyboardDefinition(
         title = "english qwertyfour",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_QWERTYFOUR_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENQwertyfourCompose.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENQwertyfourCompose.kt
@@ -300,7 +300,6 @@ val KB_EN_QWERTYFOUR_COMPOSE_SHIFTED =
 val KB_EN_QWERTYFOUR_COMPOSE: KeyboardDefinition =
     KeyboardDefinition(
         title = "english qwertyfour compose",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_QWERTYFOUR_COMPOSE_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENROThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENROThumbKey.kt
@@ -198,7 +198,6 @@ val KB_EN_RO_THUMBKEY_SHIFTED =
 val KB_EN_RO_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "english română thumb-key",
-        locales = listOf("en", "ro"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_RO_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENRsinoa.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENRsinoa.kt
@@ -190,7 +190,6 @@ val KB_EN_RSINOA_SHIFTED =
 val KB_EN_RSINOA: KeyboardDefinition =
     KeyboardDefinition(
         title = "english rsinoa",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_RSINOA_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENSKThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENSKThumbKey.kt
@@ -226,7 +226,6 @@ val KB_EN_SK_THUMBKEY_SHIFTED =
 val KB_EN_SK_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "english slovenčina thumb-key",
-        locales = listOf("en", "sk"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_SK_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENSVThumbkeyProgrammer.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENSVThumbkeyProgrammer.kt
@@ -257,7 +257,6 @@ val KB_EN_SV_THUMBKEY_PROGRAMMING_SHIFTED =
 val KB_EN_SV_THUMBKEY_PROGRAMMING: KeyboardDefinition =
     KeyboardDefinition(
         title = "english svenska thumb-key programming ",
-        locales = listOf("en", "sv"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_SV_THUMBKEY_PROGRAMMING_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKey.kt
@@ -188,7 +188,6 @@ val KB_EN_THUMBKEY_SHIFTED =
 val KB_EN_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "english thumb-key",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyCompose.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyCompose.kt
@@ -322,7 +322,6 @@ val KB_EN_THUMBKEY_COMPOSE_SHIFTED =
 val KB_EN_THUMBKEY_COMPOSE: KeyboardDefinition =
     KeyboardDefinition(
         title = "english thumb-key compose",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_THUMBKEY_COMPOSE_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyFlippedNumpad.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyFlippedNumpad.kt
@@ -188,7 +188,6 @@ val KB_EN_THUMBKEY_FLIPPED_NUMPAD_SHIFTED =
 val KB_EN_THUMBKEY_FLIPPED_NUMPAD: KeyboardDefinition =
     KeyboardDefinition(
         title = "english thumb-key with a flipped numpad layout",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_THUMBKEY_FLIPPED_NUMPAD_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyProgrammer.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyProgrammer.kt
@@ -244,7 +244,6 @@ val KB_EN_THUMBKEY_PROGRAMMING_SHIFTED =
 val KB_EN_THUMBKEY_PROGRAMMING: KeyboardDefinition =
     KeyboardDefinition(
         title = "english thumb-key programming",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_THUMBKEY_PROGRAMMING_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyProgrammerExpanded.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyProgrammerExpanded.kt
@@ -573,7 +573,6 @@ val NUMERIC_KEYBOARD_EXPANDED_SHIFTED =
 val KB_EN_THUMBKEY_PROGRAMMING_EXPANDED: KeyboardDefinition =
     KeyboardDefinition(
         title = "english thumb-key programming expanded",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_THUMBKEY_PROGRAMMING_EXPANDED_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyProgrammerWide.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyProgrammerWide.kt
@@ -324,7 +324,6 @@ val NUMERIC_KEYBOARD_WIDE =
 val KB_EN_THUMBKEY_PROGRAMMING_WIDE: KeyboardDefinition =
     KeyboardDefinition(
         title = "english thumb-key programming wide",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_THUMBKEY_PROGRAMMING_WIDE_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeySymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeySymbols.kt
@@ -241,7 +241,6 @@ val KB_EN_THUMBKEY_SYMBOLS_SHIFTED =
 val KB_EN_THUMBKEY_SYMBOLS: KeyboardDefinition =
     KeyboardDefinition(
         title = "english thumb-key symbols",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_THUMBKEY_SYMBOLS_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyWide.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyWide.kt
@@ -218,7 +218,6 @@ val KB_EN_THUMBKEY_WIDE_SHIFTED =
 val KB_EN_THUMBKEY_WIDE: KeyboardDefinition =
     KeyboardDefinition(
         title = "english thumb-key wide",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_THUMBKEY_WIDE_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyWords.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyWords.kt
@@ -235,7 +235,6 @@ val KB_EN_THUMBKEY_WORDS_SHIFTED =
 val KB_EN_THUMBKEY_WORDS: KeyboardDefinition =
     KeyboardDefinition(
         title = "english thumb-key words",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_THUMBKEY_WORDS_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyWordsSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyWordsSymbols.kt
@@ -259,7 +259,6 @@ val KB_EN_THUMBKEY_WORDS_SYMBOLS_SHIFTED =
 val KB_EN_THUMBKEY_WORDS_SYMBOLS: KeyboardDefinition =
     KeyboardDefinition(
         title = "english thumb-key words symbols",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_THUMBKEY_WORDS_SYMBOLS_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyWordsSymbolsDual.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyWordsSymbolsDual.kt
@@ -267,7 +267,6 @@ val KB_EN_THUMBKEY_WORDS_SYMBOLS_DUAL_SHIFTED =
 val KB_EN_THUMBKEY_WORDS_SYMBOLS_DUAL: KeyboardDefinition =
     KeyboardDefinition(
         title = "english thumb-key words symbols dual",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_THUMBKEY_WORDS_SYMBOLS_DUAL_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyWriter.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKeyWriter.kt
@@ -253,7 +253,6 @@ val KB_EN_THUMBKEY_WRITER_SHIFTED =
 val KB_EN_THUMBKEY_WRITER: KeyboardDefinition =
     KeyboardDefinition(
         title = "english thumb-key writer",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_THUMBKEY_WRITER_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENTwoHands.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENTwoHands.kt
@@ -331,7 +331,6 @@ val KB_EN_TWO_HANDS_SHIFTED =
 val KB_EN_TWO_HANDS: KeyboardDefinition =
     KeyboardDefinition(
         title = "english two-hands",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_TWO_HANDS_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENTwoHandsSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENTwoHandsSymbols.kt
@@ -435,7 +435,6 @@ val KB_EN_SYMBOLS_TWO_HANDS_SHIFTED =
 val KB_EN_SYMBOLS_TWO_HANDS: KeyboardDefinition =
     KeyboardDefinition(
         title = "english symbols two-hands",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_SYMBOLS_TWO_HANDS_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENTwoHandsSymbolsNumbers.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENTwoHandsSymbolsNumbers.kt
@@ -475,7 +475,6 @@ val KB_EN_SYMBOLS_NUMBERS_TWO_HANDS_SHIFTED =
 val KB_EN_SYMBOLS_NUMBERS_TWO_HANDS: KeyboardDefinition =
     KeyboardDefinition(
         title = "english symbols-numbers two-hands",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_SYMBOLS_NUMBERS_TWO_HANDS_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENTwoHandsSymbolsNumbersArrows.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENTwoHandsSymbolsNumbersArrows.kt
@@ -475,7 +475,6 @@ val KB_EN_SYMBOLS_NUMBERS_ARROWS_TWO_HANDS_SHIFTED =
 val KB_EN_SYMBOLS_NUMBERS_ARROWS_TWO_HANDS: KeyboardDefinition =
     KeyboardDefinition(
         title = "english symbols-numbers-arrows two-hands",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_SYMBOLS_NUMBERS_ARROWS_TWO_HANDS_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENTwoHandsSymbolsNumbersArrowsCompact.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENTwoHandsSymbolsNumbersArrowsCompact.kt
@@ -435,7 +435,6 @@ val TWO_HANDS_NUMERIC_ARROWS_COMPACT_KEYBOARD =
 val KB_EN_SYMBOLS_NUMBERS_ARROWS_TWO_HANDS_COMPACT: KeyboardDefinition =
     KeyboardDefinition(
         title = "english symbols-numbers-arrows two-hands compact",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_SYMBOLS_NUMBERS_ARROWS_TWO_HANDS_COMPACT_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENTypeSplit.kt
@@ -229,7 +229,6 @@ val KB_EN_TYPESPLIT_SHIFTED =
 val KB_EN_TYPESPLIT: KeyboardDefinition =
     KeyboardDefinition(
         title = "english type-split",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_TYPESPLIT_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENTypeSplitProgramming.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENTypeSplitProgramming.kt
@@ -399,7 +399,6 @@ val KB_EN_TYPESPLIT_PROGRAMMING_NUMERIC =
 val KB_EN_TYPESPLIT_PROGRAMMING: KeyboardDefinition =
     KeyboardDefinition(
         title = "english type-split programming",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_TYPESPLIT_PROGRAMMING_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENTypeSplitShort.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENTypeSplitShort.kt
@@ -429,7 +429,6 @@ val KB_EN_TYPESPLIT_SHORT_NUMERIC =
 val KB_EN_TYPESPLIT_SHORT: KeyboardDefinition =
     KeyboardDefinition(
         title = "english type-split short",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EN_TYPESPLIT_SHORT_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/EOCyrillicThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/EOCyrillicThumbKey.kt
@@ -199,7 +199,6 @@ val KB_EO_CYRILLIC_THUMBKEY_SHIFTED =
 val KB_EO_CYRILLIC_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "esperanto cyrillic thumb-key",
-        locales = listOf("eo"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EO_CYRILLIC_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/EOENDEThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/EOENDEThumbKey.kt
@@ -210,7 +210,6 @@ val KB_EO_EN_DE_THUMBKEY_SHIFTED =
 val KB_EO_EN_DE_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "esperanto english deutsch thumb-key",
-        locales = listOf("eo", "en", "de"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EO_EN_DE_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ESCAMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ESCAMessagEase.kt
@@ -261,7 +261,6 @@ val KB_ES_CA_MESSAGEASE_SHIFTED =
 val KB_ES_CA_MESSAGEASE: KeyboardDefinition =
     KeyboardDefinition(
         title = "español català messagease",
-        locales = listOf("es", "ca"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_ES_CA_MESSAGEASE_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ESCAThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ESCAThumbKey.kt
@@ -212,7 +212,6 @@ val KB_ES_CA_THUMBKEY_SHIFTED =
 val KB_ES_CA_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "español català thumb-key",
-        locales = listOf("es", "ca"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_ES_CA_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ESEOThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ESEOThumbKey.kt
@@ -190,7 +190,6 @@ val KB_ES_EO_THUMBKEY_SHIFTED =
 val KB_ES_EO_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "español esperanto thumb-key",
-        locales = listOf("es", "eo"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_ES_EO_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ESMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ESMessagEase.kt
@@ -215,7 +215,6 @@ val KB_ES_MESSAGEASE_SHIFTED =
 val KB_ES_MESSAGEASE: KeyboardDefinition =
     KeyboardDefinition(
         title = "español messagease",
-        locales = listOf("es"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_ES_MESSAGEASE_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ESThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ESThumbKey.kt
@@ -200,7 +200,6 @@ val KB_ES_THUMBKEY_SHIFTED =
 val KB_ES_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "español thumb-key",
-        locales = listOf("es"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_ES_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ESThumbKeySymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ESThumbKeySymbols.kt
@@ -230,7 +230,6 @@ val KB_ES_THUMBKEY_SYMBOLS_SHIFTED =
 val KB_ES_THUMBKEY_SYMBOLS: KeyboardDefinition =
     KeyboardDefinition(
         title = "español thumb-key symbols",
-        locales = listOf("es"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_ES_THUMBKEY_SYMBOLS_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ESTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ESTypeSplit.kt
@@ -277,7 +277,6 @@ val KB_ES_TYPESPLIT_SHIFTED =
 val KB_ES_TYPESPLIT: KeyboardDefinition =
     KeyboardDefinition(
         title = "español type-split",
-        locales = listOf("es"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_ES_TYPESPLIT_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/EUESThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/EUESThumbKey.kt
@@ -196,7 +196,6 @@ val KB_EU_ES_THUMBKEY_SHIFTED =
 val KB_EU_ES_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "euskara español thumb-key",
-        locales = listOf("eu", "es"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EU_ES_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/EUThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/EUThumbKey.kt
@@ -188,7 +188,6 @@ val KB_EU_THUMBKEY_SHIFTED =
 val KB_EU_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "euskara thumb-key",
-        locales = listOf("eu"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EU_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/EuropeThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/EuropeThumbKey.kt
@@ -447,7 +447,6 @@ val KB_EUROPE_THUMBKEY_SHIFTED =
 val KB_EUROPE_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "european thumb-key",
-        locales = listOf("en", "de", "fr", "es", "it", "pt", "nl"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_EUROPE_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FAThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FAThumbKey.kt
@@ -100,7 +100,6 @@ val KB_FA_THUMBKEY_MAIN =
 val KB_FA_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "فارسی thumb-key",
-        locales = listOf("fa"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_FA_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FAThumbKeySamsung.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FAThumbKeySamsung.kt
@@ -11,7 +11,6 @@ import com.dessalines.thumbkey.utils.SwipeNWay.*
 val KB_FA_THUMBKEY_SAMSUNG: KeyboardDefinition =
     KeyboardDefinition(
         title = "فارسی thumb-key samsung",
-        locales = listOf("fa"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_FA_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FIEEMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FIEEMessagEase.kt
@@ -252,7 +252,6 @@ val KB_FI_EE_MESSAGEASE_SYMBOLS_SHIFTED =
 val KB_FI_EE_MESSAGEASE_SYMBOLS: KeyboardDefinition =
     KeyboardDefinition(
         title = "suomi eesti messagease",
-        locales = listOf("fi", "ee"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_FI_EE_MESSAGEASE_SYMBOLS_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FIMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FIMessagEase.kt
@@ -223,7 +223,6 @@ val KB_FI_MESSAGEASE_SHIFTED =
 val KB_FI_MESSAGEASE: KeyboardDefinition =
     KeyboardDefinition(
         title = "suomi messagease",
-        locales = listOf("fi"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_FI_MESSAGEASE_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FIThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FIThumbKey.kt
@@ -194,7 +194,6 @@ val KB_FI_THUMBKEY_SHIFTED =
 val KB_FI_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "suomi thumb-key",
-        locales = listOf("fi"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_FI_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FIThumbKeyWide.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FIThumbKeyWide.kt
@@ -192,7 +192,6 @@ val KB_FI_THUMBKEY_WIDE_SHIFTED =
 val KB_FI_THUMBKEY_WIDE: KeyboardDefinition =
     KeyboardDefinition(
         title = "suomi thumb-key wide",
-        locales = listOf("fi"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_FI_THUMBKEY_WIDE_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FITypesSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FITypesSplit.kt
@@ -1,4 +1,4 @@
-@file:Suppress("ktlint:standard:no-wildcard-imports")
+﻿@file:Suppress("ktlint:standard:no-wildcard-imports")
 
 package com.dessalines.thumbkey.keyboards
 
@@ -257,7 +257,6 @@ val KB_FI_TYPESPLIT_SHIFTED =
 val KB_FI_TYPESPLIT: KeyboardDefinition =
     KeyboardDefinition(
         title = "suomi type-split",
-        locales = listOf("fi"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_FI_TYPESPLIT_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FRENFrappeFluideV1.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FRENFrappeFluideV1.kt
@@ -511,7 +511,6 @@ fun makeLeftHandedControlLeftSide(kb: KeyboardC): KeyboardC {
 val KB_FR_EN_FRAPPE_FLUIDE_V1: KeyboardDefinition =
     KeyboardDefinition(
         title = "français frappefluide (fr+en) v1",
-        locales = listOf("fr", "en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_FR_EN_FRAPPE_FLUIDE_V1_MAIN,
@@ -523,7 +522,6 @@ val KB_FR_EN_FRAPPE_FLUIDE_V1: KeyboardDefinition =
 val KB_FR_EN_FRAPPE_FLUIDE_V1_CONTROL_LEFT_SIDE: KeyboardDefinition =
     KeyboardDefinition(
         title = "français frappefluide (fr+en) v1 (outils à gauche)",
-        locales = listOf("fr", "en"),
         modes =
             KeyboardDefinitionModes(
                 main = makeControlLeftSide(KB_FR_EN_FRAPPE_FLUIDE_V1_MAIN),
@@ -535,7 +533,6 @@ val KB_FR_EN_FRAPPE_FLUIDE_V1_CONTROL_LEFT_SIDE: KeyboardDefinition =
 val KB_FR_EN_FRAPPE_FLUIDE_V1_LEFT_HANDED: KeyboardDefinition =
     KeyboardDefinition(
         title = "français frappefluide (fr+en) v1 (gauchère)",
-        locales = listOf("fr", "en"),
         modes =
             KeyboardDefinitionModes(
                 main = makeLeftHanded(KB_FR_EN_FRAPPE_FLUIDE_V1_MAIN),
@@ -547,7 +544,6 @@ val KB_FR_EN_FRAPPE_FLUIDE_V1_LEFT_HANDED: KeyboardDefinition =
 val KB_FR_EN_FRAPPE_FLUIDE_V1_LEFT_HANDED_CONTROL_LEFT_SIDE: KeyboardDefinition =
     KeyboardDefinition(
         title = "français frappefluide (fr+en) v1 (gauchère, outils à gauche)",
-        locales = listOf("fr", "en"),
         modes =
             KeyboardDefinitionModes(
                 main = makeLeftHandedControlLeftSide(KB_FR_EN_FRAPPE_FLUIDE_V1_MAIN),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FRMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FRMessagEase.kt
@@ -406,7 +406,6 @@ val KB_FR_MESSAGEASE_SHIFTED =
 val KB_FR_MESSAGEASE: KeyboardDefinition =
     KeyboardDefinition(
         title = "français messagease",
-        locales = listOf("fr"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_FR_MESSAGEASE_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FRThumbKeyV1.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FRThumbKeyV1.kt
@@ -223,7 +223,6 @@ val KB_FR_THUMBKEY_V1_SHIFTED =
 val KB_FR_THUMBKEY_V1: KeyboardDefinition =
     KeyboardDefinition(
         title = "français thumb-key v1",
-        locales = listOf("fr"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_FR_THUMBKEY_V1_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FRThumbKeyV2.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FRThumbKeyV2.kt
@@ -223,7 +223,6 @@ val KB_FR_THUMBKEY_V2_SHIFTED =
 val KB_FR_THUMBKEY_V2: KeyboardDefinition =
     KeyboardDefinition(
         title = "français thumb-key v2",
-        locales = listOf("fr"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_FR_THUMBKEY_V2_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FRThumbKeyV3.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FRThumbKeyV3.kt
@@ -272,7 +272,6 @@ val KB_FR_THUMBKEY_V3_SHIFTED =
 val KB_FR_THUMBKEY_V3: KeyboardDefinition =
     KeyboardDefinition(
         title = "français thumb-key v3",
-        locales = listOf("fr"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_FR_THUMBKEY_V3_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/FRTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/FRTypeSplit.kt
@@ -237,7 +237,6 @@ val KB_FR_TYPESPLIT_SHIFTED =
 val KB_FR_TYPESPLIT: KeyboardDefinition =
     KeyboardDefinition(
         title = "français type-split",
-        locales = listOf("fr"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_FR_TYPESPLIT_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/GRNormThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/GRNormThumbKey.kt
@@ -195,7 +195,6 @@ val KB_GRNORM_THUMBKEY_SHIFTED =
 val KB_GRNORM_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "ελληνικά normal thumb-key",
-        locales = listOf("el"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_GRNORM_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/GRNormThumbKeySymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/GRNormThumbKeySymbols.kt
@@ -250,7 +250,6 @@ val KB_GRNORM_THUMBKEY_SYMBOLS_SHIFTED =
 val KB_GRNORM_THUMBKEY_SYMBOLS: KeyboardDefinition =
     KeyboardDefinition(
         title = "ελληνικά thumb-key symbols",
-        locales = listOf("el"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_GRNORM_THUMBKEY_SYMBOLS_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/GRThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/GRThumbKey.kt
@@ -205,7 +205,6 @@ val KB_GR_THUMBKEY_SHIFTED =
 val KB_GR_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "ελληνικά thumb-key",
-        locales = listOf("el"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_GR_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/GlagoliticThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/GlagoliticThumbKey.kt
@@ -232,7 +232,6 @@ val KB_GLAGOLITIC_THUMBKEY_SHIFTED =
 val KB_GLAGOLITIC_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "ⰳⰾⰰⰳⱁⰾⰻⱌⰰ thumb-key",
-        locales = listOf("cu"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_GLAGOLITIC_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/HEMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/HEMessagEase.kt
@@ -81,7 +81,6 @@ val KB_HE_MESSAGEASE_MAIN =
 val KB_HE_MESSAGEASE: KeyboardDefinition =
     KeyboardDefinition(
         title = "עברית messagease",
-        locales = listOf("he"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_HE_MESSAGEASE_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/HEMessagEaseSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/HEMessagEaseSymbols.kt
@@ -106,7 +106,6 @@ val KB_HE_MESSAGEASE_SYMBOLS_MAIN =
 val KB_HE_MESSAGEASE_SYMBOLS: KeyboardDefinition =
     KeyboardDefinition(
         title = "עברית messagease symbols",
-        locales = listOf("he"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_HE_MESSAGEASE_SYMBOLS_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/HEThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/HEThumbKey.kt
@@ -93,7 +93,6 @@ val KB_HE_THUMBKEY_MAIN =
 val KB_HE_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "עברית thumb-key",
-        locales = listOf("he"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_HE_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/HIThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/HIThumbKey.kt
@@ -198,7 +198,6 @@ val KB_HI_THUMBKEY_SHIFTED =
 val KB_HI_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "हिन्दी thumb-key",
-        locales = listOf("hi"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_HI_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/HIThumbKeyExtended.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/HIThumbKeyExtended.kt
@@ -212,7 +212,6 @@ val KB_HI_THUMBKEY_EXTENDED_SHIFTED =
 val KB_HI_THUMBKEY_EXTENDED: KeyboardDefinition =
     KeyboardDefinition(
         title = "हिन्दी thumb-key extended",
-        locales = listOf("hi"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_HI_THUMBKEY_EXTENDED_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/HRThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/HRThumbKey.kt
@@ -192,7 +192,6 @@ val KB_HR_THUMBKEY_SHIFTED =
 val KB_HR_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "hrvatski thumb-key",
-        locales = listOf("hr"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_HR_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/HRThumbKeySymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/HRThumbKeySymbols.kt
@@ -249,7 +249,6 @@ val KB_HR_THUMBKEY_SYMBOLS_SHIFTED =
 val KB_HR_THUMBKEY_SYMBOLS: KeyboardDefinition =
     KeyboardDefinition(
         title = "hrvatski thumb-key symbols",
-        locales = listOf("hr"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_HR_THUMBKEY_SYMBOLS_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/HRTwoHands.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/HRTwoHands.kt
@@ -333,7 +333,6 @@ val KB_HR_TWO_HANDS_SHIFTED =
 val KB_HR_TWO_HANDS: KeyboardDefinition =
     KeyboardDefinition(
         title = "hrvatski two-hands",
-        locales = listOf("hr"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_HR_TWO_HANDS_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/HUHungramTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/HUHungramTypeSplit.kt
@@ -333,7 +333,6 @@ val KB_HU_HUNGRAM_SHIFTED =
 val KB_HU_HUNGRAM: KeyboardDefinition =
     KeyboardDefinition(
         title = "magyar hungram",
-        locales = listOf("hu"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_HU_HUNGRAM_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/HUThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/HUThumbKey.kt
@@ -200,7 +200,6 @@ val KB_HU_THUMBKEY_SHIFTED =
 val KB_HU_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "magyar thumb-key",
-        locales = listOf("hu"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_HU_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/HUTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/HUTypeSplit.kt
@@ -227,7 +227,6 @@ val KB_HU_TYPESPLIT_SHIFTED =
 val KB_HU_TYPESPLIT: KeyboardDefinition =
     KeyboardDefinition(
         title = "magyar type-split",
-        locales = listOf("hu"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_HU_TYPESPLIT_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/IDThumbKeySymbolsNumbersV1.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/IDThumbKeySymbolsNumbersV1.kt
@@ -259,7 +259,6 @@ val KB_ID_THUMBKEY_SYMBOLS_NUMBERS_V1_SHIFTED =
 val KB_ID_THUMBKEY_SYMBOLS_NUMBERS_V1: KeyboardDefinition =
     KeyboardDefinition(
         title = "bahasa indonesia thumb-key symbols-numbers v1",
-        locales = listOf("id"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_ID_THUMBKEY_SYMBOLS_NUMBERS_V1_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/IDThumbKeySymbolsV1.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/IDThumbKeySymbolsV1.kt
@@ -243,7 +243,6 @@ val KB_ID_THUMBKEY_SYMBOLS_V1_SHIFTED =
 val KB_ID_THUMBKEY_SYMBOLS_V1: KeyboardDefinition =
     KeyboardDefinition(
         title = "bahasa indonesia thumb-key symbols v1",
-        locales = listOf("id"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_ID_THUMBKEY_SYMBOLS_V1_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/IDThumbKeySymbolsV2.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/IDThumbKeySymbolsV2.kt
@@ -243,7 +243,6 @@ val KB_ID_THUMBKEY_SYMBOLS_V2_SHIFTED =
 val KB_ID_THUMBKEY_SYMBOLS_V2: KeyboardDefinition =
     KeyboardDefinition(
         title = "bahasa indonesia thumb-key symbols v2",
-        locales = listOf("id"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_ID_THUMBKEY_SYMBOLS_V2_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ITMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ITMessagEase.kt
@@ -196,7 +196,6 @@ val KB_IT_MESSAGEASE_SHIFTED =
 val KB_IT_MESSAGEASE: KeyboardDefinition =
     KeyboardDefinition(
         title = "italiano messagease",
-        locales = listOf("it"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_IT_MESSAGEASE_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ITMessagEaseSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ITMessagEaseSymbols.kt
@@ -388,7 +388,6 @@ val KB_IT_MESSAGEASE_SYMBOLS_SHIFTED =
 val KB_IT_MESSAGEASE_SYMBOLS: KeyboardDefinition =
     KeyboardDefinition(
         title = "italiano messagease symbols",
-        locales = listOf("it"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_IT_MESSAGEASE_SYMBOLS_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ITThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ITThumbKey.kt
@@ -208,7 +208,6 @@ val KB_IT_THUMBKEY_SHIFTED =
 val KB_IT_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "italiano thumb-key",
-        locales = listOf("it"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_IT_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ITTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ITTypeSplit.kt
@@ -205,7 +205,6 @@ val KB_IT_TYPESPLIT_SHIFTED =
 val KB_IT_TYPESPLIT: KeyboardDefinition =
     KeyboardDefinition(
         title = "italiano type-split",
-        locales = listOf("it"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_IT_TYPESPLIT_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/JAHiraganaThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/JAHiraganaThumbKey.kt
@@ -210,7 +210,6 @@ val KB_JA_HIRAGANA_THUMBKEY_SHIFTED =
 val KB_JA_HIRAGANA_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "japanese hiragana thumb-key",
-        locales = listOf("ja"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_JA_HIRAGANA_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/JAHiraganaTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/JAHiraganaTypeSplit.kt
@@ -256,7 +256,6 @@ val KB_JA_HIRAGANA_TYPESPLIT_SHIFTED =
 val KB_JA_HIRAGANA_TYPESPLIT: KeyboardDefinition =
     KeyboardDefinition(
         title = "japanese hiragana type-split",
-        locales = listOf("ja"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_JA_HIRAGANA_TYPESPLIT_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/JAKanaStandard.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/JAKanaStandard.kt
@@ -263,7 +263,6 @@ val KB_JA_KANA_STANDARD_KATAKANA =
 val KB_JA_KANA_STANDARD: KeyboardDefinition =
     KeyboardDefinition(
         title = "japanese standard kana keyboard",
-        locales = listOf("ja"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_JA_KANA_STANDARD_HIRAGANA,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/JAKanaThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/JAKanaThumbKey.kt
@@ -269,7 +269,6 @@ val KB_JA_KANA_THUMBKEY_KATAKANA =
 val KB_JA_KANA_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "japanese kana thumb-key",
-        locales = listOf("ja"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_JA_KANA_THUMBKEY_HIRAGANA,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/JAKatakanaThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/JAKatakanaThumbKey.kt
@@ -205,7 +205,6 @@ val KB_JA_KATAKANA_THUMBKEY_SHIFTED =
 val KB_JA_KATAKANA_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "japanese katakana thumb-key",
-        locales = listOf("ja"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_JA_KATAKANA_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/JAKatakanaTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/JAKatakanaTypeSplit.kt
@@ -262,5 +262,4 @@ val KB_JA_KATAKANA_TYPESPLIT: KeyboardDefinition =
                 shifted = KB_JA_KATAKANA_TYPESPLIT_SHIFTED,
                 numeric = TYPESPLIT_NUMERIC_KEYBOARD,
             ),
-        locales = listOf("ja"),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/KAThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/KAThumbKey.kt
@@ -97,5 +97,4 @@ val KB_KA_THUMBKEY: KeyboardDefinition =
                 shifted = KB_KA_THUMBKEY_MAIN,
                 numeric = NUMERIC_KEYBOARD,
             ),
-        locales = listOf("ka"),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/KNThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/KNThumbKey.kt
@@ -296,5 +296,4 @@ val KB_KN_THUMBKEY: KeyboardDefinition =
             KeyboardDefinitionSettings(
                 autoCapitalizers = arrayOf(::autoCapitalizeI, ::autoCapitalizeIApostrophe),
             ),
-        locales = listOf("kn"),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/KROneThumb.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/KROneThumb.kt
@@ -133,7 +133,6 @@ val KB_KR_ONETHUMB_MAIN =
 val KB_KR_ONETHUMB: KeyboardDefinition =
     KeyboardDefinition(
         title = "한국어 one-thumb",
-        locales = listOf("ko"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_KR_ONETHUMB_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/KRThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/KRThumbKey.kt
@@ -194,7 +194,6 @@ val KB_KR_THUMBKEY_SHIFTED =
 val KB_KR_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "한국어 thumb-key",
-        locales = listOf("ko"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_KR_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/KRTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/KRTypeSplit.kt
@@ -130,7 +130,6 @@ val KB_KR_TYPESPLIT_MAIN =
 val KB_KR_TYPESPLIT: KeyboardDefinition =
     KeyboardDefinition(
         title = "한국어 type-split",
-        locales = listOf("ko"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_KR_TYPESPLIT_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/KZThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/KZThumbKey.kt
@@ -214,7 +214,6 @@ val KB_KZ_THUMBKEY_SHIFTED =
 val KB_KZ_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "қазақша thumb-key",
-        locales = listOf("kk"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_KZ_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/LTThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/LTThumbKey.kt
@@ -196,7 +196,6 @@ val KB_LT_THUMBKEY_SHIFTED =
 val KB_LT_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "lietuvių kalba thumb-key",
-        locales = listOf("lt"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_LT_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/LVLTGThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/LVLTGThumbKey.kt
@@ -198,7 +198,6 @@ val KB_LV_LTG_THUMBKEY_SHIFTED =
 val KB_LV_LTG_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "latviešu valoda thumb-key",
-        locales = listOf("lv"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_LV_LTG_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/MATHThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/MATHThumbKey.kt
@@ -208,7 +208,6 @@ val KB_MATH_THUMBKEY_SLASH =
 val KB_MATH_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "math thumb-key",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_MATH_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/MYThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/MYThumbKey.kt
@@ -237,5 +237,4 @@ val KB_MY_THUMBKEY: KeyboardDefinition =
             KeyboardDefinitionSettings(
                 autoCapitalizers = arrayOf(::autoCapitalizeI, ::autoCapitalizeIApostrophe),
             ),
-        locales = listOf("my"),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/NLThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/NLThumbKey.kt
@@ -192,7 +192,6 @@ val KB_NL_THUMBKEY_SHIFTED =
 val KB_NL_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "nederlands thumb-key",
-        locales = listOf("nl"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_NL_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/NLTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/NLTypeSplit.kt
@@ -203,7 +203,6 @@ val KB_NL_TYPESPLIT_SHIFTED =
 val KB_NL_TYPESPLIT: KeyboardDefinition =
     KeyboardDefinition(
         title = "nederlands type-split",
-        locales = listOf("nl"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_NL_TYPESPLIT_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/NOThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/NOThumbKey.kt
@@ -192,7 +192,6 @@ val KB_NO_THUMBKEY_SHIFTED =
 val KB_NO_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "norsk thumb-key",
-        locales = listOf("no"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_NO_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/NOThumbKeyDataDriven.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/NOThumbKeyDataDriven.kt
@@ -192,7 +192,6 @@ val KB_NO_THUMBKEY_DATADRIVEN_SHIFTED =
 val KB_NO_THUMBKEY_DATADRIVEN: KeyboardDefinition =
     KeyboardDefinition(
         title = "norsk thumb-key datadrevet",
-        locales = listOf("no"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_NO_THUMBKEY_DATADRIVEN_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/PLMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/PLMessagEase.kt
@@ -336,7 +336,6 @@ val KB_PL_MESSAGEASE_NUMERIC =
 val KB_PL_MESSAGEASE: KeyboardDefinition =
     KeyboardDefinition(
         title = "polski messagease",
-        locales = listOf("pl"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_PL_MESSAGEASE_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/PLThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/PLThumbKey.kt
@@ -200,7 +200,6 @@ val KB_PL_THUMBKEY_SHIFTED =
 val KB_PL_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "polski thumb-key",
-        locales = listOf("pl"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_PL_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/PLTypeSplitSymbolsV1.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/PLTypeSplitSymbolsV1.kt
@@ -253,7 +253,6 @@ val KB_PL_TYPESPLIT_SYMBOLS_V1_SHIFTED =
 val KB_PL_TYPESPLIT_SYMBOLS_V1: KeyboardDefinition =
     KeyboardDefinition(
         title = "polski symbols type-split v1",
-        locales = listOf("pl"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_PL_TYPESPLIT_SYMBOLS_V1_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/PLTypeSplitSymbolsV2.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/PLTypeSplitSymbolsV2.kt
@@ -281,5 +281,4 @@ val KB_PL_TYPESPLIT_SYMBOLS_V2: KeyboardDefinition =
                 shifted = KB_PL_TYPESPLIT_SYMBOLS_V2_SHIFTED,
                 numeric = TYPESPLIT_NUMERIC_KEYBOARD,
             ),
-        locales = listOf("pl"),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/PLTypeSplitV1.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/PLTypeSplitV1.kt
@@ -287,5 +287,4 @@ val KB_PL_TYPESPLIT_V1: KeyboardDefinition =
                 shifted = KB_PL_TYPESPLIT_V1_SHIFTED,
                 numeric = TYPESPLIT_NUMERIC_KEYBOARD,
             ),
-        locales = listOf("pl"),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/PLTypeSplitV2.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/PLTypeSplitV2.kt
@@ -281,7 +281,6 @@ val KB_PL_TYPESPLIT_V2_SHIFTED =
 val KB_PL_TYPESPLIT_V2: KeyboardDefinition =
     KeyboardDefinition(
         title = "polski type-split v2",
-        locales = listOf("pl"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_PL_TYPESPLIT_V2_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/PTDvorakWide.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/PTDvorakWide.kt
@@ -254,5 +254,4 @@ val KB_PT_DVORAK_WIDE: KeyboardDefinition =
                 shifted = KB_PT_DVORAK_WIDE_SHIFTED,
                 numeric = WIDE_NUMERIC_KEYBOARD,
             ),
-        locales = listOf("pt"),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/PTENThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/PTENThumbKey.kt
@@ -204,7 +204,6 @@ val KB_PT_EN_THUMBKEY_SHIFTED =
 val KB_PT_EN_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "português english thumb-key",
-        locales = listOf("pt", "en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_PT_EN_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/PTThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/PTThumbKey.kt
@@ -206,7 +206,6 @@ val KB_PT_THUMBKEY_SHIFTED =
 val KB_PT_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "português thumb-key",
-        locales = listOf("pt"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_PT_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/PTTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/PTTypeSplit.kt
@@ -249,5 +249,4 @@ val KB_PT_TYPESPLIT: KeyboardDefinition =
                 shifted = KB_PT_TYPESPLIT_SHIFTED,
                 numeric = TYPESPLIT_NUMERIC_KEYBOARD,
             ),
-        locales = listOf("pt"),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/RUArti.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/RUArti.kt
@@ -182,5 +182,4 @@ val KB_RU_ARTI: KeyboardDefinition =
             ),
         settings =
             KeyboardDefinitionSettings(),
-        locales = listOf("ru"),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/RUHyper.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/RUHyper.kt
@@ -251,5 +251,4 @@ val KB_RU_HYPER: KeyboardDefinition =
             KeyboardDefinitionSettings(
                 autoCapitalizers = arrayOf(::autoCapitalizeI, ::autoCapitalizeIApostrophe),
             ),
-        locales = listOf("ru"),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/RUMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/RUMessagEase.kt
@@ -195,7 +195,6 @@ val KB_RU_MESSAGEASE_SHIFTED =
 val KB_RU_MESSAGEASE: KeyboardDefinition =
     KeyboardDefinition(
         title = "русский messagease",
-        locales = listOf("ru"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_RU_MESSAGEASE_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/RUMessagEaseSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/RUMessagEaseSymbols.kt
@@ -254,5 +254,4 @@ val KB_RU_MESSAGEASE_SYMBOLS: KeyboardDefinition =
                 shifted = KB_RU_MESSAGEASE_SYMBOLS_SHIFTED,
                 numeric = KB_EN_MESSAGEASE_NUMERIC,
             ),
-        locales = listOf("ru"),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/RUMessagEaseWriter.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/RUMessagEaseWriter.kt
@@ -262,7 +262,6 @@ val KB_RU_MESSAGEASE_WRITER_SHIFTED =
 val KB_RU_MESSAGEASE_WRITER: KeyboardDefinition =
     KeyboardDefinition(
         title = "русский messagease writer",
-        locales = listOf("ru"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_RU_MESSAGEASE_WRITER_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/RUMessageOwl.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/RUMessageOwl.kt
@@ -211,7 +211,6 @@ val KB_RU_MESSAGE_OWL_SHIFTED =
 val KB_RU_MESSAGE_OWL: KeyboardDefinition =
     KeyboardDefinition(
         title = "русский owl",
-        locales = listOf("ru"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_RU_MESSAGE_OWL_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/RUThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/RUThumbKey.kt
@@ -202,7 +202,6 @@ val KB_RU_THUMBKEY_SHIFTED =
 val KB_RU_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "русский thumb-key",
-        locales = listOf("ru"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_RU_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/RUThumbKeySymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/RUThumbKeySymbols.kt
@@ -258,5 +258,4 @@ val KB_RU_THUMBKEY_SYMBOLS: KeyboardDefinition =
                 shifted = KB_RU_THUMBKEY_SYMBOLS_SHIFTED,
                 numeric = NUMERIC_KEYBOARD,
             ),
-        locales = listOf("ru"),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/RUThumbKeyWriter.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/RUThumbKeyWriter.kt
@@ -266,7 +266,6 @@ val KB_RU_THUMBKEY_WRITER_SHIFTED =
 val KB_RU_THUMBKEY_WRITER: KeyboardDefinition =
     KeyboardDefinition(
         title = "русский writer thumb-key",
-        locales = listOf("ru"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_RU_THUMBKEY_WRITER_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/SKThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/SKThumbKey.kt
@@ -217,7 +217,6 @@ val KB_SK_THUMBKEY_V1_SHIFTED =
 val KB_SK_THUMBKEY_V1: KeyboardDefinition =
     KeyboardDefinition(
         title = "slovenčina thumb-key v1",
-        locales = listOf("sk"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_SK_THUMBKEY_V1_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/SKThumbKeyV2.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/SKThumbKeyV2.kt
@@ -229,7 +229,6 @@ val KB_SK_THUMBKEY_V2_SHIFTED =
 val KB_SK_THUMBKEY_V2: KeyboardDefinition =
     KeyboardDefinition(
         title = "slovenčina thumb-key v2",
-        locales = listOf("sk"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_SK_THUMBKEY_V2_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/SKThumbKeyV3.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/SKThumbKeyV3.kt
@@ -188,7 +188,6 @@ val KB_SK_THUMBKEY_V3_SHIFTED =
 val KB_SK_THUMBKEY_V3: KeyboardDefinition =
     KeyboardDefinition(
         title = "slovenčina thumb-key v3",
-        locales = listOf("sk"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_SK_THUMBKEY_V3_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/SLMessagEaseSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/SLMessagEaseSymbols.kt
@@ -246,7 +246,6 @@ val KB_SL_MESSAGEASE_SYMBOLS_SHIFTED =
 val KB_SL_MESSAGEASE_SYMBOLS: KeyboardDefinition =
     KeyboardDefinition(
         title = "slovenščina messagease symbols",
-        locales = listOf("sl"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_SL_MESSAGEASE_SYMBOLS_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/SRLatnEnDeThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/SRLatnEnDeThumbKey.kt
@@ -199,7 +199,6 @@ val KB_SRLATN_EN_DE_THUMBKEY_SHIFTED =
 val KB_SRLATN_EN_DE_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "srpski (latinica) engleski nemački thumb-key",
-        locales = listOf("sr-Latn", "en", "de"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_SRLATN_EN_DE_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/SRLatnThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/SRLatnThumbKey.kt
@@ -192,7 +192,6 @@ val KB_SRLATN_THUMBKEY_SHIFTED =
 val KB_SRLATN_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "srpski (latinica) thumb-key",
-        locales = listOf("sr-Latn"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_SRLATN_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/SRThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/SRThumbKey.kt
@@ -192,7 +192,6 @@ val KB_SR_THUMBKEY_SHIFTED =
 val KB_SR_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "српски / srpski thumb-key",
-        locales = listOf("sr"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_SR_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/SVMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/SVMessagEase.kt
@@ -223,7 +223,6 @@ val KB_SV_MESSAGEASE_SHIFTED =
 val KB_SV_MESSAGEASE: KeyboardDefinition =
     KeyboardDefinition(
         title = "svenska messagease",
-        locales = listOf("sv"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_SV_MESSAGEASE_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/SVThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/SVThumbKey.kt
@@ -190,7 +190,6 @@ val KB_SV_THUMBKEY_SHIFTED =
 val KB_SV_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "svenska thumb-key",
-        locales = listOf("sv"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_SV_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ScandinavianMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ScandinavianMessagEase.kt
@@ -264,7 +264,6 @@ val KB_SCANDINAVIAN_MESSAGEASE_SHIFTED =
 val KB_SCANDINAVIAN_MESSAGEASE: KeyboardDefinition =
     KeyboardDefinition(
         title = "scandinavian messagease",
-        locales = listOf("da", "no", "sv"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_SCANDINAVIAN_MESSAGEASE_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/T9.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/T9.kt
@@ -566,7 +566,6 @@ val KB_T9_SHIFTED =
 val KB_T9: KeyboardDefinition =
     KeyboardDefinition(
         title = "T9",
-        locales = listOf("en"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_T9_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/THThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/THThumbKey.kt
@@ -123,7 +123,6 @@ val KB_TH_THUMBKEY_MAIN =
 val KB_TH_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "ภาษาไทย thai thumb-key",
-        locales = listOf("th"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_TH_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/THThumbKeyKhamChueam.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/THThumbKeyKhamChueam.kt
@@ -208,7 +208,6 @@ val KB_TH_THUMBKEY_KHAM_CHUEAM_SHIFTED =
 val KB_TH_THUMBKEY_KHAM_CHUEAM: KeyboardDefinition =
     KeyboardDefinition(
         title = "ภาษาไทย thai thumb-key คำเชื่อม",
-        locales = listOf("th"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_TH_THUMBKEY_KHAM_CHUEAM_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/TOKSitelenThumbkeyEmoji.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/TOKSitelenThumbkeyEmoji.kt
@@ -245,7 +245,6 @@ val KB_TOK_SITELEN_THUMBKEY_EMOJI_SHIFTED =
 val KB_TOK_SITELEN_THUMBKEY_EMOJI: KeyboardDefinition =
     KeyboardDefinition(
         title = "toki pona sitelen thumb-key emoji",
-        locales = listOf("tok"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_TOK_SITELEN_THUMBKEY_EMOJI_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/TOKThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/TOKThumbKey.kt
@@ -422,5 +422,4 @@ val KB_TOK_THUMBKEY: KeyboardDefinition =
                 numeric = NUMERIC_KEYBOARD,
             ),
         settings = KeyboardDefinitionSettings(autoShift = false),
-        locales = listOf("en"),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/TRArti.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/TRArti.kt
@@ -348,7 +348,6 @@ val KB_TR_ARTI_NUMERIC =
 val KB_TR_ARTI: KeyboardDefinition =
     KeyboardDefinition(
         title = "türkçe artı çok",
-        locales = listOf("tr"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_TR_ARTI_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/TRThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/TRThumbKey.kt
@@ -259,5 +259,4 @@ val KB_TR_THUMBKEY: KeyboardDefinition =
                 shifted = KB_TR_THUMBKEY_SHIFTED,
                 numeric = NUMERIC_KEYBOARD,
             ),
-        locales = listOf("tr"),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/TRTypeSplit.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/TRTypeSplit.kt
@@ -239,5 +239,4 @@ val KB_TR_TYPESPLIT: KeyboardDefinition =
                 shifted = KB_TR_TYPESPLIT_SHIFTED,
                 numeric = TYPESPLIT_NUMERIC_KEYBOARD,
             ),
-        locales = listOf("tr"),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/UKBYRUThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/UKBYRUThumbKey.kt
@@ -204,7 +204,6 @@ val KB_UK_BY_RU_THUMBKEY_SHIFTED =
 val KB_UK_BY_RU_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "українська беларуская русский thumb-key",
-        locales = listOf("uk", "be", "ru"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_UK_BY_RU_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/UKMessagEaseSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/UKMessagEaseSymbols.kt
@@ -252,5 +252,4 @@ val KB_UK_MESSAGEASE_SYMBOLS: KeyboardDefinition =
                 shifted = KB_UK_MESSAGEASE_SYMBOLS_SHIFTED,
                 numeric = KB_EN_MESSAGEASE_NUMERIC,
             ),
-        locales = listOf("uk"),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/UKRUMessagEaseSymbols.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/UKRUMessagEaseSymbols.kt
@@ -248,7 +248,6 @@ val KB_UK_RU_MESSAGEASE_SYMBOLS_SHIFTED =
 val KB_UK_RU_MESSAGEASE_SYMBOLS: KeyboardDefinition =
     KeyboardDefinition(
         title = "українська русский messagease symbols",
-        locales = listOf("uk", "ru"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_UK_RU_MESSAGEASE_SYMBOLS_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/UKThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/UKThumbKey.kt
@@ -196,7 +196,6 @@ val KB_UK_THUMBKEY_SHIFTED =
 val KB_UK_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "українська thumb-key",
-        locales = listOf("uk"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_UK_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/VNThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/VNThumbKey.kt
@@ -296,7 +296,6 @@ val KB_VN_THUMBKEY_SHIFTED =
 val KB_VN_THUMBKEY: KeyboardDefinition =
     KeyboardDefinition(
         title = "tiếng việt thumb-key",
-        locales = listOf("vi"),
         modes =
             KeyboardDefinitionModes(
                 main = KB_VN_THUMBKEY_MAIN,

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
@@ -125,7 +125,6 @@ fun KeyboardKey(
     onToggleHideLetters: () -> Unit,
     onAutoCapitalize: (enable: Boolean) -> Unit,
     onSwitchLanguage: () -> Unit,
-    onCycleLocale: () -> Unit,
     onChangePosition: ((old: KeyboardPosition) -> KeyboardPosition) -> Unit,
     onKeyEvent: () -> Unit,
     oppositeCaseKey: KeyItemC? = null,
@@ -249,7 +248,6 @@ fun KeyboardKey(
                         onToggleHideLetters = onToggleHideLetters,
                         onAutoCapitalize = onAutoCapitalize,
                         onSwitchLanguage = onSwitchLanguage,
-                        onCycleLocale = onCycleLocale,
                         onChangePosition = onChangePosition,
                         onKeyEvent = onKeyEvent,
                     )
@@ -272,7 +270,6 @@ fun KeyboardKey(
                             onToggleHideLetters = onToggleHideLetters,
                             onAutoCapitalize = onAutoCapitalize,
                             onSwitchLanguage = onSwitchLanguage,
-                            onCycleLocale = onCycleLocale,
                             onChangePosition = onChangePosition,
                             onKeyEvent = onKeyEvent,
                         )
@@ -572,7 +569,6 @@ fun KeyboardKey(
                                 onToggleHideLetters = onToggleHideLetters,
                                 onAutoCapitalize = onAutoCapitalize,
                                 onSwitchLanguage = onSwitchLanguage,
-                                onCycleLocale = onCycleLocale,
                                 onChangePosition = onChangePosition,
                                 onKeyEvent = onKeyEvent,
                             )
@@ -611,7 +607,6 @@ fun KeyboardKey(
                                         onToggleHideLetters = onToggleHideLetters,
                                         onAutoCapitalize = onAutoCapitalize,
                                         onSwitchLanguage = onSwitchLanguage,
-                                        onCycleLocale = onCycleLocale,
                                         onChangePosition = onChangePosition,
                                         onKeyEvent = onKeyEvent,
                                     )

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
@@ -99,7 +99,6 @@ fun KeyboardScreen(
     settings: AppSettings?,
     clipboardRepository: ClipboardRepository,
     onSwitchLanguage: () -> Unit,
-    onCycleLocale: () -> Unit,
     onChangePosition: ((old: KeyboardPosition) -> KeyboardPosition) -> Unit,
     onToggleHideLetters: () -> Unit,
     onGoToClipboardSettings: () -> Unit,
@@ -437,10 +436,6 @@ fun KeyboardScreen(
                                     onSwitchLanguage()
                                     mode = KeyboardMode.MAIN
                                 },
-                                onCycleLocale = {
-                                    onCycleLocale()
-                                    mode = KeyboardMode.MAIN
-                                },
                                 onChangePosition = onChangePosition,
                                 onKeyEvent = {
                                     when (mode) {
@@ -734,10 +729,6 @@ fun KeyboardScreen(
                                         },
                                         onSwitchLanguage = {
                                             onSwitchLanguage()
-                                            mode = KeyboardMode.MAIN
-                                        },
-                                        onCycleLocale = {
-                                            onCycleLocale()
                                             mode = KeyboardMode.MAIN
                                         },
                                         onChangePosition = onChangePosition,

--- a/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardModificationService.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardModificationService.kt
@@ -307,7 +307,6 @@ fun getCommonKeyCFromKeyAction(keyActionSerializable: KeyActionSerializable?): K
         KeyActionSerializable.DeleteWordBeforeCursor -> DELETE_WORD_BEFORE_CURSOR_KEYC
         KeyActionSerializable.DeleteWordAfterCursor -> DELETE_WORD_AFTER_CURSOR_KEYC
         KeyActionSerializable.SwitchLanguage -> SWITCH_LANGUAGE_KEYC
-        KeyActionSerializable.CycleLocale -> SWITCH_LANGUAGE_KEYC
         KeyActionSerializable.SwitchIME -> SWITCH_IME_KEYC
         KeyActionSerializable.SwitchIMEVoice -> SWITCH_IME_VOICE_KEYC
         KeyActionSerializable.HideKeyboard -> HIDE_KEYBOARD_KEYC
@@ -500,7 +499,6 @@ enum class KeyActionSerializable {
     Undo,
     Redo,
     SwitchLanguage,
-    CycleLocale,
     SwitchIME,
     SwitchIMEVoice,
     HideKeyboard,

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
@@ -42,7 +42,6 @@ data class KeyboardDefinitionSettings(
 @optics
 data class KeyboardDefinition(
     val title: String,
-    val locales: List<String>? = null,
     val modes: KeyboardDefinitionModes,
     val settings: KeyboardDefinitionSettings = KeyboardDefinitionSettings(),
 ) {
@@ -278,8 +277,6 @@ sealed class KeyAction {
     data object Redo : KeyAction()
 
     data object SwitchLanguage : KeyAction()
-
-    data object CycleLocale : KeyAction()
 
     data object SwitchIME : KeyAction()
 

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -347,7 +347,6 @@ fun performKeyAction(
     onToggleHideLetters: () -> Unit,
     onAutoCapitalize: (enable: Boolean) -> Unit,
     onSwitchLanguage: () -> Unit,
-    onCycleLocale: () -> Unit,
     onChangePosition: ((old: KeyboardPosition) -> KeyboardPosition) -> Unit,
     onKeyEvent: () -> Unit,
 ) {
@@ -1390,10 +1389,6 @@ fun performKeyAction(
 
         KeyAction.SwitchLanguage -> {
             onSwitchLanguage()
-        }
-
-        KeyAction.CycleLocale -> {
-            onCycleLocale()
         }
 
         KeyAction.SwitchIME -> {


### PR DESCRIPTION
Reverts dessalines/thumb-key#1774

Fixes #1816 

@markokocic This broke thumb-key on older devices, ~android 12 at least confirmed.

If you'd like to do another one, you'll have to either test it on an emulator, or find an older device to test it on.