### PR TITLE
Update README examples to set `swipeType`

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ This YAML configuration modifies the key in the second row, first column, center
   - `ctrled`
   - `alted`
 - `key1_0` specifies the key to modify. The first number is the row, and the second number is the column. The top row is 0, and the left column is 0.
-- `center` specifies which slide/touch direction of the key to modify. Possible values are:
+- `center` specifies which slide/touch direction of the key to modify. Possible values depend on the value of `swipeType` -- for `swipeType: EIGHT_WAY`, they are:
   - `center`
   - `left`
   - `topLeft`
@@ -201,11 +201,13 @@ This YAML configuration modifies the key in the second row, first column, center
 ENThumbKey:
   main:
     key0_0:
+      swipeType: EIGHT_WAY
       right: { text: ê }
       topRight: { text: è }
       top: { text: ę }
   shifted:
     key0_0:
+      swipeType: EIGHT_WAY
       right: { text: Ê }
       topRight: { text: È }
       top: { text: Ę }
@@ -232,6 +234,8 @@ ESCAMessagEase:
 
 - Two keyboards are modified: `ENThumbKey (english thumbkey)` and `ESCAMessagEase (español català messagease)`.
 - The first keyboard has both `main` and `shifted` modes modified.
+- Because we are adding swipe directions to letters in `ENThumbKey` which don't
+  have them by default, we must adjust `swipeType`.
 - The second keyboard uses the `size` property to specify the display size of the text. Possible values are:
   - `LARGE`
   - `SMALL`


### PR DESCRIPTION
The examples adjust the "s" key in ENThumbKey, which is `FOUR_WAY_DIAGONAL` by default:
https://github.com/dessalines/thumb-key/blob/main/app/src/main/java/com/dessalines/thumbkey/keyboards/ENThumbKey.kt#L19

I got stuck on this when customizing my layout, and it looks like someone else did too:
https://github.com/dessalines/thumb-key/issues/1804

Let me know if there's a different way you'd like to explain this, or if there are other places in the README it should appear.

I checked README formatting with `prettier`:
```
prettier -c README.md
Checking formatting...
All matched files use Prettier code style!
```

I uploaded some videos here of how the keyboard behaves before and after: https://drive.google.com/drive/folders/1mYsf3e5TyVAjCp0SBlXLfyuAnpLC7Nqo