### PR TITLE
Add slide+hold cursor navigation

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/db/AppDb.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/db/AppDb.kt
@@ -62,6 +62,7 @@ const val DEFAULT_CIRCULAR_DRAG_ENABLED = 1
 const val DEFAULT_CLOCKWISE_DRAG_ACTION = 0
 const val DEFAULT_COUNTERCLOCKWISE_DRAG_ACTION = 1
 const val DEFAULT_GHOST_KEYS_ENABLED = 0
+const val DEFAULT_SLIDE_HOLD_ENABLED = 0
 const val DEFAULT_KEY_MODIFICATIONS = ""
 const val DEFAULT_IGNORE_BOTTOM_PADDING = 0
 const val DEFAULT_SHOW_TOAST_ON_LAYOUT_SWITCH = 1
@@ -252,6 +253,11 @@ data class AppSettings(
         defaultValue = DEFAULT_GHOST_KEYS_ENABLED.toString(),
     )
     val ghostKeysEnabled: Int,
+    @ColumnInfo(
+        name = "slide_hold_enabled",
+        defaultValue = DEFAULT_SLIDE_HOLD_ENABLED.toString(),
+    )
+    val slideHoldEnabled: Int,
     @ColumnInfo(
         name = "key_modifications",
         defaultValue = "",
@@ -475,6 +481,8 @@ data class BehaviorUpdate(
     val counterclockwiseDragAction: Int,
     @ColumnInfo(name = "ghost_keys_enabled")
     val ghostKeysEnabled: Int,
+    @ColumnInfo(name = "slide_hold_enabled")
+    val slideHoldEnabled: Int,
 )
 
 data class KeyModificationsUpdate(
@@ -612,7 +620,7 @@ class AppSettingsRepository(
 }
 
 @Database(
-    version = 26,
+    version = 27,
     entities = [AppSettings::class],
     exportSchema = true,
 )
@@ -660,6 +668,7 @@ abstract class AppDB : RoomDatabase() {
                             MIGRATION_23_24,
                             MIGRATION_24_25,
                             MIGRATION_25_26,
+                            MIGRATION_26_27,
                         )
                         // Necessary because it can't insert data on creation
                         .addCallback(

--- a/app/src/main/java/com/dessalines/thumbkey/db/Migrations.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/db/Migrations.kt
@@ -293,3 +293,12 @@ val MIGRATION_25_26 =
             )
         }
     }
+
+val MIGRATION_26_27 =
+    object : Migration(26, 27) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL(
+                "ALTER TABLE AppSettings ADD COLUMN slide_hold_enabled INTEGER NOT NULL DEFAULT $DEFAULT_SLIDE_HOLD_ENABLED",
+            )
+        }
+    }

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/CommonKeys.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/CommonKeys.kt
@@ -282,6 +282,20 @@ val BACKSPACE_KEY_ITEM =
 
 val BACKSPACE_WIDE_KEY_ITEM = BACKSPACE_KEY_ITEM.copy(widthMultiplier = 3)
 
+val SPACEBAR_TOP_KEYC =
+    KeyC(
+        action = CursorToLineStart,
+        swipeReturnAction = CursorToTextStart,
+        display = null,
+    )
+
+val SPACEBAR_BOTTOM_KEYC =
+    KeyC(
+        action = CursorToLineEnd,
+        swipeReturnAction = CursorToTextEnd,
+        display = null,
+    )
+
 val SPACEBAR_LEFT_KEYC =
     KeyC(
         action =
@@ -319,6 +333,8 @@ val SPACEBAR_KEY_ITEM =
         center = SPACEBAR_CENTER_KEYC,
         swipeType = SwipeNWay.EIGHT_WAY,
         slideType = SlideType.MOVE_CURSOR,
+        top = SPACEBAR_TOP_KEYC,
+        bottom = SPACEBAR_BOTTOM_KEYC,
         left = SPACEBAR_LEFT_KEYC,
         right = SPACEBAR_RIGHT_KEYC,
         bottomLeft = PREVIOUS_WORD_BEFORE_CURSOR_KEYC,
@@ -330,7 +346,7 @@ val SPACEBAR_KEY_ITEM =
 val SPACEBAR_SKINNY_KEY_ITEM = SPACEBAR_KEY_ITEM.copy(widthMultiplier = 1)
 val SPACEBAR_DOUBLE_KEY_ITEM = SPACEBAR_KEY_ITEM.copy(widthMultiplier = 2)
 
-val SPACEBAR_TOP_KEYC =
+val SPACEBAR_PROGRAMMING_TOP_KEYC =
     KeyC(
         action =
             SendEvent(
@@ -341,7 +357,7 @@ val SPACEBAR_TOP_KEYC =
             ),
         display = null,
     )
-val SPACEBAR_BOTTOM_KEYC =
+val SPACEBAR_PROGRAMMING_BOTTOM_KEYC =
     KeyC(
         action =
             SendEvent(
@@ -359,8 +375,8 @@ val SPACEBAR_PROGRAMMING_KEY_ITEM =
         slideType = SlideType.MOVE_CURSOR,
         left = SPACEBAR_LEFT_KEYC,
         right = SPACEBAR_RIGHT_KEYC,
-        top = SPACEBAR_TOP_KEYC,
-        bottom = SPACEBAR_BOTTOM_KEYC,
+        top = SPACEBAR_PROGRAMMING_TOP_KEYC,
+        bottom = SPACEBAR_PROGRAMMING_BOTTOM_KEYC,
         backgroundColor = SURFACE_VARIANT,
         widthMultiplier = 3,
     )
@@ -463,8 +479,8 @@ val SPACEBAR_ALL_DIRECTIONS =
     SPACEBAR_TYPESPLIT_MIDDLE_KEY_ITEM.copy(
         left = SPACEBAR_LEFT_KEYC.copy(display = KeyDisplay.TextDisplay("←"), color = MUTED),
         right = SPACEBAR_RIGHT_KEYC.copy(display = KeyDisplay.TextDisplay("→"), color = MUTED),
-        top = SPACEBAR_TOP_KEYC.copy(display = KeyDisplay.TextDisplay("↑"), color = MUTED),
-        bottom = SPACEBAR_BOTTOM_KEYC.copy(display = KeyDisplay.TextDisplay("↓"), color = MUTED),
+        top = SPACEBAR_PROGRAMMING_TOP_KEYC.copy(display = KeyDisplay.TextDisplay("↑"), color = MUTED),
+        bottom = SPACEBAR_PROGRAMMING_BOTTOM_KEYC.copy(display = KeyDisplay.TextDisplay("↓"), color = MUTED),
     )
 
 val BACKSPACE_TYPESPLIT_KEY_ITEM =

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
@@ -2,6 +2,7 @@ package com.dessalines.thumbkey.ui.components.keyboard
 import android.content.Context
 import android.media.AudioManager
 import android.os.Build
+import android.util.Log
 import android.view.HapticFeedbackConstants
 import android.view.KeyEvent
 import androidx.compose.animation.AnimatedVisibility
@@ -63,24 +64,39 @@ import com.dessalines.thumbkey.utils.Selection
 import com.dessalines.thumbkey.utils.SlideType
 import com.dessalines.thumbkey.utils.SwipeDirection
 import com.dessalines.thumbkey.utils.SwipeNWay
+import com.dessalines.thumbkey.utils.TAG
 import com.dessalines.thumbkey.utils.buildTapActions
 import com.dessalines.thumbkey.utils.circularDirection
 import com.dessalines.thumbkey.utils.colorVariantToColor
+import com.dessalines.thumbkey.utils.deleteWordBeforeCursor
 import com.dessalines.thumbkey.utils.doneKeyAction
 import com.dessalines.thumbkey.utils.fontSizeVariantToFontSize
 import com.dessalines.thumbkey.utils.isPasswordField
+import com.dessalines.thumbkey.utils.nextWordAfterCursor
 import com.dessalines.thumbkey.utils.performKeyAction
+import com.dessalines.thumbkey.utils.previousWordBeforeCursor
 import com.dessalines.thumbkey.utils.pxToSp
 import com.dessalines.thumbkey.utils.slideCursorDistance
 import com.dessalines.thumbkey.utils.startSelection
 import com.dessalines.thumbkey.utils.swipeDirection
 import com.dessalines.thumbkey.utils.toPx
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeMark
 import kotlin.time.TimeSource
+
+// magic number found from trial and error
+private const val DRAG_RETURN_THRESHOLD_FACTOR = 0.71f
+
+private const val SLIDE_HOLD_SLOW_TICK_THRESHOLD = 4 // number of ticks at the slow rate
+private const val SLIDE_HOLD_SLOW_TICK_DELAY_MS = 300L // ms between ticks during slow phase
+private const val SLIDE_HOLD_FAST_TICK_DELAY_MS = 100L // ms between ticks during fast phase
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -133,6 +149,7 @@ fun KeyboardKey(
     circularDragEnabled: Boolean,
     clockwiseDragAction: CircularDragAction,
     counterclockwiseDragAction: CircularDragAction,
+    slideHoldEnabled: Boolean,
 ) {
     // Necessary for swipe settings to get updated correctly
     val id =
@@ -140,7 +157,8 @@ fun KeyboardKey(
             vibrateOnTap + vibrateOnSlide + soundOnTap + legendHeight + legendWidth + minSwipeLength +
             slideSensitivity + slideEnabled + slideCursorMovementMode + slideSpacebarDeadzoneEnabled +
             slideBackspaceDeadzoneEnabled + dragReturnEnabled + circularDragEnabled +
-            clockwiseDragAction.ordinal + counterclockwiseDragAction.ordinal
+            clockwiseDragAction.ordinal + counterclockwiseDragAction.ordinal +
+            slideHoldEnabled
 
     val ctx = LocalContext.current
     val ime = ctx as IMEService
@@ -172,6 +190,12 @@ fun KeyboardKey(
 
     var selection by remember { mutableStateOf(Selection()) }
 
+    // Slide-hold states
+    var slideHoldDirection by remember { mutableStateOf<SwipeDirection?>(null) }
+    var slideHoldReturnDetected by remember { mutableStateOf(false) }
+    var slideHoldTickCount by remember { mutableIntStateOf(0) }
+    var slideHoldRepeatJob by remember { mutableStateOf<kotlinx.coroutines.Job?>(null) }
+
     val backgroundColor =
         if (!(isDragged.value || isPressed)) {
             colorVariantToColor(colorVariant = key.backgroundColor)
@@ -184,6 +208,18 @@ fun KeyboardKey(
     val view = LocalView.current
     val audioManager = ctx.getSystemService(Context.AUDIO_SERVICE) as AudioManager
 
+    /**
+     * The type of haptic feedback to use when moving the cursor with slide
+     * gestures, based on the device's supported API.
+     */
+    val slideHapticConstant =
+        if (Build.VERSION.SDK_INT >= 27) {
+            HapticFeedbackConstants.TEXT_HANDLE_MOVE
+        } else {
+            // Compatible with API 24, but vibration will not distinguish between tap and slide
+            HapticFeedbackConstants.KEYBOARD_TAP
+        }
+
     LaunchedEffect(key1 = isPressed) {
         if (isPressed) {
             if (vibrateOnTap) {
@@ -193,6 +229,148 @@ fun KeyboardKey(
             }
             if (soundOnTap) {
                 audioManager.playSoundEffect(AudioManager.FX_KEY_CLICK, .1f)
+            }
+        }
+    }
+
+    suspend fun repeatCursorMovement(dir: SwipeDirection) {
+        var tickCount = 0
+        while (currentCoroutineContext().isActive) {
+            val delayMs =
+                if (tickCount < SLIDE_HOLD_SLOW_TICK_THRESHOLD) {
+                    SLIDE_HOLD_SLOW_TICK_DELAY_MS
+                } else {
+                    SLIDE_HOLD_FAST_TICK_DELAY_MS
+                }
+            delay(delayMs)
+            val keyCode =
+                when (dir) {
+                    SwipeDirection.LEFT -> {
+                        KeyEvent.KEYCODE_DPAD_LEFT
+                    }
+
+                    SwipeDirection.RIGHT -> {
+                        KeyEvent.KEYCODE_DPAD_RIGHT
+                    }
+
+                    else -> {
+                        // This should never happen)
+                        Log.d(TAG, "ERROR: Invalid swipe direction: $dir")
+                    }
+                }
+            if (slideHoldReturnDetected) {
+                if (dir == SwipeDirection.RIGHT) nextWordAfterCursor(ime) else previousWordBeforeCursor(ime)
+            } else {
+                ime.currentInputConnection.sendKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, keyCode))
+                ime.currentInputConnection.sendKeyEvent(KeyEvent(KeyEvent.ACTION_UP, keyCode))
+            }
+            tickCount++
+            slideHoldTickCount = tickCount
+            if (vibrateOnSlide) view.performHapticFeedback(slideHapticConstant)
+        }
+    }
+
+    suspend fun repeatDeleteAction() {
+        var tickCount = 0
+        while (currentCoroutineContext().isActive) {
+            val delayMs =
+                if (tickCount < SLIDE_HOLD_SLOW_TICK_THRESHOLD) {
+                    SLIDE_HOLD_SLOW_TICK_DELAY_MS
+                } else {
+                    SLIDE_HOLD_FAST_TICK_DELAY_MS
+                }
+            delay(delayMs)
+            if (slideHoldReturnDetected) {
+                deleteWordBeforeCursor(ime)
+            } else {
+                ime.currentInputConnection.sendKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DEL))
+                ime.currentInputConnection.sendKeyEvent(KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_DEL))
+            }
+            tickCount++
+            slideHoldTickCount = tickCount
+            if (vibrateOnSlide) view.performHapticFeedback(slideHapticConstant)
+        }
+    }
+
+    /**
+     * Resets all state variables associated with the slide-hold gesture.
+     *
+     * @return The number of ticks that occurred during the slide-hold before it was reset.
+     */
+    fun resetSlideHoldVariables(): Int {
+        // Always clean up slide-hold at drag end. Capture ticks before clearing
+        // so the branch below can decide whether the hold actually fired.
+        val slideHoldTicks = slideHoldTickCount
+        slideHoldRepeatJob?.cancel()
+        slideHoldRepeatJob = null
+        slideHoldDirection = null
+        slideHoldReturnDetected = false
+        slideHoldTickCount = 0
+        return slideHoldTicks
+    }
+
+    fun handleSlideHold() {
+        // Slide-hold: detect swipe direction, then
+        // repeat cursor movement (spacebar) or deletion (backspace) while held
+        val returnThreshold = minSwipeLength * DRAG_RETURN_THRESHOLD_FACTOR
+
+        if (slideHoldDirection != null) {
+            // Direction already detected; check for return gesture.
+            if (!slideHoldReturnDetected && maxOffset.getDistance() >= minSwipeLength) {
+                // Mirrors the drag-return detection in onDragEnd: the gesture qualifies as "slide-and-return" if either
+                // (a) it's close enough to the origin, or
+                // (b) it moved into a different cardinal direction from the max-offset direction.
+                val currentOffset = positions.lastOrNull() ?: Offset(offsetX, offsetY)
+                val closeEnough = currentOffset.getDistance() <= returnThreshold
+                val currentSwipeDirection =
+                    swipeDirection(
+                        currentOffset.x,
+                        currentOffset.y,
+                        minSwipeLength,
+                        SwipeNWay.FOUR_WAY_CROSS,
+                    )
+                val maxSwipeDirection =
+                    swipeDirection(
+                        maxOffset.x,
+                        maxOffset.y,
+                        minSwipeLength,
+                        SwipeNWay.FOUR_WAY_CROSS,
+                    )
+                val oppositeDirection = currentSwipeDirection != maxSwipeDirection
+                if (closeEnough || oppositeDirection) {
+                    slideHoldReturnDetected = true
+                }
+            }
+        } else {
+            // Try to detect cardinal swipe direction
+            val dir =
+                swipeDirection(
+                    offsetX,
+                    offsetY,
+                    minSwipeLength,
+                    SwipeNWay.FOUR_WAY_CROSS,
+                )
+            if (dir == null) {
+                return
+            }
+
+            slideHoldDirection = dir
+            when (key.slideType) {
+                SlideType.MOVE_CURSOR -> {
+                    if (dir == SwipeDirection.LEFT || dir == SwipeDirection.RIGHT) {
+                        // Launch repeating cursor movement coroutine
+                        slideHoldRepeatJob = scope.launch { repeatCursorMovement(dir) }
+                    }
+                }
+
+                SlideType.DELETE -> {
+                    // Backspace: only left-swipe is supported
+                    if (dir == SwipeDirection.LEFT) {
+                        slideHoldRepeatJob = scope.launch { repeatDeleteAction() }
+                    }
+                }
+
+                SlideType.NONE -> {}
             }
         }
     }
@@ -301,18 +479,6 @@ fun KeyboardKey(
                         // First detection is large enough to preserve swipe actions.
                         val slideOffsetTrigger = (keySize.dp.toPx() * 0.75) + minSwipeLength
 
-                        /**
-                         * The type of haptic feedback to use when moving the cursor with slide
-                         * gestures, based on the device's supported API.
-                         */
-                        val slideHapticConstant =
-                            if (Build.VERSION.SDK_INT >= 27) {
-                                HapticFeedbackConstants.TEXT_HANDLE_MOVE
-                            } else {
-                                // Compatible with API 24, but vibration will not distinguish between tap and slide
-                                HapticFeedbackConstants.KEYBOARD_TAP
-                            }
-
                         // These keys have a lot of functionality.
                         // We can tap; swipe; slide the cursor left/right; select and delete text
                         // Spacebar:
@@ -326,7 +492,9 @@ fun KeyboardKey(
                         //      Slide gesture delete
                         //          Wtih slide gesture deadzone to allow normal swipes
                         //          Without deadzone
-                        if (key.slideType == SlideType.MOVE_CURSOR && slideEnabled) {
+                        if ((key.slideType == SlideType.MOVE_CURSOR || key.slideType == SlideType.DELETE) && slideHoldEnabled) {
+                            handleSlideHold()
+                        } else if (key.slideType == SlideType.MOVE_CURSOR && slideEnabled) {
                             val slideSelectionOffsetTrigger = (keySize.dp.toPx() * 1.25) + minSwipeLength
                             if (abs(offsetY) > slideSelectionOffsetTrigger) {
                                 // If user slides upwards, enable selection
@@ -470,7 +638,15 @@ fun KeyboardKey(
                     onDragEnd = {
                         lateinit var action: KeyAction
 
-                        if (key.slideType == SlideType.NONE ||
+                        val slideHoldTicks = resetSlideHoldVariables()
+
+                        if ((key.slideType == SlideType.MOVE_CURSOR || key.slideType == SlideType.DELETE) &&
+                            slideHoldEnabled && slideHoldTicks > 0
+                        ) {
+                            // The repeat coroutine already handled all movement/deletion; nothing more to do.
+                            action = KeyAction.Noop
+                            doneKeyAction(scope, action, isDragged, releasedKey, animationHelperSpeed)
+                        } else if (key.slideType == SlideType.NONE ||
                             !slideEnabled ||
                             ((key.slideType == SlideType.DELETE) && !selection.active) ||
                             ((key.slideType == SlideType.MOVE_CURSOR) && !hasSlideMoveCursorTriggered)
@@ -480,7 +656,7 @@ fun KeyboardKey(
                             // offset where we recognize if the swipe is back to the initial key
                             // this offset needs to take the minSwipeLength into consideration. Otherwise
                             // just a little (1px) swipe back would trigger the DragReturn action
-                            val finalOffsetThreshold = minSwipeLength * 0.71f // magic number found from trial and error
+                            val finalOffsetThreshold = minSwipeLength * DRAG_RETURN_THRESHOLD_FACTOR // magic number found from trial and error
 
                             // offset needed, at which the swipe qualifies for DragReturn or Circular
                             // depending on minSwipeLength setting to have consistent swipe lengths or circle sizes

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
@@ -656,7 +656,7 @@ fun KeyboardKey(
                             // offset where we recognize if the swipe is back to the initial key
                             // this offset needs to take the minSwipeLength into consideration. Otherwise
                             // just a little (1px) swipe back would trigger the DragReturn action
-                            val finalOffsetThreshold = minSwipeLength * DRAG_RETURN_THRESHOLD_FACTOR // magic number found from trial and error
+                            val finalOffsetThreshold = minSwipeLength * DRAG_RETURN_THRESHOLD_FACTOR
 
                             // offset needed, at which the swipe qualifies for DragReturn or Circular
                             // depending on minSwipeLength setting to have consistent swipe lengths or circle sizes

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
@@ -37,7 +37,6 @@ import androidx.emoji2.emojipicker.EmojiPickerView
 import com.dessalines.thumbkey.IMEService
 import com.dessalines.thumbkey.R
 import com.dessalines.thumbkey.db.AppSettings
-import com.dessalines.thumbkey.db.ClipboardItem
 import com.dessalines.thumbkey.db.ClipboardRepository
 import com.dessalines.thumbkey.db.DEFAULT_ANIMATION_HELPER_SPEED
 import com.dessalines.thumbkey.db.DEFAULT_ANIMATION_SPEED
@@ -67,6 +66,7 @@ import com.dessalines.thumbkey.db.DEFAULT_PUSHUP_SIZE
 import com.dessalines.thumbkey.db.DEFAULT_SLIDE_BACKSPACE_DEADZONE_ENABLED
 import com.dessalines.thumbkey.db.DEFAULT_SLIDE_CURSOR_MOVEMENT_MODE
 import com.dessalines.thumbkey.db.DEFAULT_SLIDE_ENABLED
+import com.dessalines.thumbkey.db.DEFAULT_SLIDE_HOLD_ENABLED
 import com.dessalines.thumbkey.db.DEFAULT_SLIDE_SENSITIVITY
 import com.dessalines.thumbkey.db.DEFAULT_SLIDE_SPACEBAR_DEADZONE_ENABLED
 import com.dessalines.thumbkey.db.DEFAULT_SOUND_ON_TAP
@@ -230,6 +230,7 @@ fun KeyboardScreen(
     val counterclockwiseDragAction =
         CircularDragAction.entries[settings?.counterclockwiseDragAction ?: DEFAULT_COUNTERCLOCKWISE_DRAG_ACTION]
     val ghostKeysEnabled = (settings?.ghostKeysEnabled ?: DEFAULT_GHOST_KEYS_ENABLED).toBool()
+    val slideHoldEnabled = (settings?.slideHoldEnabled ?: DEFAULT_SLIDE_HOLD_ENABLED).toBool()
 
     val keyBorderWidthFloat = keyBorderWidth / 10.0f
     val keyBorderColour = MaterialTheme.colorScheme.outline
@@ -450,6 +451,7 @@ fun KeyboardScreen(
                                 circularDragEnabled = circularDragEnabled,
                                 clockwiseDragAction = clockwiseDragAction,
                                 counterclockwiseDragAction = counterclockwiseDragAction,
+                                slideHoldEnabled = slideHoldEnabled,
                             )
                         }
                     }
@@ -754,6 +756,7 @@ fun KeyboardScreen(
                                         circularDragEnabled = circularDragEnabled,
                                         clockwiseDragAction = clockwiseDragAction,
                                         counterclockwiseDragAction = counterclockwiseDragAction,
+                                        slideHoldEnabled = slideHoldEnabled,
                                     )
                                 }
                             }

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/backupandrestore/BackupAndRestoreScreen.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/backupandrestore/BackupAndRestoreScreen.kt
@@ -71,6 +71,7 @@ import com.dessalines.thumbkey.db.DEFAULT_SHOW_TOAST_ON_LAYOUT_SWITCH
 import com.dessalines.thumbkey.db.DEFAULT_SLIDE_BACKSPACE_DEADZONE_ENABLED
 import com.dessalines.thumbkey.db.DEFAULT_SLIDE_CURSOR_MOVEMENT_MODE
 import com.dessalines.thumbkey.db.DEFAULT_SLIDE_ENABLED
+import com.dessalines.thumbkey.db.DEFAULT_SLIDE_HOLD_ENABLED
 import com.dessalines.thumbkey.db.DEFAULT_SLIDE_SENSITIVITY
 import com.dessalines.thumbkey.db.DEFAULT_SLIDE_SPACEBAR_DEADZONE_ENABLED
 import com.dessalines.thumbkey.db.DEFAULT_SOUND_ON_TAP
@@ -280,6 +281,7 @@ private fun resetAppSettingsToDefault(appSettingsViewModel: AppSettingsViewModel
             clipboardMaxSize = DEFAULT_CLIPBOARD_MAX_SIZE,
             usePrivateClipboard = DEFAULT_USE_PRIVATE_CLIPBOARD,
             showOnScreenKeyboard = DEFAULT_SHOW_ON_SCREEN_KEYBOARD,
+            slideHoldEnabled = DEFAULT_SLIDE_HOLD_ENABLED,
         ),
     )
 }

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/behavior/BehaviorScreen.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/behavior/BehaviorScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material.icons.outlined.Circle
 import androidx.compose.material.icons.outlined.SpaceBar
 import androidx.compose.material.icons.outlined.SwapHoriz
 import androidx.compose.material.icons.outlined.Swipe
+import androidx.compose.material.icons.outlined.SwipeRight
 import androidx.compose.material.icons.outlined.UTurnRight
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -49,6 +50,7 @@ import com.dessalines.thumbkey.db.DEFAULT_MIN_SWIPE_LENGTH
 import com.dessalines.thumbkey.db.DEFAULT_SLIDE_BACKSPACE_DEADZONE_ENABLED
 import com.dessalines.thumbkey.db.DEFAULT_SLIDE_CURSOR_MOVEMENT_MODE
 import com.dessalines.thumbkey.db.DEFAULT_SLIDE_ENABLED
+import com.dessalines.thumbkey.db.DEFAULT_SLIDE_HOLD_ENABLED
 import com.dessalines.thumbkey.db.DEFAULT_SLIDE_SENSITIVITY
 import com.dessalines.thumbkey.db.DEFAULT_SLIDE_SPACEBAR_DEADZONE_ENABLED
 import com.dessalines.thumbkey.db.DEFAULT_SPACEBAR_MULTITAPS
@@ -97,6 +99,7 @@ fun BehaviorScreen(
     var counterclockwiseDragActionState =
         CircularDragAction.entries[settings?.counterclockwiseDragAction ?: DEFAULT_COUNTERCLOCKWISE_DRAG_ACTION]
     var ghostKeysEnabledState = (settings?.ghostKeysEnabled ?: DEFAULT_GHOST_KEYS_ENABLED).toBool()
+    var slideHoldEnabledState = (settings?.slideHoldEnabled ?: DEFAULT_SLIDE_HOLD_ENABLED).toBool()
 
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -121,6 +124,7 @@ fun BehaviorScreen(
                 clockwiseDragAction = clockwiseDragActionState.ordinal,
                 counterclockwiseDragAction = counterclockwiseDragActionState.ordinal,
                 ghostKeysEnabled = ghostKeysEnabledState.toInt(),
+                slideHoldEnabled = slideHoldEnabledState.toInt(),
             ),
         )
     }
@@ -401,6 +405,25 @@ fun BehaviorScreen(
                             Icon(
                                 imageVector = Icons.Outlined.BorderInner,
                                 contentDescription = stringResource(R.string.ghost_keys_enable),
+                            )
+                        },
+                    )
+                    SwitchPreference(
+                        value = slideHoldEnabledState,
+                        onValueChange = {
+                            slideHoldEnabledState = it
+                            updateBehavior()
+                        },
+                        title = {
+                            Text(stringResource(R.string.slide_hold_enable))
+                        },
+                        summary = {
+                            Text(stringResource(R.string.slide_hold_description))
+                        },
+                        icon = {
+                            Icon(
+                                imageVector = Icons.Outlined.SwipeRight,
+                                contentDescription = stringResource(R.string.slide_hold_enable),
                             )
                         },
                     )

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/behavior/BehaviorScreen.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/behavior/BehaviorScreen.kt
@@ -208,6 +208,9 @@ fun BehaviorScreen(
                         value = slideEnabledState,
                         onValueChange = {
                             slideEnabledState = it
+                            if (slideHoldEnabledState) {
+                                slideHoldEnabledState = false
+                            }
                             updateBehavior()
                         },
                         title = {
@@ -303,6 +306,29 @@ fun BehaviorScreen(
                             Icon(
                                 imageVector = Icons.AutoMirrored.Outlined.Backspace,
                                 contentDescription = stringResource(R.string.slide_backspace_deadzone_enable),
+                            )
+                        },
+                    )
+                    SwitchPreference(
+                        value = slideHoldEnabledState,
+                        onValueChange = {
+                            slideHoldEnabledState = it
+                            if (slideEnabledState) {
+                                slideEnabledState = false
+                            }
+
+                            updateBehavior()
+                        },
+                        title = {
+                            Text(stringResource(R.string.slide_hold_enable))
+                        },
+                        summary = {
+                            Text(stringResource(R.string.slide_hold_description))
+                        },
+                        icon = {
+                            Icon(
+                                imageVector = Icons.Outlined.SwipeRight,
+                                contentDescription = stringResource(R.string.slide_hold_enable),
                             )
                         },
                     )
@@ -405,25 +431,6 @@ fun BehaviorScreen(
                             Icon(
                                 imageVector = Icons.Outlined.BorderInner,
                                 contentDescription = stringResource(R.string.ghost_keys_enable),
-                            )
-                        },
-                    )
-                    SwitchPreference(
-                        value = slideHoldEnabledState,
-                        onValueChange = {
-                            slideHoldEnabledState = it
-                            updateBehavior()
-                        },
-                        title = {
-                            Text(stringResource(R.string.slide_hold_enable))
-                        },
-                        summary = {
-                            Text(stringResource(R.string.slide_hold_description))
-                        },
-                        icon = {
-                            Icon(
-                                imageVector = Icons.Outlined.SwipeRight,
-                                contentDescription = stringResource(R.string.slide_hold_enable),
                             )
                         },
                     )

--- a/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardModificationService.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardModificationService.kt
@@ -24,10 +24,10 @@ import com.dessalines.thumbkey.keyboards.PREVIOUS_WORD_BEFORE_CURSOR_KEYC
 import com.dessalines.thumbkey.keyboards.REDO_KEYC
 import com.dessalines.thumbkey.keyboards.RETURN_KEYC
 import com.dessalines.thumbkey.keyboards.SELECT_ALL_KEYC
-import com.dessalines.thumbkey.keyboards.SPACEBAR_BOTTOM_KEYC
 import com.dessalines.thumbkey.keyboards.SPACEBAR_LEFT_KEYC
+import com.dessalines.thumbkey.keyboards.SPACEBAR_PROGRAMMING_BOTTOM_KEYC
+import com.dessalines.thumbkey.keyboards.SPACEBAR_PROGRAMMING_TOP_KEYC
 import com.dessalines.thumbkey.keyboards.SPACEBAR_RIGHT_KEYC
-import com.dessalines.thumbkey.keyboards.SPACEBAR_TOP_KEYC
 import com.dessalines.thumbkey.keyboards.SWITCH_IME_KEYC
 import com.dessalines.thumbkey.keyboards.SWITCH_IME_VOICE_KEYC
 import com.dessalines.thumbkey.keyboards.SWITCH_LANGUAGE_KEYC
@@ -292,8 +292,8 @@ fun getCommonKeyCFromKeyAction(keyActionSerializable: KeyActionSerializable?): K
         KeyActionSerializable.ToggleAltModeFalse -> TOGGLE_ALT_FALSE_KEYC
         KeyActionSerializable.Left -> SPACEBAR_LEFT_KEYC
         KeyActionSerializable.Right -> SPACEBAR_RIGHT_KEYC
-        KeyActionSerializable.Top -> SPACEBAR_TOP_KEYC
-        KeyActionSerializable.Bottom -> SPACEBAR_BOTTOM_KEYC
+        KeyActionSerializable.Top -> SPACEBAR_PROGRAMMING_TOP_KEYC
+        KeyActionSerializable.Bottom -> SPACEBAR_PROGRAMMING_BOTTOM_KEYC
         KeyActionSerializable.IMEComplete -> RETURN_KEYC
         KeyActionSerializable.PreviousWordBeforeCursor -> PREVIOUS_WORD_BEFORE_CURSOR_KEYC
         KeyActionSerializable.NextWordAfterCursor -> NEXT_WORD_AFTER_CURSOR_KEYC

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
@@ -278,6 +278,14 @@ sealed class KeyAction {
 
     data object Redo : KeyAction()
 
+    data object CursorToLineStart : KeyAction()
+
+    data object CursorToLineEnd : KeyAction()
+
+    data object CursorToTextStart : KeyAction()
+
+    data object CursorToTextEnd : KeyAction()
+
     data object SwitchLanguage : KeyAction()
 
     data object SwitchIME : KeyAction()

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -455,6 +455,26 @@ fun performKeyAction(
             selectLineWithCursor(ime)
         }
 
+        is KeyAction.CursorToLineStart -> {
+            Log.d(TAG, "Cursor to line start")
+            cursorToLineStart(ime)
+        }
+
+        is KeyAction.CursorToLineEnd -> {
+            Log.d(TAG, "Cursor to line end")
+            cursorToLineEnd(ime)
+        }
+
+        is KeyAction.CursorToTextStart -> {
+            Log.d(TAG, "Cursor to text start")
+            cursorToTextStart(ime)
+        }
+
+        is KeyAction.CursorToTextEnd -> {
+            Log.d(TAG, "Cursor to text end")
+            cursorToTextEnd(ime)
+        }
+
         is KeyAction.ReplaceLastText -> {
             Log.d(TAG, "replacing last word")
             val text = action.text
@@ -1632,6 +1652,37 @@ fun moveCursor(
     val selection = startSelection(ime)
     selection.right(delta)
     ime.currentInputConnection.setSelection(selection.end, selection.end)
+}
+
+fun cursorToLineStart(ime: IMEService) {
+    ime.currentInputConnection.sendKeyEvent(
+        KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_MOVE_HOME),
+    )
+    ime.currentInputConnection.sendKeyEvent(
+        KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_MOVE_HOME),
+    )
+}
+
+fun cursorToLineEnd(ime: IMEService) {
+    ime.currentInputConnection.sendKeyEvent(
+        KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_MOVE_END),
+    )
+    ime.currentInputConnection.sendKeyEvent(
+        KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_MOVE_END),
+    )
+}
+
+fun cursorToTextStart(ime: IMEService) {
+    ime.currentInputConnection.setSelection(0, 0)
+}
+
+fun cursorToTextEnd(ime: IMEService) {
+    val ic = ime.currentInputConnection
+    // Sum text before and after the cursor to find the absolute end position.
+    // Using large limits to handle long documents; typical mobile content is well within range.
+    val before = ic.getTextBeforeCursor(1_000_000, 0)?.length ?: return
+    val after = ic.getTextAfterCursor(1_000_000, 0)?.length ?: return
+    ic.setSelection(before + after, before + after)
 }
 
 fun previousWordBeforeCursor(ime: IMEService) {

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -1658,17 +1658,11 @@ fun cursorToLineStart(ime: IMEService) {
     ime.currentInputConnection.sendKeyEvent(
         KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_MOVE_HOME),
     )
-    ime.currentInputConnection.sendKeyEvent(
-        KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_MOVE_HOME),
-    )
 }
 
 fun cursorToLineEnd(ime: IMEService) {
     ime.currentInputConnection.sendKeyEvent(
         KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_MOVE_END),
-    )
-    ime.currentInputConnection.sendKeyEvent(
-        KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_MOVE_END),
     )
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,6 +94,8 @@
     <string name="circular_drag_enable">Circular drag</string>
     <string name="ghost_keys_enable">Ghost keys</string>
     <string name="ghost_keys_description">Access hidden symbol keys without switching to numeric view</string>
+    <string name="slide_hold_enable">Slide-hold cursor movement</string>
+    <string name="slide_hold_description">Slide and hold to repeat cursor movement, slide-return-hold for word movement. Backspace: slide-hold to repeat delete, slide-return-hold for word delete.</string>
     <string name="backup_database">Backup database</string>
     <string name="restore_database">Restore database</string>
     <string name="restore_database_warning">Warning: This will clear out your current database</string>


### PR DESCRIPTION
Introduces a new "Slide-hold cursor movement" behavior setting that changes how the spacebar and backspace respond to slide gestures:

Spacebar:
- Slide right/left + hold: repeat cursor movement (char-by-char, accelerating)
- Slide-and-return right/left + hold: repeat word-by-word movement

Backspace:
- Slide left + hold: repeat character deletion (accelerating)
- Slide-and-return left + hold: repeat word deletion

Additionally, the following changes apply to the spacebar regardless of whether the new setting is enabled:
- Slide up/down: move cursor to line start/end
- Slide-and-return up/down: move cursor to text start/end

related: #1618 , #1670