### PR TITLE
fix: handle null case when getting selected text content via java cla…

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -1330,11 +1330,13 @@ fun performKeyAction(
         KeyAction.Copy -> {
             fun performCopy() {
                 if (ime.clipboardUsePrivate()) {
-                    val text = ime.currentInputConnection.getSelectedText(0).toString()
-                    ime.clipboardAddPrivateClip(text)?.let {
-                        // Text successfully added to clipboard history
-                        val message = ime.getString(R.string.copy)
-                        Toast.makeText(ime, message, Toast.LENGTH_SHORT).show()
+                    val text = ime.currentInputConnection.getSelectedText(0)
+                    if (text != null) {
+                        ime.clipboardAddPrivateClip(text.toString())?.let {
+                            // Text successfully added to clipboard history
+                            val message = ime.getString(R.string.copy)
+                            Toast.makeText(ime, message, Toast.LENGTH_SHORT).show()
+                        }
                     }
                 } else {
                     ime.currentInputConnection.performContextMenuAction(android.R.id.copy)


### PR DESCRIPTION
…ss: if no text is selected, and that somehow user manage to trigger the copy action, it used to crash when trying to convert null to string
closes #1866