### PR TITLE
Normalize characters in the European layout (#1828)

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/EuropeThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/EuropeThumbKey.kt
@@ -21,7 +21,11 @@ val KB_EUROPE_THUMBKEY_MAIN =
                     topRight = KeyC("»", color = MUTED),
                     left = KeyC("¿", color = MUTED),
                     right = KeyC("?", color = MUTED),
-                    bottomLeft = KeyC("\u0304", displayText = "◌̄"),
+                    bottomLeft =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("◌̄"),
+                            action = NormalizeLastKey("\u0304"),
+                        ),
                     bottomRight =
                         KeyC(
                             CommitText("p"),
@@ -43,20 +47,36 @@ val KB_EUROPE_THUMBKEY_MAIN =
                 KeyItemC(
                     center = KeyC("i", size = LARGE),
                     swipeType = FOUR_WAY_DIAGONAL,
-                    topLeft = KeyC("\u0303", displayText = "◌̃"),
-                    topRight = KeyC("\u0306", displayText = "◌̆"),
+                    topLeft =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("◌̃"),
+                            action = NormalizeLastKey("\u0303"),
+                        ),
+                    topRight =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("◌̆"),
+                            action = NormalizeLastKey("\u0306"),
+                        ),
                     bottomLeft =
                         KeyC(
                             CommitText("m"),
                         ),
-                    bottomRight = KeyC("\u030c", displayText = "◌̌"),
+                    bottomRight =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("◌̌"),
+                            action = NormalizeLastKey("\u030c"),
+                        ),
                 ),
                 EMOJI_KEY_ITEM,
             ),
             listOf(
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
-                    topLeft = KeyC("\u0313", displayText = "◌̓"),
+                    topLeft =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("◌̓"),
+                            action = NormalizeLastKey("\u0313"),
+                        ),
                     top =
                         KeyC(
                             // PER MILLE SIGN
@@ -64,7 +84,11 @@ val KB_EUROPE_THUMBKEY_MAIN =
                             action = CommitText("\u2030"),
                             color = MUTED,
                         ),
-                    topRight = KeyC("\u0326", displayText = "◌̦"),
+                    topRight =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("◌̦"),
+                            action = NormalizeLastKey("\u0326"),
+                        ),
                     left =
                         KeyC(
                             // DAGGER
@@ -76,7 +100,11 @@ val KB_EUROPE_THUMBKEY_MAIN =
                         KeyC(
                             CommitText("h"),
                         ),
-                    bottomLeft = KeyC("\u030f", displayText = "◌̏"),
+                    bottomLeft =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("◌̏"),
+                            action = NormalizeLastKey("\u030f"),
+                        ),
                     bottom =
                         KeyC(
                             // PLUS-MINUS SIGN
@@ -84,7 +112,11 @@ val KB_EUROPE_THUMBKEY_MAIN =
                             action = CommitText("\u00b1"),
                             color = MUTED,
                         ),
-                    bottomRight = KeyC("\u0307", displayText = "◌̇"),
+                    bottomRight =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("◌̇"),
+                            action = NormalizeLastKey("\u0307"),
+                        ),
                 ),
                 KeyItemC(
                     center = KeyC("r", size = LARGE),
@@ -123,8 +155,16 @@ val KB_EUROPE_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
-                    topLeft = KeyC("\u030a", displayText = "◌̊"),
-                    topRight = KeyC("\u0328", displayText = "◌̨"),
+                    topLeft =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("◌̊"),
+                            action = NormalizeLastKey("\u030a"),
+                        ),
+                    topRight =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("◌̨"),
+                            action = NormalizeLastKey("\u0328"),
+                        ),
                     left =
                         KeyC(
                             CommitText("u"),
@@ -141,9 +181,21 @@ val KB_EUROPE_THUMBKEY_MAIN =
                             ToggleShiftMode(false),
                             swipeReturnAction = ToggleCurrentWordCapitalization(false),
                         ),
-                    bottomLeft = KeyC("\u0312", displayText = "◌̒"),
-                    right = KeyC("\u0308", displayText = "◌̈"),
-                    bottomRight = KeyC("\u0327", displayText = "◌̧"),
+                    bottomLeft =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("◌̒"),
+                            action = NormalizeLastKey("\u0312"),
+                        ),
+                    right =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("◌̈"),
+                            action = NormalizeLastKey("\u0308"),
+                        ),
+                    bottomRight =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("◌̧"),
+                            action = NormalizeLastKey("\u0327"),
+                        ),
                 ),
                 NUMERIC_KEY_ITEM,
             ),
@@ -209,14 +261,30 @@ val KB_EUROPE_THUMBKEY_MAIN =
                         KeyC(
                             CommitText("d"),
                         ),
-                    topRight = KeyC("\u0300", displayText = "◌̀"),
+                    topRight =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("◌̀"),
+                            action = NormalizeLastKey("\u0300"),
+                        ),
                     left =
                         KeyC(
                             CommitText("ß"),
                         ),
-                    right = KeyC("\u0302", displayText = "◌̂"),
-                    bottomLeft = KeyC("\u030b", displayText = "◌̋"),
-                    bottomRight = KeyC("\u0301", displayText = "◌́"),
+                    right =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("◌̂"),
+                            action = NormalizeLastKey("\u0302"),
+                        ),
+                    bottomLeft =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("◌̋"),
+                            action = NormalizeLastKey("\u030b"),
+                        ),
+                    bottomRight =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("◌́"),
+                            action = NormalizeLastKey("\u0301"),
+                        ),
                 ),
                 BACKSPACE_KEY_ITEM,
             ),
@@ -238,7 +306,11 @@ val KB_EUROPE_THUMBKEY_SHIFTED =
                     topRight = KeyC("»", color = MUTED),
                     left = KeyC("¿", color = MUTED),
                     right = KeyC("?", color = MUTED),
-                    bottomLeft = KeyC("\u0304", displayText = "◌̄"),
+                    bottomLeft =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("◌̄"),
+                            action = NormalizeLastKey("\u0304"),
+                        ),
                     bottomRight =
                         KeyC(
                             CommitText("P"),
@@ -260,20 +332,36 @@ val KB_EUROPE_THUMBKEY_SHIFTED =
                 KeyItemC(
                     center = KeyC("I", size = LARGE),
                     swipeType = FOUR_WAY_DIAGONAL,
-                    topLeft = KeyC("\u0303", displayText = "◌̃"),
-                    topRight = KeyC("\u0306", displayText = "◌̆"),
+                    topLeft =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("◌̃"),
+                            action = NormalizeLastKey("\u0303"),
+                        ),
+                    topRight =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("◌̆"),
+                            action = NormalizeLastKey("\u0306"),
+                        ),
                     bottomLeft =
                         KeyC(
                             CommitText("M"),
                         ),
-                    bottomRight = KeyC("\u030c", displayText = "◌̌"),
+                    bottomRight =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("◌̌"),
+                            action = NormalizeLastKey("\u030c"),
+                        ),
                 ),
                 EMOJI_KEY_ITEM,
             ),
             listOf(
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
-                    topLeft = KeyC("\u0313", displayText = "◌̓"),
+                    topLeft =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("◌̓"),
+                            action = NormalizeLastKey("\u0313"),
+                        ),
                     top =
                         KeyC(
                             // PER MILLE SIGN
@@ -281,7 +369,11 @@ val KB_EUROPE_THUMBKEY_SHIFTED =
                             action = CommitText("\u2030"),
                             color = MUTED,
                         ),
-                    topRight = KeyC("\u0326", displayText = "◌̦"),
+                    topRight =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("◌̦"),
+                            action = NormalizeLastKey("\u0326"),
+                        ),
                     left =
                         KeyC(
                             // DOUBLE DAGGER
@@ -293,7 +385,11 @@ val KB_EUROPE_THUMBKEY_SHIFTED =
                         KeyC(
                             CommitText("H"),
                         ),
-                    bottomLeft = KeyC("\u030f", displayText = "◌̏"),
+                    bottomLeft =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("◌̏"),
+                            action = NormalizeLastKey("\u030f"),
+                        ),
                     bottom =
                         KeyC(
                             // PLUS-MINUS SIGN
@@ -301,7 +397,11 @@ val KB_EUROPE_THUMBKEY_SHIFTED =
                             action = CommitText("\u00b1"),
                             color = MUTED,
                         ),
-                    bottomRight = KeyC("\u0307", displayText = "◌̇"),
+                    bottomRight =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("◌̇"),
+                            action = NormalizeLastKey("\u0307"),
+                        ),
                 ),
                 KeyItemC(
                     center = KeyC("R", size = LARGE),
@@ -340,8 +440,16 @@ val KB_EUROPE_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
-                    topLeft = KeyC("\u030a", displayText = "◌̊"),
-                    topRight = KeyC("\u0328", displayText = "◌̨"),
+                    topLeft =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("◌̊"),
+                            action = NormalizeLastKey("\u030a"),
+                        ),
+                    topRight =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("◌̨"),
+                            action = NormalizeLastKey("\u0328"),
+                        ),
                     left =
                         KeyC(
                             CommitText("U"),
@@ -361,9 +469,21 @@ val KB_EUROPE_THUMBKEY_SHIFTED =
                             swipeReturnAction = ToggleCurrentWordCapitalization(false),
                             color = MUTED,
                         ),
-                    bottomLeft = KeyC("\u0312", displayText = "◌̒"),
-                    right = KeyC("\u0308", displayText = "◌̈"),
-                    bottomRight = KeyC("\u0327", displayText = "◌̧"),
+                    bottomLeft =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("◌̒"),
+                            action = NormalizeLastKey("\u0312"),
+                        ),
+                    right =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("◌̈"),
+                            action = NormalizeLastKey("\u0308"),
+                        ),
+                    bottomRight =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("◌̧"),
+                            action = NormalizeLastKey("\u0327"),
+                        ),
                 ),
                 NUMERIC_KEY_ITEM,
             ),
@@ -426,14 +546,30 @@ val KB_EUROPE_THUMBKEY_SHIFTED =
                         KeyC(
                             CommitText("D"),
                         ),
-                    topRight = KeyC("\u0300", displayText = "◌̀"),
+                    topRight =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("◌̀"),
+                            action = NormalizeLastKey("\u0300"),
+                        ),
                     left =
                         KeyC(
                             CommitText("ẞ"),
                         ),
-                    right = KeyC("\u0302", displayText = "◌̂"),
-                    bottomLeft = KeyC("\u030b", displayText = "◌̋"),
-                    bottomRight = KeyC("\u0301", displayText = "◌́"),
+                    right =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("◌̂"),
+                            action = NormalizeLastKey("\u0302"),
+                        ),
+                    bottomLeft =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("◌̋"),
+                            action = NormalizeLastKey("\u030b"),
+                        ),
+                    bottomRight =
+                        KeyC(
+                            display = KeyDisplay.TextDisplay("◌́"),
+                            action = NormalizeLastKey("\u0301"),
+                        ),
                 ),
                 BACKSPACE_KEY_ITEM,
             ),

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
@@ -225,6 +225,11 @@ sealed class KeyAction {
         val text: String,
     ) : KeyAction()
 
+    class NormalizeLastKey(
+        val text: String,
+        val form: java.text.Normalizer.Form? = java.text.Normalizer.Form.NFC,
+    ) : KeyAction()
+
     class SmartQuotes(
         val start: String,
         val end: String,

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -1208,6 +1208,20 @@ fun performKeyAction(
             }
         }
 
+        is KeyAction.NormalizeLastKey -> {
+            Log.d(TAG, "combining last key")
+            val mark = action.text
+            val form = action.form
+            val textBefore = ime.currentInputConnection.getTextBeforeCursor(1, 0)
+
+            val textNew = java.text.Normalizer.normalize("$textBefore$mark", form)
+
+            if (textNew != textBefore) {
+                ime.currentInputConnection.deleteSurroundingText(1, 0)
+                ime.currentInputConnection.commitText(textNew, 1)
+            }
+        }
+
         is KeyAction.ToggleShiftMode -> {
             val enable = action.enable
             Log.d(TAG, "Toggling Shifted: $enable")


### PR DESCRIPTION
This solves the problem of some apps and input fields not accepting decomposed characters, while keeping the ability to create "cursed" characters by stacking combining marks intact. Since both use cases of this layout ie,

 - entering text in any European language without switching layouts
 - abusing combining characters for fun and profit

are preserved, I did not add a separate setting to enable or disable normalization. However, if someone wanted to implement a toggle to enable/disable normalization they would only need to change the KeyAction.NormalizeLastKey code block in utils/Utils.kt

Implementing a decomposing behaviour would be similarly easy: just add a button that would have

    KeyC(
        display = ...,
        action = NormaliseLastKey("", java.text.Normalizer.Form.NFD),
    )

as its bound action. I did not think that such a thing is necessary at the moment.