### PR TITLE
Add Turkish ı and İ to the European layout (#1884)

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/EuropeThumbKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/EuropeThumbKey.kt
@@ -46,7 +46,6 @@ val KB_EUROPE_THUMBKEY_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("i", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft =
                         KeyC(
                             display = KeyDisplay.TextDisplay("◌̃"),
@@ -65,6 +64,10 @@ val KB_EUROPE_THUMBKEY_MAIN =
                         KeyC(
                             display = KeyDisplay.TextDisplay("◌̌"),
                             action = NormalizeLastKey("\u030c"),
+                        ),
+                    top =
+                        KeyC(
+                            CommitText("ı"),
                         ),
                 ),
                 EMOJI_KEY_ITEM,
@@ -331,7 +334,6 @@ val KB_EUROPE_THUMBKEY_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("I", size = LARGE),
-                    swipeType = FOUR_WAY_DIAGONAL,
                     topLeft =
                         KeyC(
                             display = KeyDisplay.TextDisplay("◌̃"),
@@ -350,6 +352,10 @@ val KB_EUROPE_THUMBKEY_SHIFTED =
                         KeyC(
                             display = KeyDisplay.TextDisplay("◌̌"),
                             action = NormalizeLastKey("\u030c"),
+                        ),
+                    top =
+                        KeyC(
+                            CommitText("İ"),
                         ),
                 ),
                 EMOJI_KEY_ITEM,


### PR DESCRIPTION
Resolves #1884

I don’t see why it shouldn’t work (I have exactly these actions added through ‘Modify keys’), but want to add a disclaimer that I haven’t actually compiled and tried it.