### PR TITLE
Fix database import/export

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/backupandrestore/BackupAndRestoreScreen.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/backupandrestore/BackupAndRestoreScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -85,8 +86,12 @@ import com.dessalines.thumbkey.utils.SimpleTopAppBar
 import com.dessalines.thumbkey.utils.keyboardLayoutsSetFromDbIndexString
 import com.dessalines.thumbkey.utils.updateLayouts
 import com.roomdbexportimport.RoomDBExportImport
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import me.zhanghai.compose.preference.Preference
 import me.zhanghai.compose.preference.ProvidePreferenceTheme
+import java.time.LocalDate
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -97,23 +102,35 @@ fun BackupAndRestoreScreen(
     Log.d("thumb key", "Got to Backup and Restore screen")
 
     val ctx = LocalContext.current
+    val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
 
     var showConfirmResetDialog by remember { mutableStateOf(false) }
 
-    val dbSavedText = stringResource(R.string.database_backed_up)
-    val dbRestoredText = stringResource(R.string.database_restored)
-
     val dbHelper = RoomDBExportImport(AppDB.getDatabase(ctx).openHelper)
+
+    val backedUpMsg = stringResource(R.string.database_backed_up)
+    val operationFailedTemplate = stringResource(R.string.database_operation_failed)
 
     val exportDbLauncher =
         rememberLauncherForActivityResult(
             ActivityResultContracts.CreateDocument("application/zip"),
         ) {
-            it?.also {
+            it?.also { uri ->
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    dbHelper.export(ctx, it)
-                    Toast.makeText(ctx, dbSavedText, Toast.LENGTH_SHORT).show()
+                    scope.launch {
+                        withContext(Dispatchers.IO) { dbHelper.export(ctx, uri) }
+                            .onSuccess {
+                                Toast.makeText(ctx, backedUpMsg, Toast.LENGTH_SHORT).show()
+                            }.onFailure {
+                                Toast
+                                    .makeText(
+                                        ctx,
+                                        operationFailedTemplate.format(it.message ?: it.stackTraceToString()),
+                                        Toast.LENGTH_LONG,
+                                    ).show()
+                            }
+                    }
                 }
             }
         }
@@ -122,10 +139,19 @@ fun BackupAndRestoreScreen(
         rememberLauncherForActivityResult(
             ActivityResultContracts.OpenDocument(),
         ) {
-            it?.also {
+            it?.also { uri ->
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    dbHelper.import(ctx, it, true)
-                    Toast.makeText(ctx, dbRestoredText, Toast.LENGTH_SHORT).show()
+                    scope.launch {
+                        withContext(Dispatchers.IO) { dbHelper.import(ctx, uri, true) }
+                            .onFailure {
+                                Toast
+                                    .makeText(
+                                        ctx,
+                                        operationFailedTemplate.format(it.message ?: it.stackTraceToString()),
+                                        Toast.LENGTH_LONG,
+                                    ).show()
+                            }
+                    }
                 }
             }
         }
@@ -187,7 +213,13 @@ fun BackupAndRestoreScreen(
                             )
                         },
                         onClick = {
-                            exportDbLauncher.launch("thumb-key")
+                            val filename =
+                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                                    "${LocalDate.now()}-thumb-key.zip"
+                                } else {
+                                    "thumb-key.zip"
+                                }
+                            exportDbLauncher.launch(filename)
                         },
                     )
                     Preference(

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -28,7 +28,6 @@
     <string name="key_border_width">عرض حدود المفتاح: %1$s</string>
     <string name="circular_drag_enable">سحب دائري</string>
     <string name="ghost_keys_enable">مفاتيح الأشباح</string>
-    <string name="database_restored">تم استعادة قاعدة البيانات.</string>
     <string name="database_backed_up">تم نسخ قاعدة البيانات احتياطيًا.</string>
     <string name="backup_and_restore">النسخ الاحتياطي والاستعادة</string>
     <string name="settings">الإعدادات</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -72,7 +72,6 @@
     <string name="backup_database">Архивиране на базата данни</string>
     <string name="restore_database">Възстановяване на базата данни</string>
     <string name="restore_database_warning">Предупреждение: Това ще изчисти текущата ви база данни</string>
-    <string name="database_restored">Базата данни е възстановена.</string>
     <string name="backup_and_restore">Резервно копие</string>
     <string name="cancel">Отказ</string>
     <string name="slide_cursor_acceleration_threshold_acceleration">Прагово ускорение</string>

--- a/app/src/main/res/values-br/strings.xml
+++ b/app/src/main/res/values-br/strings.xml
@@ -90,7 +90,6 @@
     <string name="backup_database">Gwarediñ ar stlennvon</string>
     <string name="restore_database">Assav ar stlennvon</string>
     <string name="restore_database_warning">Diwallit: adderaouekaet e vo ho stlennvon</string>
-    <string name="database_restored">Stlennvon assavet.</string>
     <string name="database_backed_up">Stlennvon gwaredet.</string>
     <string name="backup_and_restore">Assav ha gwarediñ</string>
     <string name="dual">Doubl</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -92,7 +92,6 @@
     <string name="backup_database">Sikkerhedskopier database</string>
     <string name="restore_database">Gendan database</string>
     <string name="restore_database_warning">Advarsel: Dette vil slette din nuværende database</string>
-    <string name="database_restored">Gendannede database.</string>
     <string name="database_backed_up">Sikkerhedskopierede database.</string>
     <string name="backup_and_restore">Sikkerhedskopiering og gendannelse</string>
     <string name="modify_keys">Tilpas taster</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -74,7 +74,6 @@
     <string name="send_numeric">Zifferntaste</string>
     <string name="circular_drag_enable">Kreisförmig ziehen</string>
     <string name="restore_database">Datenbank wiederherstellen</string>
-    <string name="database_restored">Datenbank wiederhergestellt.</string>
     <string name="database_backed_up">Datenbank gesichert.</string>
     <string name="backup_and_restore">Sicherung und Wiederherstellung</string>
     <string name="slide_cursor_acceleration_quadratic">Quadratische Beschleunigung</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -89,7 +89,6 @@
     <string name="backup_database">Guardar configuracion</string>
     <string name="restore_database">Cargar configuaracion</string>
     <string name="restore_database_warning">Precaucion: esto borrara tu configuracion actual</string>
-    <string name="database_restored">Configuracion restaurada.</string>
     <string name="database_backed_up">Configuracion guardada.</string>
     <string name="backup_and_restore">Guardar y restablecer</string>
     <string name="modify_keys">Modificar las teclas</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -90,7 +90,6 @@
     <string name="restore_database_warning">هشدار: با این کار پایگاه داده کنونی شما به طور کامل پاک می‌شود</string>
     <string name="twilight">شفق</string>
     <string name="slide_cursor_movement_mode">حالت حرکت مکان نما</string>
-    <string name="database_restored">پایگاه‌داده بازگردانی شد.</string>
     <string name="send_oppsite_case">حرف با حالت وارونه (بزرگ یا کوچک)</string>
     <string name="slide_spacebar_deadzone_enable">کلید فاصله: امکان استفاده از کشیدن انگشت معمولی برای حرکات کشیدنی</string>
     <string name="modify_keys">سفارشی‌سازی کلیدها</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -91,7 +91,6 @@
     <string name="backup_database">Sauvegarder la base de données</string>
     <string name="restore_database">Restaurer la base de données</string>
     <string name="restore_database_warning">Attention : votre base de données sera réinitialisée</string>
-    <string name="database_restored">La base de données a été restaurée.</string>
     <string name="database_backed_up">La base de données a été sauvegardée.</string>
     <string name="backup_and_restore">Sauvegarde et restauration</string>
     <string name="modify_keys">Modifications des touches</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -84,7 +84,6 @@
     <string name="ghost_keys_description">Accedi ai simboli nascosti senza dover passare alla tastiera numerica</string>
     <string name="restore_database">Ripristino database</string>
     <string name="restore_database_warning">Attenzione: il database corrente verrà eliminato</string>
-    <string name="database_restored">Database ripristinato.</string>
     <string name="database_backed_up">Database salvato.</string>
     <string name="backup_and_restore">Backup e ripristino</string>
     <string name="modify_keys">Modifica tasti</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -63,7 +63,6 @@
     <string name="finish_setup">設定完了</string>
     <string name="key_padding">キーの余白: %1$s</string>
     <string name="ghost_keys_description">数字ビューに切り替えずに隠れた記号キーにアクセス</string>
-    <string name="database_restored">データベースが復元されました。</string>
     <string name="follow_me_mastodon">Mastodonでフォローする</string>
     <string name="open_source">オープンソース</string>
     <string name="look_and_feel">外観と操作感</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -54,7 +54,6 @@
     <string name="hide_symbols">Ukryj symbole</string>
     <string name="restore_database">Przywróć kopię zapasową</string>
     <string name="restore_database_warning">Uwaga: To wyczyści twoją obecną bazę danych</string>
-    <string name="database_restored">Baza danych przywrócona.</string>
     <string name="database_backed_up">Kopia zapasowa bazy danych została wykonana.</string>
     <string name="green">Zielony</string>
     <string name="test_out_thumbkey">Przetestuj Thumb-Key</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -94,7 +94,6 @@
     <string name="how_to_modify_keys">Как модифицировать клавиши</string>
     <string name="backup_database">Создать резервную копию</string>
     <string name="restore_database">Восстановить из резервной копии</string>
-    <string name="database_restored">Восстановление завершено.</string>
     <string name="database_backed_up">Резервная копия создана.</string>
     <string name="backup_and_restore">Резервное копирование и восстановление</string>
     <string name="restore_database_warning">Предупреждение: Все данные в текущей базе данных будут стёрты</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -67,7 +67,6 @@
     <string name="ghost_keys_description">Prístup k skrytým symbolom bez zmeny na numerický mód</string>
     <string name="restore_database">Obnoviť databázu</string>
     <string name="restore_database_warning">Upozornenie: Toto vymaže vašu aktuálnu databázu</string>
-    <string name="database_restored">Databáza obnovená.</string>
     <string name="database_backed_up">Databáza zálohovaná.</string>
     <string name="left">Vľavo</string>
     <string name="social">Sociálne siete</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -92,7 +92,6 @@
     <string name="backup_database">Shrani varnostno kopijo</string>
     <string name="restore_database">Obnovi iz varnostne kopije</string>
     <string name="restore_database_warning">Pozor: Obnovitev bo prepisala trenutne nastavitve</string>
-    <string name="database_restored">Obnovitev je končana.</string>
     <string name="database_backed_up">Varnostna kopija je shranjena.</string>
     <string name="backup_and_restore">Varnostna kopija in obnovitev</string>
     <string name="modify_keys">Uredi tipke</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -51,7 +51,6 @@
     <string name="backup_database">Verileri yedekle</string>
     <string name="restore_database">Yedeği geri döndür</string>
     <string name="restore_database_warning">Uyarı: Bu işlem mevcut verileri siler</string>
-    <string name="database_restored">Veriler Geri Döndürüldü.</string>
     <string name="database_backed_up">Veriler Yedeklendi.</string>
     <string name="backup_and_restore">Yedekleme</string>
     <string name="dark">Karanlık</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -99,8 +99,8 @@
     <string name="backup_database">Backup database</string>
     <string name="restore_database">Restore database</string>
     <string name="restore_database_warning">Warning: This will clear out your current database</string>
-    <string name="database_restored">Database Restored.</string>
     <string name="database_backed_up">Database Backed up.</string>
+    <string name="database_operation_failed">Operation failed: %1$s</string>
     <string name="backup_and_restore">Backup and restore</string>
     <string name="modify_keys">Modify keys</string>
     <string name="key_modification_placeholder">Enter YAML</string>


### PR DESCRIPTION
We were doing IO on the main thread, which is permitted for local IO but panics when the file is in a network partition. Instead, run `dbHelper.{import,export}` with `Dispatchers.IO`.

Also stop ignoring import/export errors, previously you'd get the `Database imported` toast even if the import/export failed. This adds a `database_operation_failed` string to notify the user in that case.

Another issue was the default filename, which had no file extension. So, if you had backed up with the default filename (`thumb-key`), you could not select it in the import stage as the Android filepicker determines MIME types by the file extension (which we specify using `importDbLauncher.launch(arrayOf("application/zip"))`).

I've added a .zip suffix and a YYYY-MM-DD- prefix (when the API version is high enough) to fix that.
