### PR TITLE
Add customizable long press duration and fix regressions

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/db/AppDb.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/db/AppDb.kt
@@ -63,6 +63,7 @@ const val DEFAULT_CLOCKWISE_DRAG_ACTION = 0
 const val DEFAULT_COUNTERCLOCKWISE_DRAG_ACTION = 1
 const val DEFAULT_GHOST_KEYS_ENABLED = 0
 const val DEFAULT_SLIDE_HOLD_ENABLED = 0
+const val DEFAULT_LONG_PRESS_DURATION = 400
 const val DEFAULT_KEY_MODIFICATIONS = ""
 const val DEFAULT_IGNORE_BOTTOM_PADDING = 0
 const val DEFAULT_SHOW_TOAST_ON_LAYOUT_SWITCH = 1
@@ -258,6 +259,11 @@ data class AppSettings(
         defaultValue = DEFAULT_SLIDE_HOLD_ENABLED.toString(),
     )
     val slideHoldEnabled: Int,
+    @ColumnInfo(
+        name = "long_press_duration",
+        defaultValue = DEFAULT_LONG_PRESS_DURATION.toString(),
+    )
+    val longPressDuration: Int,
     @ColumnInfo(
         name = "key_modifications",
         defaultValue = "",
@@ -483,6 +489,8 @@ data class BehaviorUpdate(
     val ghostKeysEnabled: Int,
     @ColumnInfo(name = "slide_hold_enabled")
     val slideHoldEnabled: Int,
+    @ColumnInfo(name = "long_press_duration")
+    val longPressDuration: Int,
 )
 
 data class KeyModificationsUpdate(
@@ -620,7 +628,7 @@ class AppSettingsRepository(
 }
 
 @Database(
-    version = 27,
+    version = 28,
     entities = [AppSettings::class],
     exportSchema = true,
 )
@@ -669,6 +677,7 @@ abstract class AppDB : RoomDatabase() {
                             MIGRATION_24_25,
                             MIGRATION_25_26,
                             MIGRATION_26_27,
+                            MIGRATION_27_28,
                         )
                         // Necessary because it can't insert data on creation
                         .addCallback(

--- a/app/src/main/java/com/dessalines/thumbkey/db/Migrations.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/db/Migrations.kt
@@ -12,6 +12,15 @@ val MIGRATION_1_2 =
         }
     }
 
+val MIGRATION_27_28 =
+    object : Migration(27, 28) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL(
+                "ALTER TABLE AppSettings ADD COLUMN long_press_duration INTEGER NOT NULL DEFAULT $DEFAULT_LONG_PRESS_DURATION",
+            )
+        }
+    }
+
 val MIGRATION_2_3 =
     object : Migration(2, 3) {
         override fun migrate(db: SupportSQLiteDatabase) {

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardKey.kt
@@ -13,9 +13,12 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.waitForUpOrCancellation
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -150,6 +153,7 @@ fun KeyboardKey(
     clockwiseDragAction: CircularDragAction,
     counterclockwiseDragAction: CircularDragAction,
     slideHoldEnabled: Boolean,
+    longPressDuration: Int,
 ) {
     // Necessary for swipe settings to get updated correctly
     val id =
@@ -158,7 +162,7 @@ fun KeyboardKey(
             slideSensitivity + slideEnabled + slideCursorMovementMode + slideSpacebarDeadzoneEnabled +
             slideBackspaceDeadzoneEnabled + dragReturnEnabled + circularDragEnabled +
             clockwiseDragAction.ordinal + counterclockwiseDragAction.ordinal +
-            slideHoldEnabled
+            slideHoldEnabled + longPressDuration
 
     val ctx = LocalContext.current
     val ime = ctx as IMEService
@@ -171,6 +175,7 @@ fun KeyboardKey(
     val isPressed by interactionSource.collectIsPressedAsState()
 
     val isDragged = remember { mutableStateOf(false) }
+    var longPressTriggered by remember { mutableStateOf(false) }
     val releasedKey = remember { mutableStateOf<String?>(null) }
 
     var tapCount by remember { mutableIntStateOf(0) }
@@ -392,47 +397,66 @@ fun KeyboardKey(
                     (Modifier)
                 },
             ).background(color = backgroundColor)
-            // Note: pointerInput has a delay when switching keyboards, so you must use this
-            .combinedClickable(
-                interactionSource = interactionSource,
-                indication = null,
-                hapticFeedbackEnabled = false, // We manually trigger haptics instead
-                onClick = {
-                    // Set the last key info, and the tap count
-                    val cAction = key.center.action
-                    lastAction.value?.let { (lastAction, time) ->
-                        if (time.elapsedNow() < 1.seconds && lastAction == cAction && !ime.didCursorMove()) {
-                            tapCount += 1
-                        } else {
-                            tapCount = 0
-                        }
-                    }
-                    lastAction.value = Pair(cAction, TimeSource.Monotonic.markNow())
+            // The key1 is necessary, otherwise new swipes wont work
+            .pointerInput(key1 = id) {
+                awaitEachGesture {
+                    val down = awaitFirstDown()
+                    longPressTriggered = false
+                    val press = PressInteraction.Press(down.position)
+                    scope.launch { interactionSource.emit(press) }
 
-                    // Set the correct action
-                    val action = tapActions[tapCount % tapActions.size]
-                    performKeyAction(
-                        action = action,
-                        ime = ime,
-                        autoCapitalize = autoCapitalize,
-                        keyboardSettings = keyboardSettings,
-                        onToggleShiftMode = onToggleShiftMode,
-                        onToggleCtrlMode = onToggleCtrlMode,
-                        onToggleAltMode = onToggleAltMode,
-                        onToggleNumericMode = onToggleNumericMode,
-                        onToggleEmojiMode = onToggleEmojiMode,
-                        onToggleClipboardMode = onToggleClipboardMode,
-                        onToggleCapsLock = onToggleCapsLock,
-                        onToggleHideLetters = onToggleHideLetters,
-                        onAutoCapitalize = onAutoCapitalize,
-                        onSwitchLanguage = onSwitchLanguage,
-                        onChangePosition = onChangePosition,
-                        onKeyEvent = onKeyEvent,
-                    )
-                    doneKeyAction(scope, action, isDragged, releasedKey, animationHelperSpeed)
-                },
-                onLongClick = {
-                    key.longPress?.let { action ->
+                    val longPressJob =
+                        scope.launch {
+                            delay(longPressDuration.toLong())
+                            if (!isDragged.value) {
+                                key.longPress?.let { action ->
+                                    longPressTriggered = true
+                                    performKeyAction(
+                                        action = action,
+                                        ime = ime,
+                                        autoCapitalize = autoCapitalize,
+                                        keyboardSettings = keyboardSettings,
+                                        onToggleShiftMode = onToggleShiftMode,
+                                        onToggleCtrlMode = onToggleCtrlMode,
+                                        onToggleAltMode = onToggleAltMode,
+                                        onToggleNumericMode = onToggleNumericMode,
+                                        onToggleEmojiMode = onToggleEmojiMode,
+                                        onToggleClipboardMode = onToggleClipboardMode,
+                                        onToggleCapsLock = onToggleCapsLock,
+                                        onToggleHideLetters = onToggleHideLetters,
+                                        onAutoCapitalize = onAutoCapitalize,
+                                        onSwitchLanguage = onSwitchLanguage,
+                                        onChangePosition = onChangePosition,
+                                        onKeyEvent = onKeyEvent,
+                                    )
+                                    doneKeyAction(scope, action, isDragged, releasedKey, animationHelperSpeed)
+                                    if (vibrateOnTap) {
+                                        view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+                                    }
+                                    if (soundOnTap) {
+                                        audioManager.playSoundEffect(AudioManager.FX_KEY_CLICK, .1f)
+                                    }
+                                }
+                            }
+                        }
+
+                    var upOrCancel = waitForUpOrCancellation()
+                    longPressJob.cancel()
+
+                    if (upOrCancel != null && !longPressTriggered && !isDragged.value) {
+                        // Set the last key info, and the tap count
+                        val cAction = key.center.action
+                        lastAction.value?.let { (lastAction, time) ->
+                            if (time.elapsedNow() < 1.seconds && lastAction == cAction && !ime.didCursorMove()) {
+                                tapCount += 1
+                            } else {
+                                tapCount = 0
+                            }
+                        }
+                        lastAction.value = Pair(cAction, TimeSource.Monotonic.markNow())
+
+                        // Set the correct action
+                        val action = tapActions[tapCount % tapActions.size]
                         performKeyAction(
                             action = action,
                             ime = ime,
@@ -452,22 +476,25 @@ fun KeyboardKey(
                             onKeyEvent = onKeyEvent,
                         )
                         doneKeyAction(scope, action, isDragged, releasedKey, animationHelperSpeed)
-                        if (vibrateOnTap) {
-                            view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
-                        }
-                        if (soundOnTap) {
-                            audioManager.playSoundEffect(AudioManager.FX_KEY_CLICK, .1f)
-                        }
                     }
-                },
-            )
-            // The key1 is necessary, otherwise new swipes wont work
+
+                    scope.launch {
+                        interactionSource.emit(
+                            if (upOrCancel != null) PressInteraction.Release(press) else PressInteraction.Cancel(press),
+                        )
+                    }
+                }
+            }
             .pointerInput(key1 = id) {
                 detectDragGestures(
                     onDragStart = {
-                        isDragged.value = true
+                        if (!longPressTriggered) {
+                            isDragged.value = true
+                        }
                     },
                     onDrag = { change, dragAmount ->
+                        if (longPressTriggered) return@detectDragGestures
+
                         change.consume()
                         val (x, y) = dragAmount
                         offsetX += x
@@ -475,6 +502,8 @@ fun KeyboardKey(
                         val offset = Offset(offsetX, offsetY)
                         positions += offset
                         if (offset.getDistanceSquared() > maxOffset.getDistanceSquared()) maxOffset = offset
+
+                        if (longPressTriggered) return@detectDragGestures
 
                         // First detection is large enough to preserve swipe actions.
                         val slideOffsetTrigger = (keySize.dp.toPx() * 0.75) + minSwipeLength
@@ -636,6 +665,18 @@ fun KeyboardKey(
                         }
                     },
                     onDragEnd = {
+                        if (longPressTriggered) {
+                            // Reset the drags
+                            offsetX = 0f
+                            offsetY = 0f
+                            maxOffset = Offset(0f, 0f)
+                            positions = listOf()
+
+                            // Reset selection
+                            selection = Selection()
+                            return@detectDragGestures
+                        }
+
                         lateinit var action: KeyAction
 
                         val slideHoldTicks = resetSlideHoldVariables()

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/keyboard/KeyboardScreen.kt
@@ -58,6 +58,7 @@ import com.dessalines.thumbkey.db.DEFAULT_KEY_HEIGHT
 import com.dessalines.thumbkey.db.DEFAULT_KEY_PADDING
 import com.dessalines.thumbkey.db.DEFAULT_KEY_RADIUS
 import com.dessalines.thumbkey.db.DEFAULT_KEY_WIDTH
+import com.dessalines.thumbkey.db.DEFAULT_LONG_PRESS_DURATION
 import com.dessalines.thumbkey.db.DEFAULT_MIN_SWIPE_LENGTH
 import com.dessalines.thumbkey.db.DEFAULT_NON_SQUARE_KEYS
 import com.dessalines.thumbkey.db.DEFAULT_POSITION
@@ -233,6 +234,7 @@ fun KeyboardScreen(
         CircularDragAction.entries[settings?.counterclockwiseDragAction ?: DEFAULT_COUNTERCLOCKWISE_DRAG_ACTION]
     val ghostKeysEnabled = (settings?.ghostKeysEnabled ?: DEFAULT_GHOST_KEYS_ENABLED).toBool()
     val slideHoldEnabled = (settings?.slideHoldEnabled ?: DEFAULT_SLIDE_HOLD_ENABLED).toBool()
+    val longPressDuration = (settings?.longPressDuration ?: DEFAULT_LONG_PRESS_DURATION)
 
     val keyBorderWidthFloat = keyBorderWidth / 10.0f
     val keyBorderColour = MaterialTheme.colorScheme.outline
@@ -445,6 +447,7 @@ fun KeyboardScreen(
                                     clockwiseDragAction = clockwiseDragAction,
                                     counterclockwiseDragAction = counterclockwiseDragAction,
                                     slideHoldEnabled = slideHoldEnabled,
+                                    longPressDuration = longPressDuration,
                                 )
                             }
                         }
@@ -630,6 +633,7 @@ fun KeyboardScreen(
                                     clockwiseDragAction = clockwiseDragAction,
                                     counterclockwiseDragAction = counterclockwiseDragAction,
                                     slideHoldEnabled = slideHoldEnabled,
+                                    longPressDuration = longPressDuration,
                                 )
                             }
                         }
@@ -936,6 +940,7 @@ fun KeyboardScreen(
                                         clockwiseDragAction = clockwiseDragAction,
                                         counterclockwiseDragAction = counterclockwiseDragAction,
                                         slideHoldEnabled = slideHoldEnabled,
+                                        longPressDuration = longPressDuration,
                                     )
                                 }
                             }

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/backupandrestore/BackupAndRestoreScreen.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/backupandrestore/BackupAndRestoreScreen.kt
@@ -62,6 +62,7 @@ import com.dessalines.thumbkey.db.DEFAULT_KEY_MODIFICATIONS
 import com.dessalines.thumbkey.db.DEFAULT_KEY_PADDING
 import com.dessalines.thumbkey.db.DEFAULT_KEY_RADIUS
 import com.dessalines.thumbkey.db.DEFAULT_KEY_WIDTH
+import com.dessalines.thumbkey.db.DEFAULT_LONG_PRESS_DURATION
 import com.dessalines.thumbkey.db.DEFAULT_MIN_SWIPE_LENGTH
 import com.dessalines.thumbkey.db.DEFAULT_NON_SQUARE_KEYS
 import com.dessalines.thumbkey.db.DEFAULT_POSITION
@@ -314,6 +315,7 @@ private fun resetAppSettingsToDefault(appSettingsViewModel: AppSettingsViewModel
             usePrivateClipboard = DEFAULT_USE_PRIVATE_CLIPBOARD,
             showOnScreenKeyboard = DEFAULT_SHOW_ON_SCREEN_KEYBOARD,
             slideHoldEnabled = DEFAULT_SLIDE_HOLD_ENABLED,
+            longPressDuration = DEFAULT_LONG_PRESS_DURATION,
         ),
     )
 }

--- a/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/behavior/BehaviorScreen.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/ui/components/settings/behavior/BehaviorScreen.kt
@@ -46,6 +46,7 @@ import com.dessalines.thumbkey.db.DEFAULT_CLOCKWISE_DRAG_ACTION
 import com.dessalines.thumbkey.db.DEFAULT_COUNTERCLOCKWISE_DRAG_ACTION
 import com.dessalines.thumbkey.db.DEFAULT_DRAG_RETURN_ENABLED
 import com.dessalines.thumbkey.db.DEFAULT_GHOST_KEYS_ENABLED
+import com.dessalines.thumbkey.db.DEFAULT_LONG_PRESS_DURATION
 import com.dessalines.thumbkey.db.DEFAULT_MIN_SWIPE_LENGTH
 import com.dessalines.thumbkey.db.DEFAULT_SLIDE_BACKSPACE_DEADZONE_ENABLED
 import com.dessalines.thumbkey.db.DEFAULT_SLIDE_CURSOR_MOVEMENT_MODE
@@ -101,6 +102,9 @@ fun BehaviorScreen(
     var ghostKeysEnabledState = (settings?.ghostKeysEnabled ?: DEFAULT_GHOST_KEYS_ENABLED).toBool()
     var slideHoldEnabledState = (settings?.slideHoldEnabled ?: DEFAULT_SLIDE_HOLD_ENABLED).toBool()
 
+    var longPressDurationState = (settings?.longPressDuration ?: DEFAULT_LONG_PRESS_DURATION).toFloat()
+    var longPressDurationSliderState by remember { mutableFloatStateOf(longPressDurationState) }
+
     val snackbarHostState = remember { SnackbarHostState() }
 
     val scrollState = rememberScrollState()
@@ -125,6 +129,7 @@ fun BehaviorScreen(
                 counterclockwiseDragAction = counterclockwiseDragActionState.ordinal,
                 ghostKeysEnabled = ghostKeysEnabledState.toInt(),
                 slideHoldEnabled = slideHoldEnabledState.toInt(),
+                longPressDuration = longPressDurationState.toInt(),
             ),
         )
     }
@@ -159,6 +164,30 @@ fun BehaviorScreen(
                         icon = {
                             Icon(
                                 imageVector = Icons.Outlined.Abc,
+                                contentDescription = null,
+                            )
+                        },
+                    )
+                    SliderPreference(
+                        value = longPressDurationState,
+                        sliderValue = longPressDurationSliderState,
+                        onValueChange = {
+                            longPressDurationState = it
+                            updateBehavior()
+                        },
+                        onSliderValueChange = { longPressDurationSliderState = it },
+                        valueRange = 100f..1000f,
+                        title = {
+                            val longPressDurationStr =
+                                stringResource(
+                                    R.string.long_press_duration,
+                                    longPressDurationSliderState.toInt().toString(),
+                                )
+                            Text(longPressDurationStr)
+                        },
+                        icon = {
+                            Icon(
+                                imageVector = Icons.Outlined.Swipe,
                                 contentDescription = null,
                             )
                         },

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -104,7 +104,7 @@
     <string name="ignore_bottom_padding">Игнориране на долния отстъп</string>
     <string name="show_toast_on_layout_switch">Показване на съобщение при смяна на подредбата</string>
     <string name="disable_fullscreen_editor">Изключване на текстовия редактор на цял екран</string>
-    <string name="warning_invalid_mode">Режимът „%s“ не е дефиниран за подредбата „%s“.</string>
+    <string name="warning_invalid_mode">Режимът „%1$s“ не е дефиниран за подредбата „%2$s“.</string>
     <string name="clipboard_history">История на клипборда</string>
     <string name="clipboard_history_enabled">Включване на историята на клипборда</string>
     <string name="clipboard_history_enabled_description">Запазване на копирания текст с цел бърз достъп</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -132,7 +132,7 @@
     <string name="ignore_bottom_padding">Ignorar el relleno inferior</string>
     <string name="show_toast_on_layout_switch">Mostrar mensaje emergente al cambiar el diseño</string>
     <string name="disable_fullscreen_editor">Deshabilitar el editor de texto a pantalla completa</string>
-    <string name="warning_invalid_mode">El modo \"%s\" no está definido para el diseño \"%s\".</string>
+    <string name="warning_invalid_mode">El modo \"%1$s\" no está definido para el diseño \"%2$s\".</string>
     <string name="database_operation_failed">Error en la operación: %1$s</string>
     <string name="clipboard_history_enabled_description">Almacene el texto copiado para un acceso rápido</string>
     <string name="clipboard_auto_cleanup">Limpieza automática de entradas antiguas</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -99,7 +99,7 @@
     <string name="how_to_modify_keys">Comment modifier les touches</string>
     <string name="ignore_bottom_padding">Ignorer l\'espacement inférieur</string>
     <string name="key_modification_placeholder">Insérer du YAML</string>
-    <string name="warning_invalid_mode">Le mode \"%s\" n\'est pas défini pour la disposition \"%s\".</string>
+    <string name="warning_invalid_mode">Le mode \"%1$s\" n\'est pas défini pour la disposition \"%2$s\".</string>
     <string name="clipboard_history">Historique du presse-papier</string>
     <string name="clipboard_history_enabled">Activer l\'historique du presse-papier</string>
     <string name="clipboard_history_enabled_description">Enregistrer le texte copié pour un accès rapide</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -133,7 +133,7 @@
     <string name="clipboard_disabled">История буфера обмена отключена</string>
     <string name="clipboard_go_to_settings">Перейти в настройки буфера обмена</string>
     <string name="clipboard_characters">Символов: %1$d</string>
-    <string name="warning_invalid_mode">Режим \"%s\" не определён для макета \"%s\".</string>
+    <string name="warning_invalid_mode">Режим \"%1$s\" не определён для макета \"%2$s\".</string>
     <string name="position_padding">Смещение позиции: %1$s</string>
     <string name="use_private_clipboard">Использовать защищённый буфер обмена</string>
     <string name="use_private_clipboard_description">Копирование происходит во внутренний буфер обмена вместо системного</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -134,7 +134,7 @@
     <string name="clipboard_disabled">Zgodovina odložišča ni omogočena</string>
     <string name="clipboard_go_to_settings">Na nastavitve odložišča</string>
     <string name="position_padding">Odmik od roba: %1$s</string>
-    <string name="warning_invalid_mode">Način \"%s\" v razporeditvi \"%s\" ni določen.</string>
+    <string name="warning_invalid_mode">Način \"%1$s\" v razporeditvi \"%2$s\" ni določen.</string>
     <string name="use_private_clipboard">Zasebno odložišče</string>
     <string name="use_private_clipboard_description">Kopiraj v interno odložišče namesto v sistemskega</string>
     <string name="other">Drugo</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,6 +57,7 @@
     <string name="min_swipe_length">Minimum swipe length: %1$s</string>
     <string name="animation_speed">Animation speed: %1$s</string>
     <string name="animation_helper_speed">Animation helper speed: %1$s</string>
+    <string name="long_press_duration">Long press duration: %1$sms</string>
     <string name="slide_enable">Slide gestures</string>
     <string name="slide_cursor_movement_mode">Cursor movement mode</string>
     <string name="slide_sensitivity">Slide sensitivity: %1$s</string>
@@ -108,7 +109,7 @@
     <string name="ignore_bottom_padding">Ignore bottom padding</string>
     <string name="show_toast_on_layout_switch">Show toast on layout switch</string>
     <string name="disable_fullscreen_editor">Disable fullscreen text editor</string>
-    <string name="warning_invalid_mode">Mode \"%s\" is not defined for layout \"%s\".</string>
+    <string name="warning_invalid_mode">Mode \"%1$s\" is not defined for layout \"%2$s\".</string>
     <!-- Clipboard History -->
     <string name="clipboard_history">Clipboard history</string>
     <string name="clipboard_history_enabled">Enable clipboard history</string>


### PR DESCRIPTION
- Add long_press_duration to AppSettings and implement Room migration
- Add long press duration slider (100ms-1000ms) to Behavior settings
- Refactor KeyboardKey touch handling to support custom long press duration
- Fix: Ignore swipe/drag gestures after a long press has triggered
- Fix: Correct positional formatting for warning_invalid_mode in all translations
- Maintain visual feedback using InteractionSource in the custom gesture handler