### PR TITLE
Adding Deepseek-generated 5x5 (whale) and 4x4 (marlin) layouts

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMarlin.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMarlin.kt
@@ -1,0 +1,236 @@
+@file:Suppress("ktlint:standard:no-wildcard-imports")
+
+package com.dessalines.thumbkey.keyboards
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.*
+import com.dessalines.thumbkey.utils.*
+import com.dessalines.thumbkey.utils.ColorVariant.*
+import com.dessalines.thumbkey.utils.FontSizeVariant.*
+import com.dessalines.thumbkey.utils.KeyAction.*
+
+val KB_EN_MARLIN_MAIN =
+    KeyboardC(
+        listOf(
+            listOf(
+                KeyItemC(
+                    center = KeyC("d", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("o", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("u", size = LARGE),
+                ),
+                EMOJI_KEY_ITEM.copy(
+                    center = KeyC("m", size = LARGE),
+                    right =
+                        TOGGLE_EMOJI_MODE_TRUE_KEYC.copy(
+                            size = SMALL,
+                            color = MUTED,
+                        ),
+                    backgroundColor = SURFACE,
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("t", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("e", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("h", size = LARGE),
+                    left = KeyC(".", color = MUTED),
+                    right = KeyC(",", color = MUTED),
+                    topRight = KeyC("'", color = MUTED),
+                    bottomRight = KeyC("-", color = MUTED),
+                    bottom =
+                        RETURN_KEYC.copy(
+                            size = SMALL,
+                            color = MUTED,
+                        ),
+                    bottomLeft = KeyC("*", color = MUTED),
+                ),
+                NUMERIC_KEY_ITEM.copy(
+                    center = KeyC("n", size = LARGE),
+                    right =
+                        TOGGLE_NUMERIC_MODE_TRUE_KEYC.copy(
+                            size = SMALL,
+                            color = MUTED,
+                        ),
+                    backgroundColor = SURFACE,
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("i", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("a", size = LARGE),
+                    top = KeyC("z"),
+                    bottom = KeyC("k"),
+                    left = KeyC("x"),
+                    right = KeyC("q"),
+                ),
+                KeyItemC(
+                    center = KeyC("r", size = LARGE),
+                    top = KeyC("f"),
+                    bottom = KeyC("w"),
+                    left = KeyC("p"),
+                    right = KeyC("g"),
+                    topRight = KeyC("b"),
+                    bottomRight = KeyC("v"),
+                    topLeft = KeyC("y"),
+                    bottomLeft = KeyC("j"),
+                ),
+                KeyItemC(
+                    center = KeyC("s", size = LARGE),
+                    top =
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
+                            action = ToggleShiftMode(true),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(true),
+                            color = MUTED,
+                        ),
+                    bottom =
+                        KeyC(
+                            ToggleShiftMode(false),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(false),
+                        ),
+                ),
+            ),
+            listOf(
+                BACKSPACE_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("l", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("c", size = LARGE),
+                ),
+                SPACEBAR_SKINNY_KEY_ITEM,
+            ),
+        ),
+    )
+
+val KB_EN_MARLIN_SHIFTED =
+    KeyboardC(
+        listOf(
+            listOf(
+                KeyItemC(
+                    center = KeyC("D", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("O", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("U", size = LARGE),
+                ),
+                EMOJI_KEY_ITEM.copy(
+                    center = KeyC("M", size = LARGE),
+                    right =
+                        TOGGLE_EMOJI_MODE_TRUE_KEYC.copy(
+                            size = SMALL,
+                            color = MUTED,
+                        ),
+                    backgroundColor = SURFACE,
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("T", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("E", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("H", size = LARGE),
+                    left = KeyC(".", color = MUTED),
+                    right = KeyC(",", color = MUTED),
+                    topRight = KeyC("'", color = MUTED),
+                    bottomRight = KeyC("-", color = MUTED),
+                    bottom =
+                        RETURN_KEYC.copy(
+                            size = SMALL,
+                            color = MUTED,
+                        ),
+                    bottomLeft = KeyC("*", color = MUTED),
+                ),
+                NUMERIC_KEY_ITEM.copy(
+                    center = KeyC("N", size = LARGE),
+                    right =
+                        TOGGLE_NUMERIC_MODE_TRUE_KEYC.copy(
+                            size = SMALL,
+                            color = MUTED,
+                        ),
+                    backgroundColor = SURFACE,
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("I", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("A", size = LARGE),
+                    top = KeyC("Z"),
+                    bottom = KeyC("K"),
+                    left = KeyC("X"),
+                    right = KeyC("Q"),
+                ),
+                KeyItemC(
+                    center = KeyC("R", size = LARGE),
+                    top = KeyC("F"),
+                    bottom = KeyC("W"),
+                    left = KeyC("P"),
+                    right = KeyC("G"),
+                    topRight = KeyC("B"),
+                    bottomRight = KeyC("V"),
+                    topLeft = KeyC("Y"),
+                    bottomLeft = KeyC("J"),
+                ),
+                KeyItemC(
+                    center = KeyC("S", size = LARGE),
+                    bottom =
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
+                            action = ToggleShiftMode(false),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(false),
+                            color = MUTED,
+                        ),
+                    top =
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.Outlined.KeyboardCapslock),
+                            capsModeDisplay = KeyDisplay.IconDisplay(Icons.Outlined.Copyright),
+                            action = ToggleCapsLock,
+                            swipeReturnAction = ToggleCurrentWordCapitalization(true),
+                            color = MUTED,
+                        ),
+                ),
+            ),
+            listOf(
+                BACKSPACE_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("L", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("C", size = LARGE),
+                ),
+                SPACEBAR_SKINNY_KEY_ITEM,
+            ),
+        ),
+    )
+
+val KB_EN_MARLIN: KeyboardDefinition =
+    KeyboardDefinition(
+        title = "english marlin",
+        modes =
+            KeyboardDefinitionModes(
+                main = KB_EN_MARLIN_MAIN,
+                shifted = KB_EN_MARLIN_SHIFTED,
+                numeric = NUMERIC_KEYBOARD,
+            ),
+        settings =
+            KeyboardDefinitionSettings(
+                autoCapitalizers = arrayOf(::autoCapitalizeI, ::autoCapitalizeIApostrophe),
+            ),
+    )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENWhale.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENWhale.kt
@@ -1,0 +1,278 @@
+@file:Suppress("ktlint:standard:no-wildcard-imports")
+
+package com.dessalines.thumbkey.keyboards
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.*
+import com.dessalines.thumbkey.utils.*
+import com.dessalines.thumbkey.utils.ColorVariant.*
+import com.dessalines.thumbkey.utils.FontSizeVariant.*
+import com.dessalines.thumbkey.utils.KeyAction.*
+
+val KB_EN_WHALE_MAIN =
+    KeyboardC(
+        listOf(
+            listOf(
+                KeyItemC(
+                    center = KeyC("b", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("p", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("v", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("w", size = LARGE),
+                ),
+                EMOJI_KEY_ITEM.copy(
+                    center = KeyC("f", size = LARGE),
+                    right =
+                        TOGGLE_EMOJI_MODE_TRUE_KEYC.copy(
+                            size = SMALL,
+                            color = MUTED,
+                        ),
+                    backgroundColor = SURFACE,
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("y", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("g", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("k", size = LARGE),
+                    bottom = KeyC("j"),
+                    top = KeyC("q"),
+                    left = KeyC("z"),
+                    right = KeyC("x"),
+                ),
+                KeyItemC(
+                    center = KeyC("u", size = LARGE),
+                ),
+                NUMERIC_KEY_ITEM.copy(
+                    center = KeyC("m", size = LARGE),
+                    right =
+                        TOGGLE_NUMERIC_MODE_TRUE_KEYC.copy(
+                            size = SMALL,
+                            color = MUTED,
+                        ),
+                    backgroundColor = SURFACE,
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("d", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("i", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC(".", size = LARGE),
+                    right = KeyC(",", color = MUTED),
+                    topRight = KeyC("'", color = MUTED),
+                    bottomRight = KeyC("-", color = MUTED),
+                    bottom =
+                        RETURN_KEYC.copy(
+                            size = SMALL,
+                            color = MUTED,
+                        ),
+                    bottomLeft = KeyC("*", color = MUTED),
+                    backgroundColor = SURFACE_VARIANT,
+                ),
+                KeyItemC(
+                    center = KeyC("l", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("c", size = LARGE),
+                    top =
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
+                            action = ToggleShiftMode(true),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(true),
+                            color = MUTED,
+                        ),
+                    bottom =
+                        KeyC(
+                            ToggleShiftMode(false),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(false),
+                        ),
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("o", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("a", size = LARGE),
+                ),
+                BACKSPACE_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("h", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("r", size = LARGE),
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("t", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("e", size = LARGE),
+                ),
+                SPACEBAR_SKINNY_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("n", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("s", size = LARGE),
+                ),
+            ),
+        ),
+    )
+
+val KB_EN_WHALE_SHIFTED =
+    KeyboardC(
+        listOf(
+            listOf(
+                KeyItemC(
+                    center = KeyC("B", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("P", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("V", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("W", size = LARGE),
+                ),
+                EMOJI_KEY_ITEM.copy(
+                    center = KeyC("F", size = LARGE),
+                    right =
+                        TOGGLE_EMOJI_MODE_TRUE_KEYC.copy(
+                            size = SMALL,
+                            color = MUTED,
+                        ),
+                    backgroundColor = SURFACE,
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("Y", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("G", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("K", size = LARGE),
+                    bottom = KeyC("J"),
+                    top = KeyC("Q"),
+                    left = KeyC("Z"),
+                    right = KeyC("X"),
+                ),
+                KeyItemC(
+                    center = KeyC("U", size = LARGE),
+                ),
+                NUMERIC_KEY_ITEM.copy(
+                    center = KeyC("M", size = LARGE),
+                    right =
+                        TOGGLE_NUMERIC_MODE_TRUE_KEYC.copy(
+                            size = SMALL,
+                            color = MUTED,
+                        ),
+                    backgroundColor = SURFACE,
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("D", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("I", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC(".", size = LARGE),
+                    right = KeyC(",", color = MUTED),
+                    topRight = KeyC("'", color = MUTED),
+                    bottomRight = KeyC("-", color = MUTED),
+                    bottom =
+                        RETURN_KEYC.copy(
+                            size = SMALL,
+                            color = MUTED,
+                        ),
+                    bottomLeft = KeyC("*", color = MUTED),
+                    backgroundColor = SURFACE_VARIANT,
+                ),
+                KeyItemC(
+                    center = KeyC("L", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("C", size = LARGE),
+                    bottom =
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
+                            action = ToggleShiftMode(false),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(false),
+                            color = MUTED,
+                        ),
+                    top =
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.Outlined.KeyboardCapslock),
+                            capsModeDisplay = KeyDisplay.IconDisplay(Icons.Outlined.Copyright),
+                            action = ToggleCapsLock,
+                            swipeReturnAction = ToggleCurrentWordCapitalization(true),
+                            color = MUTED,
+                        ),
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("O", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("A", size = LARGE),
+                ),
+                BACKSPACE_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("H", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("R", size = LARGE),
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("T", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("E", size = LARGE),
+                ),
+                SPACEBAR_SKINNY_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("N", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("S", size = LARGE),
+                ),
+            ),
+        ),
+    )
+
+val KB_EN_WHALE: KeyboardDefinition =
+    KeyboardDefinition(
+        title = "english whale",
+        modes =
+            KeyboardDefinitionModes(
+                main = KB_EN_WHALE_MAIN,
+                shifted = KB_EN_WHALE_SHIFTED,
+                numeric = NUMERIC_KEYBOARD,
+            ),
+        settings =
+            KeyboardDefinitionSettings(
+                autoCapitalizers = arrayOf(::autoCapitalizeI, ::autoCapitalizeIApostrophe),
+            ),
+    )

--- a/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
@@ -50,6 +50,7 @@ import com.dessalines.thumbkey.keyboards.KB_EN_HYPER
 import com.dessalines.thumbkey.keyboards.KB_EN_HYPER_SPACE
 import com.dessalines.thumbkey.keyboards.KB_EN_IT_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_EN_LA_THUMBKEY
+import com.dessalines.thumbkey.keyboards.KB_EN_MARLIN
 import com.dessalines.thumbkey.keyboards.KB_EN_MESSAGEASE
 import com.dessalines.thumbkey.keyboards.KB_EN_MESSAGEASE_COMPOSE
 import com.dessalines.thumbkey.keyboards.KB_EN_MESSAGEASE_COMPOSE_LEFT_FLIPPED_NUMPAD
@@ -99,6 +100,7 @@ import com.dessalines.thumbkey.keyboards.KB_EN_TWO_HANDS
 import com.dessalines.thumbkey.keyboards.KB_EN_TYPESPLIT
 import com.dessalines.thumbkey.keyboards.KB_EN_TYPESPLIT_PROGRAMMING
 import com.dessalines.thumbkey.keyboards.KB_EN_TYPESPLIT_SHORT
+import com.dessalines.thumbkey.keyboards.KB_EN_WHALE
 import com.dessalines.thumbkey.keyboards.KB_EO_CYRILLIC_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_EO_EN_DE_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_ES_CA_MESSAGEASE
@@ -464,4 +466,6 @@ enum class KeyboardLayout(
     ENMessagEaseComposeFlipped(KB_EN_MESSAGEASE_COMPOSE_LEFT_FLIPPED_NUMPAD), // english messagease compose flipped
     FRMessagEaseFlipped(KB_FR_MESSAGEASE_LEFT_FLIPPED_NUMPAD), // français messagease left-handed flipped
     BNThumbKey(KB_BN_THUMBKEY), // বাংলা thumb-key
+    ENWhale(KB_EN_WHALE),
+    ENMarlin(KB_EN_MARLIN),
 }


### PR DESCRIPTION
- Fixes #1940

See the linked issue above for its links and rationales.

I've been testing out whale, and its pretty fast even at the beginning.

# Whale

<img height="300" alt="Screenshot_2026-07-10-11-34-48-09_2562f11e997739b9ac75807299a56645" src="https://github.com/user-attachments/assets/8e7cc64a-95f6-4fa9-bb98-ddc78c616821" />

# Marlin

<img height="300" alt="Screenshot_2026-07-10-11-40-39-25_2562f11e997739b9ac75807299a56645" src="https://github.com/user-attachments/assets/7a121222-430d-486c-8d25-458112edff2d" />




 