### PR TITLE
Deepseek layout fixes 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ app/schemas
 .classpath
 .kotlin
 build.sh
+deploy_to_device.sh

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMarlin.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMarlin.kt
@@ -14,16 +14,16 @@ val KB_EN_MARLIN_MAIN =
         listOf(
             listOf(
                 KeyItemC(
-                    center = KeyC("d", size = LARGE),
-                ),
-                KeyItemC(
-                    center = KeyC("o", size = LARGE),
+                    center = KeyC("m", size = LARGE),
                 ),
                 KeyItemC(
                     center = KeyC("u", size = LARGE),
                 ),
+                KeyItemC(
+                    center = KeyC("o", size = LARGE),
+                ),
                 EMOJI_KEY_ITEM.copy(
-                    center = KeyC("m", size = LARGE),
+                    center = KeyC("d", size = LARGE),
                     right =
                         TOGGLE_EMOJI_MODE_TRUE_KEYC.copy(
                             size = SMALL,
@@ -34,13 +34,13 @@ val KB_EN_MARLIN_MAIN =
             ),
             listOf(
                 KeyItemC(
-                    center = KeyC("t", size = LARGE),
-                ),
-                KeyItemC(
-                    center = KeyC("e", size = LARGE),
+                    center = KeyC("n", size = LARGE),
                 ),
                 KeyItemC(
                     center = KeyC("h", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("e", size = LARGE),
                     left = KeyC(".", color = MUTED),
                     right = KeyC(",", color = MUTED),
                     topRight = KeyC("'", color = MUTED),
@@ -53,7 +53,7 @@ val KB_EN_MARLIN_MAIN =
                     bottomLeft = KeyC("*", color = MUTED),
                 ),
                 NUMERIC_KEY_ITEM.copy(
-                    center = KeyC("n", size = LARGE),
+                    center = KeyC("t", size = LARGE),
                     right =
                         TOGGLE_NUMERIC_MODE_TRUE_KEYC.copy(
                             size = SMALL,
@@ -64,17 +64,17 @@ val KB_EN_MARLIN_MAIN =
             ),
             listOf(
                 KeyItemC(
-                    center = KeyC("i", size = LARGE),
+                    center = KeyC("s", size = LARGE),
                 ),
                 KeyItemC(
-                    center = KeyC("a", size = LARGE),
+                    center = KeyC("r", size = LARGE),
                     top = KeyC("z"),
                     bottom = KeyC("k"),
                     left = KeyC("x"),
                     right = KeyC("q"),
                 ),
                 KeyItemC(
-                    center = KeyC("r", size = LARGE),
+                    center = KeyC("a", size = LARGE),
                     top = KeyC("f"),
                     bottom = KeyC("w"),
                     left = KeyC("p"),
@@ -85,7 +85,7 @@ val KB_EN_MARLIN_MAIN =
                     bottomLeft = KeyC("j"),
                 ),
                 KeyItemC(
-                    center = KeyC("s", size = LARGE),
+                    center = KeyC("i", size = LARGE),
                     top =
                         KeyC(
                             display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
@@ -103,10 +103,10 @@ val KB_EN_MARLIN_MAIN =
             listOf(
                 BACKSPACE_KEY_ITEM,
                 KeyItemC(
-                    center = KeyC("l", size = LARGE),
+                    center = KeyC("c", size = LARGE),
                 ),
                 KeyItemC(
-                    center = KeyC("c", size = LARGE),
+                    center = KeyC("l", size = LARGE),
                 ),
                 SPACEBAR_SKINNY_KEY_ITEM,
             ),
@@ -118,16 +118,16 @@ val KB_EN_MARLIN_SHIFTED =
         listOf(
             listOf(
                 KeyItemC(
-                    center = KeyC("D", size = LARGE),
-                ),
-                KeyItemC(
-                    center = KeyC("O", size = LARGE),
+                    center = KeyC("M", size = LARGE),
                 ),
                 KeyItemC(
                     center = KeyC("U", size = LARGE),
                 ),
+                KeyItemC(
+                    center = KeyC("O", size = LARGE),
+                ),
                 EMOJI_KEY_ITEM.copy(
-                    center = KeyC("M", size = LARGE),
+                    center = KeyC("D", size = LARGE),
                     right =
                         TOGGLE_EMOJI_MODE_TRUE_KEYC.copy(
                             size = SMALL,
@@ -138,13 +138,13 @@ val KB_EN_MARLIN_SHIFTED =
             ),
             listOf(
                 KeyItemC(
-                    center = KeyC("T", size = LARGE),
-                ),
-                KeyItemC(
-                    center = KeyC("E", size = LARGE),
+                    center = KeyC("N", size = LARGE),
                 ),
                 KeyItemC(
                     center = KeyC("H", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("E", size = LARGE),
                     left = KeyC(".", color = MUTED),
                     right = KeyC(",", color = MUTED),
                     topRight = KeyC("'", color = MUTED),
@@ -157,7 +157,7 @@ val KB_EN_MARLIN_SHIFTED =
                     bottomLeft = KeyC("*", color = MUTED),
                 ),
                 NUMERIC_KEY_ITEM.copy(
-                    center = KeyC("N", size = LARGE),
+                    center = KeyC("T", size = LARGE),
                     right =
                         TOGGLE_NUMERIC_MODE_TRUE_KEYC.copy(
                             size = SMALL,
@@ -168,17 +168,17 @@ val KB_EN_MARLIN_SHIFTED =
             ),
             listOf(
                 KeyItemC(
-                    center = KeyC("I", size = LARGE),
+                    center = KeyC("S", size = LARGE),
                 ),
                 KeyItemC(
-                    center = KeyC("A", size = LARGE),
+                    center = KeyC("R", size = LARGE),
                     top = KeyC("Z"),
                     bottom = KeyC("K"),
                     left = KeyC("X"),
                     right = KeyC("Q"),
                 ),
                 KeyItemC(
-                    center = KeyC("R", size = LARGE),
+                    center = KeyC("A", size = LARGE),
                     top = KeyC("F"),
                     bottom = KeyC("W"),
                     left = KeyC("P"),
@@ -189,7 +189,7 @@ val KB_EN_MARLIN_SHIFTED =
                     bottomLeft = KeyC("J"),
                 ),
                 KeyItemC(
-                    center = KeyC("S", size = LARGE),
+                    center = KeyC("I", size = LARGE),
                     bottom =
                         KeyC(
                             display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
@@ -210,10 +210,10 @@ val KB_EN_MARLIN_SHIFTED =
             listOf(
                 BACKSPACE_KEY_ITEM,
                 KeyItemC(
-                    center = KeyC("L", size = LARGE),
+                    center = KeyC("C", size = LARGE),
                 ),
                 KeyItemC(
-                    center = KeyC("C", size = LARGE),
+                    center = KeyC("L", size = LARGE),
                 ),
                 SPACEBAR_SKINNY_KEY_ITEM,
             ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMinnow.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMinnow.kt
@@ -1,0 +1,219 @@
+@file:Suppress("ktlint:standard:no-wildcard-imports")
+
+package com.dessalines.thumbkey.keyboards
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.*
+import com.dessalines.thumbkey.utils.*
+import com.dessalines.thumbkey.utils.ColorVariant.*
+import com.dessalines.thumbkey.utils.FontSizeVariant.*
+import com.dessalines.thumbkey.utils.KeyAction.*
+
+val KB_EN_MINNOW_MAIN =
+    KeyboardC(
+        listOf(
+            listOf(
+                KeyItemC(
+                    center = KeyC("s", size = LARGE),
+                    bottomRight = KeyC("p"),
+                ),
+                KeyItemC(
+                    center = KeyC("o", size = LARGE),
+                    bottom = KeyC("f"),
+                    bottomLeft = KeyC("g"),
+                    bottomRight = KeyC("y"),
+                ),
+                EMOJI_KEY_ITEM.copy(
+                    center = KeyC("i", size = LARGE),
+                    right =
+                        TOGGLE_EMOJI_MODE_TRUE_KEYC.copy(
+                            size = SMALL,
+                            color = MUTED,
+                        ),
+                    backgroundColor = SURFACE,
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("t", size = LARGE),
+                    right = KeyC("b"),
+                    topRight = KeyC("z"),
+                ),
+                KeyItemC(
+                    center = SPACEBAR_CENTER_KEYC,
+                    slideType = SlideType.MOVE_CURSOR,
+                    nextTapActions = SPACEBAR_NEXT_TAP_ACTIONS,
+                    top = KeyC("h"),
+                    bottom = KeyC("r"),
+                    left = KeyC("d"),
+                    right = KeyC("l"),
+                    topLeft = KeyC("c"),
+                    topRight = KeyC("u"),
+                    bottomLeft = KeyC("m"),
+                    bottomRight = KeyC("w"),
+                ),
+                NUMERIC_KEY_ITEM.copy(
+                    center = KeyC("e", size = LARGE),
+                    left = KeyC("v"),
+                    right =
+                        TOGGLE_NUMERIC_MODE_TRUE_KEYC.copy(
+                            size = SMALL,
+                            color = MUTED,
+                        ),
+                    backgroundColor = SURFACE,
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("n", size = LARGE),
+                    topRight = KeyC("k"),
+                ),
+                KeyItemC(
+                    center = BACKSPACE_KEYC,
+                    longPress = DeleteWordBeforeCursor,
+                    slideType = SlideType.DELETE,
+                    top = KeyC("j"),
+                    topLeft = KeyC("x"),
+                    left = KeyC(".", color = MUTED),
+                    right = KeyC(",", color = MUTED),
+                    topRight = KeyC("'", color = MUTED),
+                    bottomRight = KeyC("-", color = MUTED),
+                    bottom =
+                        RETURN_KEYC.copy(
+                            size = SMALL,
+                            color = MUTED,
+                        ),
+                    bottomLeft = KeyC("*", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("a", size = LARGE),
+                    topLeft = KeyC("q"),
+                    top =
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
+                            action = ToggleShiftMode(true),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(true),
+                            color = MUTED,
+                        ),
+                    bottom =
+                        KeyC(
+                            ToggleShiftMode(false),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(false),
+                        ),
+                ),
+            ),
+        ),
+    )
+
+val KB_EN_MINNOW_SHIFTED =
+    KeyboardC(
+        listOf(
+            listOf(
+                KeyItemC(
+                    center = KeyC("S", size = LARGE),
+                    bottomRight = KeyC("P"),
+                ),
+                KeyItemC(
+                    center = KeyC("O", size = LARGE),
+                    bottom = KeyC("F"),
+                    bottomLeft = KeyC("G"),
+                    bottomRight = KeyC("Y"),
+                ),
+                EMOJI_KEY_ITEM.copy(
+                    center = KeyC("I", size = LARGE),
+                    right =
+                        TOGGLE_EMOJI_MODE_TRUE_KEYC.copy(
+                            size = SMALL,
+                            color = MUTED,
+                        ),
+                    backgroundColor = SURFACE,
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("T", size = LARGE),
+                    right = KeyC("B"),
+                    topRight = KeyC("Z"),
+                ),
+                KeyItemC(
+                    center = SPACEBAR_CENTER_KEYC,
+                    slideType = SlideType.MOVE_CURSOR,
+                    nextTapActions = SPACEBAR_NEXT_TAP_ACTIONS,
+                    top = KeyC("H"),
+                    bottom = KeyC("R"),
+                    left = KeyC("D"),
+                    right = KeyC("L"),
+                    topLeft = KeyC("C"),
+                    topRight = KeyC("U"),
+                    bottomLeft = KeyC("M"),
+                    bottomRight = KeyC("W"),
+                ),
+                NUMERIC_KEY_ITEM.copy(
+                    center = KeyC("E", size = LARGE),
+                    left = KeyC("V"),
+                    right =
+                        TOGGLE_NUMERIC_MODE_TRUE_KEYC.copy(
+                            size = SMALL,
+                            color = MUTED,
+                        ),
+                    backgroundColor = SURFACE,
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("N", size = LARGE),
+                    topRight = KeyC("K"),
+                ),
+                KeyItemC(
+                    center = BACKSPACE_KEYC,
+                    longPress = DeleteWordBeforeCursor,
+                    slideType = SlideType.DELETE,
+                    top = KeyC("J"),
+                    topLeft = KeyC("X"),
+                    left = KeyC(".", color = MUTED),
+                    right = KeyC(",", color = MUTED),
+                    topRight = KeyC("'", color = MUTED),
+                    bottomRight = KeyC("-", color = MUTED),
+                    bottom =
+                        RETURN_KEYC.copy(
+                            size = SMALL,
+                            color = MUTED,
+                        ),
+                    bottomLeft = KeyC("*", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("A", size = LARGE),
+                    topLeft = KeyC("Q"),
+                    bottom =
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
+                            action = ToggleShiftMode(false),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(false),
+                            color = MUTED,
+                        ),
+                    top =
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.Outlined.KeyboardCapslock),
+                            capsModeDisplay = KeyDisplay.IconDisplay(Icons.Outlined.Copyright),
+                            action = ToggleCapsLock,
+                            swipeReturnAction = ToggleCurrentWordCapitalization(true),
+                            color = MUTED,
+                        ),
+                ),
+            ),
+        ),
+    )
+val KB_EN_MINNOW: KeyboardDefinition =
+    KeyboardDefinition(
+        title = "english minnow",
+        modes =
+            KeyboardDefinitionModes(
+                main = KB_EN_MINNOW_MAIN,
+                shifted = KB_EN_MINNOW_SHIFTED,
+                numeric = NUMERIC_KEYBOARD,
+            ),
+        settings =
+            KeyboardDefinitionSettings(
+                autoCapitalizers = arrayOf(::autoCapitalizeI, ::autoCapitalizeIApostrophe),
+            ),
+    )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENWhale.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENWhale.kt
@@ -37,6 +37,33 @@ val KB_EN_WHALE_MAIN =
             ),
             listOf(
                 KeyItemC(
+                    center = KeyC("m", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("u", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("k", size = LARGE),
+                    bottom = KeyC("j"),
+                    top = KeyC("q"),
+                    left = KeyC("z"),
+                    right = KeyC("x"),
+                ),
+                KeyItemC(
+                    center = KeyC("g", size = LARGE),
+                ),
+                NUMERIC_KEY_ITEM.copy(
+                    center = KeyC("y", size = LARGE),
+                    right =
+                        TOGGLE_NUMERIC_MODE_TRUE_KEYC.copy(
+                            size = SMALL,
+                            color = MUTED,
+                        ),
+                    backgroundColor = SURFACE,
+                ),
+            ),
+            listOf(
+                KeyItemC(
                     center = KeyC("c", size = LARGE),
                 ),
                 KeyItemC(
@@ -58,29 +85,8 @@ val KB_EN_WHALE_MAIN =
                 KeyItemC(
                     center = KeyC("i", size = LARGE),
                 ),
-                NUMERIC_KEY_ITEM.copy(
+                KeyItemC(
                     center = KeyC("d", size = LARGE),
-                    right =
-                        TOGGLE_NUMERIC_MODE_TRUE_KEYC.copy(
-                            size = SMALL,
-                            color = MUTED,
-                        ),
-                    backgroundColor = SURFACE,
-                ),
-            ),
-            listOf(
-                KeyItemC(
-                    center = KeyC("s", size = LARGE),
-                ),
-                KeyItemC(
-                    center = KeyC("n", size = LARGE),
-                ),
-                SPACEBAR_SKINNY_KEY_ITEM,
-                KeyItemC(
-                    center = KeyC("e", size = LARGE),
-                ),
-                KeyItemC(
-                    center = KeyC("t", size = LARGE),
                     top =
                         KeyC(
                             display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
@@ -112,23 +118,17 @@ val KB_EN_WHALE_MAIN =
             ),
             listOf(
                 KeyItemC(
-                    center = KeyC("m", size = LARGE),
+                    center = KeyC("s", size = LARGE),
                 ),
                 KeyItemC(
-                    center = KeyC("u", size = LARGE),
+                    center = KeyC("n", size = LARGE),
+                ),
+                SPACEBAR_SKINNY_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("e", size = LARGE),
                 ),
                 KeyItemC(
-                    center = KeyC("k", size = LARGE),
-                    bottom = KeyC("j"),
-                    top = KeyC("q"),
-                    left = KeyC("z"),
-                    right = KeyC("x"),
-                ),
-                KeyItemC(
-                    center = KeyC("g", size = LARGE),
-                ),
-                KeyItemC(
-                    center = KeyC("y", size = LARGE),
+                    center = KeyC("t", size = LARGE),
                 ),
             ),
         ),
@@ -162,6 +162,33 @@ val KB_EN_WHALE_SHIFTED =
             ),
             listOf(
                 KeyItemC(
+                    center = KeyC("M", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("U", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("K", size = LARGE),
+                    bottom = KeyC("J"),
+                    top = KeyC("Q"),
+                    left = KeyC("Z"),
+                    right = KeyC("X"),
+                ),
+                KeyItemC(
+                    center = KeyC("G", size = LARGE),
+                ),
+                NUMERIC_KEY_ITEM.copy(
+                    center = KeyC("Y", size = LARGE),
+                    right =
+                        TOGGLE_NUMERIC_MODE_TRUE_KEYC.copy(
+                            size = SMALL,
+                            color = MUTED,
+                        ),
+                    backgroundColor = SURFACE,
+                ),
+            ),
+            listOf(
+                KeyItemC(
                     center = KeyC("C", size = LARGE),
                 ),
                 KeyItemC(
@@ -183,29 +210,8 @@ val KB_EN_WHALE_SHIFTED =
                 KeyItemC(
                     center = KeyC("I", size = LARGE),
                 ),
-                NUMERIC_KEY_ITEM.copy(
+                KeyItemC(
                     center = KeyC("D", size = LARGE),
-                    right =
-                        TOGGLE_NUMERIC_MODE_TRUE_KEYC.copy(
-                            size = SMALL,
-                            color = MUTED,
-                        ),
-                    backgroundColor = SURFACE,
-                ),
-            ),
-            listOf(
-                KeyItemC(
-                    center = KeyC("S", size = LARGE),
-                ),
-                KeyItemC(
-                    center = KeyC("N", size = LARGE),
-                ),
-                SPACEBAR_SKINNY_KEY_ITEM,
-                KeyItemC(
-                    center = KeyC("E", size = LARGE),
-                ),
-                KeyItemC(
-                    center = KeyC("T", size = LARGE),
                     bottom =
                         KeyC(
                             display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
@@ -240,23 +246,17 @@ val KB_EN_WHALE_SHIFTED =
             ),
             listOf(
                 KeyItemC(
-                    center = KeyC("M", size = LARGE),
+                    center = KeyC("S", size = LARGE),
                 ),
                 KeyItemC(
-                    center = KeyC("U", size = LARGE),
+                    center = KeyC("N", size = LARGE),
+                ),
+                SPACEBAR_SKINNY_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("E", size = LARGE),
                 ),
                 KeyItemC(
-                    center = KeyC("K", size = LARGE),
-                    bottom = KeyC("J"),
-                    top = KeyC("Q"),
-                    left = KeyC("Z"),
-                    right = KeyC("X"),
-                ),
-                KeyItemC(
-                    center = KeyC("G", size = LARGE),
-                ),
-                KeyItemC(
-                    center = KeyC("Y", size = LARGE),
+                    center = KeyC("T", size = LARGE),
                 ),
             ),
         ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENWhale.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENWhale.kt
@@ -37,33 +37,6 @@ val KB_EN_WHALE_MAIN =
             ),
             listOf(
                 KeyItemC(
-                    center = KeyC("m", size = LARGE),
-                ),
-                KeyItemC(
-                    center = KeyC("u", size = LARGE),
-                ),
-                KeyItemC(
-                    center = KeyC("k", size = LARGE),
-                    bottom = KeyC("j"),
-                    top = KeyC("q"),
-                    left = KeyC("z"),
-                    right = KeyC("x"),
-                ),
-                KeyItemC(
-                    center = KeyC("g", size = LARGE),
-                ),
-                NUMERIC_KEY_ITEM.copy(
-                    center = KeyC("y", size = LARGE),
-                    right =
-                        TOGGLE_NUMERIC_MODE_TRUE_KEYC.copy(
-                            size = SMALL,
-                            color = MUTED,
-                        ),
-                    backgroundColor = SURFACE,
-                ),
-            ),
-            listOf(
-                KeyItemC(
                     center = KeyC("c", size = LARGE),
                 ),
                 KeyItemC(
@@ -85,8 +58,29 @@ val KB_EN_WHALE_MAIN =
                 KeyItemC(
                     center = KeyC("i", size = LARGE),
                 ),
-                KeyItemC(
+                NUMERIC_KEY_ITEM.copy(
                     center = KeyC("d", size = LARGE),
+                    right =
+                        TOGGLE_NUMERIC_MODE_TRUE_KEYC.copy(
+                            size = SMALL,
+                            color = MUTED,
+                        ),
+                    backgroundColor = SURFACE,
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("s", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("n", size = LARGE),
+                ),
+                SPACEBAR_SKINNY_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("e", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("t", size = LARGE),
                     top =
                         KeyC(
                             display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
@@ -118,17 +112,23 @@ val KB_EN_WHALE_MAIN =
             ),
             listOf(
                 KeyItemC(
-                    center = KeyC("s", size = LARGE),
+                    center = KeyC("m", size = LARGE),
                 ),
                 KeyItemC(
-                    center = KeyC("n", size = LARGE),
-                ),
-                SPACEBAR_SKINNY_KEY_ITEM,
-                KeyItemC(
-                    center = KeyC("e", size = LARGE),
+                    center = KeyC("u", size = LARGE),
                 ),
                 KeyItemC(
-                    center = KeyC("t", size = LARGE),
+                    center = KeyC("k", size = LARGE),
+                    bottom = KeyC("j"),
+                    top = KeyC("q"),
+                    left = KeyC("z"),
+                    right = KeyC("x"),
+                ),
+                KeyItemC(
+                    center = KeyC("g", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("y", size = LARGE),
                 ),
             ),
         ),
@@ -162,33 +162,6 @@ val KB_EN_WHALE_SHIFTED =
             ),
             listOf(
                 KeyItemC(
-                    center = KeyC("M", size = LARGE),
-                ),
-                KeyItemC(
-                    center = KeyC("U", size = LARGE),
-                ),
-                KeyItemC(
-                    center = KeyC("K", size = LARGE),
-                    bottom = KeyC("J"),
-                    top = KeyC("Q"),
-                    left = KeyC("Z"),
-                    right = KeyC("X"),
-                ),
-                KeyItemC(
-                    center = KeyC("G", size = LARGE),
-                ),
-                NUMERIC_KEY_ITEM.copy(
-                    center = KeyC("Y", size = LARGE),
-                    right =
-                        TOGGLE_NUMERIC_MODE_TRUE_KEYC.copy(
-                            size = SMALL,
-                            color = MUTED,
-                        ),
-                    backgroundColor = SURFACE,
-                ),
-            ),
-            listOf(
-                KeyItemC(
                     center = KeyC("C", size = LARGE),
                 ),
                 KeyItemC(
@@ -210,8 +183,29 @@ val KB_EN_WHALE_SHIFTED =
                 KeyItemC(
                     center = KeyC("I", size = LARGE),
                 ),
-                KeyItemC(
+                NUMERIC_KEY_ITEM.copy(
                     center = KeyC("D", size = LARGE),
+                    right =
+                        TOGGLE_NUMERIC_MODE_TRUE_KEYC.copy(
+                            size = SMALL,
+                            color = MUTED,
+                        ),
+                    backgroundColor = SURFACE,
+                ),
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("S", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("N", size = LARGE),
+                ),
+                SPACEBAR_SKINNY_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("E", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("T", size = LARGE),
                     bottom =
                         KeyC(
                             display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
@@ -246,17 +240,23 @@ val KB_EN_WHALE_SHIFTED =
             ),
             listOf(
                 KeyItemC(
-                    center = KeyC("S", size = LARGE),
+                    center = KeyC("M", size = LARGE),
                 ),
                 KeyItemC(
-                    center = KeyC("N", size = LARGE),
-                ),
-                SPACEBAR_SKINNY_KEY_ITEM,
-                KeyItemC(
-                    center = KeyC("E", size = LARGE),
+                    center = KeyC("U", size = LARGE),
                 ),
                 KeyItemC(
-                    center = KeyC("T", size = LARGE),
+                    center = KeyC("K", size = LARGE),
+                    bottom = KeyC("J"),
+                    top = KeyC("Q"),
+                    left = KeyC("Z"),
+                    right = KeyC("X"),
+                ),
+                KeyItemC(
+                    center = KeyC("G", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("Y", size = LARGE),
                 ),
             ),
         ),

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENWhale.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENWhale.kt
@@ -9,21 +9,40 @@ import com.dessalines.thumbkey.utils.ColorVariant.*
 import com.dessalines.thumbkey.utils.FontSizeVariant.*
 import com.dessalines.thumbkey.utils.KeyAction.*
 
+val DotKeyItemC =
+    KeyItemC(
+        center = KeyC(".", size = LARGE),
+        left = KeyC(",", color = MUTED),
+        topLeft = KeyC("'", color = MUTED),
+        bottomRight = KeyC("-", color = MUTED),
+        bottom =
+            RETURN_KEYC.copy(
+                size = SMALL,
+                color = MUTED,
+            ),
+        bottomLeft = KeyC("*", color = MUTED),
+        backgroundColor = SURFACE_VARIANT,
+    )
+
 val KB_EN_WHALE_MAIN =
     KeyboardC(
         listOf(
             listOf(
                 KeyItemC(
                     center = KeyC("f", size = LARGE),
+                    bottom = KeyC("j"),
                 ),
                 KeyItemC(
                     center = KeyC("w", size = LARGE),
+                    bottom = KeyC("x"),
                 ),
                 KeyItemC(
                     center = KeyC("v", size = LARGE),
+                    bottom = KeyC("q"),
                 ),
                 KeyItemC(
                     center = KeyC("p", size = LARGE),
+                    bottom = KeyC("z"),
                 ),
                 EMOJI_KEY_ITEM.copy(
                     center = KeyC("b", size = LARGE),
@@ -44,10 +63,6 @@ val KB_EN_WHALE_MAIN =
                 ),
                 KeyItemC(
                     center = KeyC("k", size = LARGE),
-                    bottom = KeyC("j"),
-                    top = KeyC("q"),
-                    left = KeyC("z"),
-                    right = KeyC("x"),
                 ),
                 KeyItemC(
                     center = KeyC("g", size = LARGE),
@@ -70,19 +85,6 @@ val KB_EN_WHALE_MAIN =
                     center = KeyC("l", size = LARGE),
                 ),
                 KeyItemC(
-                    center = KeyC(".", size = LARGE),
-                    right = KeyC(",", color = MUTED),
-                    topRight = KeyC("'", color = MUTED),
-                    bottomRight = KeyC("-", color = MUTED),
-                    bottom =
-                        RETURN_KEYC.copy(
-                            size = SMALL,
-                            color = MUTED,
-                        ),
-                    bottomLeft = KeyC("*", color = MUTED),
-                    backgroundColor = SURFACE_VARIANT,
-                ),
-                KeyItemC(
                     center = KeyC("i", size = LARGE),
                 ),
                 KeyItemC(
@@ -100,6 +102,7 @@ val KB_EN_WHALE_MAIN =
                             swipeReturnAction = ToggleCurrentWordCapitalization(false),
                         ),
                 ),
+                DotKeyItemC,
             ),
             listOf(
                 KeyItemC(
@@ -108,13 +111,13 @@ val KB_EN_WHALE_MAIN =
                 KeyItemC(
                     center = KeyC("h", size = LARGE),
                 ),
-                BACKSPACE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("a", size = LARGE),
                 ),
                 KeyItemC(
                     center = KeyC("o", size = LARGE),
                 ),
+                BACKSPACE_KEY_ITEM,
             ),
             listOf(
                 KeyItemC(
@@ -123,13 +126,13 @@ val KB_EN_WHALE_MAIN =
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
                 ),
-                SPACEBAR_SKINNY_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("e", size = LARGE),
                 ),
                 KeyItemC(
                     center = KeyC("t", size = LARGE),
                 ),
+                SPACEBAR_SKINNY_KEY_ITEM,
             ),
         ),
     )
@@ -140,15 +143,19 @@ val KB_EN_WHALE_SHIFTED =
             listOf(
                 KeyItemC(
                     center = KeyC("F", size = LARGE),
+                    bottom = KeyC("J"),
                 ),
                 KeyItemC(
                     center = KeyC("W", size = LARGE),
+                    bottom = KeyC("X"),
                 ),
                 KeyItemC(
                     center = KeyC("V", size = LARGE),
+                    bottom = KeyC("Q"),
                 ),
                 KeyItemC(
                     center = KeyC("P", size = LARGE),
+                    bottom = KeyC("Z"),
                 ),
                 EMOJI_KEY_ITEM.copy(
                     center = KeyC("B", size = LARGE),
@@ -169,10 +176,6 @@ val KB_EN_WHALE_SHIFTED =
                 ),
                 KeyItemC(
                     center = KeyC("K", size = LARGE),
-                    bottom = KeyC("J"),
-                    top = KeyC("Q"),
-                    left = KeyC("Z"),
-                    right = KeyC("X"),
                 ),
                 KeyItemC(
                     center = KeyC("G", size = LARGE),
@@ -195,19 +198,6 @@ val KB_EN_WHALE_SHIFTED =
                     center = KeyC("L", size = LARGE),
                 ),
                 KeyItemC(
-                    center = KeyC(".", size = LARGE),
-                    right = KeyC(",", color = MUTED),
-                    topRight = KeyC("'", color = MUTED),
-                    bottomRight = KeyC("-", color = MUTED),
-                    bottom =
-                        RETURN_KEYC.copy(
-                            size = SMALL,
-                            color = MUTED,
-                        ),
-                    bottomLeft = KeyC("*", color = MUTED),
-                    backgroundColor = SURFACE_VARIANT,
-                ),
-                KeyItemC(
                     center = KeyC("I", size = LARGE),
                 ),
                 KeyItemC(
@@ -228,6 +218,7 @@ val KB_EN_WHALE_SHIFTED =
                             color = MUTED,
                         ),
                 ),
+                DotKeyItemC,
             ),
             listOf(
                 KeyItemC(
@@ -236,13 +227,13 @@ val KB_EN_WHALE_SHIFTED =
                 KeyItemC(
                     center = KeyC("H", size = LARGE),
                 ),
-                BACKSPACE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("A", size = LARGE),
                 ),
                 KeyItemC(
                     center = KeyC("O", size = LARGE),
                 ),
+                BACKSPACE_KEY_ITEM,
             ),
             listOf(
                 KeyItemC(
@@ -251,13 +242,13 @@ val KB_EN_WHALE_SHIFTED =
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
                 ),
-                SPACEBAR_SKINNY_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("E", size = LARGE),
                 ),
                 KeyItemC(
                     center = KeyC("T", size = LARGE),
                 ),
+                SPACEBAR_SKINNY_KEY_ITEM,
             ),
         ),
     )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENWhale.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENWhale.kt
@@ -14,19 +14,19 @@ val KB_EN_WHALE_MAIN =
         listOf(
             listOf(
                 KeyItemC(
-                    center = KeyC("b", size = LARGE),
+                    center = KeyC("f", size = LARGE),
                 ),
                 KeyItemC(
-                    center = KeyC("p", size = LARGE),
+                    center = KeyC("w", size = LARGE),
                 ),
                 KeyItemC(
                     center = KeyC("v", size = LARGE),
                 ),
                 KeyItemC(
-                    center = KeyC("w", size = LARGE),
+                    center = KeyC("p", size = LARGE),
                 ),
                 EMOJI_KEY_ITEM.copy(
-                    center = KeyC("f", size = LARGE),
+                    center = KeyC("b", size = LARGE),
                     right =
                         TOGGLE_EMOJI_MODE_TRUE_KEYC.copy(
                             size = SMALL,
@@ -37,10 +37,10 @@ val KB_EN_WHALE_MAIN =
             ),
             listOf(
                 KeyItemC(
-                    center = KeyC("y", size = LARGE),
+                    center = KeyC("m", size = LARGE),
                 ),
                 KeyItemC(
-                    center = KeyC("g", size = LARGE),
+                    center = KeyC("u", size = LARGE),
                 ),
                 KeyItemC(
                     center = KeyC("k", size = LARGE),
@@ -50,10 +50,10 @@ val KB_EN_WHALE_MAIN =
                     right = KeyC("x"),
                 ),
                 KeyItemC(
-                    center = KeyC("u", size = LARGE),
+                    center = KeyC("g", size = LARGE),
                 ),
                 NUMERIC_KEY_ITEM.copy(
-                    center = KeyC("m", size = LARGE),
+                    center = KeyC("y", size = LARGE),
                     right =
                         TOGGLE_NUMERIC_MODE_TRUE_KEYC.copy(
                             size = SMALL,
@@ -64,10 +64,10 @@ val KB_EN_WHALE_MAIN =
             ),
             listOf(
                 KeyItemC(
-                    center = KeyC("d", size = LARGE),
+                    center = KeyC("c", size = LARGE),
                 ),
                 KeyItemC(
-                    center = KeyC("i", size = LARGE),
+                    center = KeyC("l", size = LARGE),
                 ),
                 KeyItemC(
                     center = KeyC(".", size = LARGE),
@@ -83,10 +83,10 @@ val KB_EN_WHALE_MAIN =
                     backgroundColor = SURFACE_VARIANT,
                 ),
                 KeyItemC(
-                    center = KeyC("l", size = LARGE),
+                    center = KeyC("i", size = LARGE),
                 ),
                 KeyItemC(
-                    center = KeyC("c", size = LARGE),
+                    center = KeyC("d", size = LARGE),
                     top =
                         KeyC(
                             display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
@@ -103,32 +103,32 @@ val KB_EN_WHALE_MAIN =
             ),
             listOf(
                 KeyItemC(
-                    center = KeyC("o", size = LARGE),
+                    center = KeyC("r", size = LARGE),
                 ),
-                KeyItemC(
-                    center = KeyC("a", size = LARGE),
-                ),
-                BACKSPACE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("h", size = LARGE),
                 ),
+                BACKSPACE_KEY_ITEM,
                 KeyItemC(
-                    center = KeyC("r", size = LARGE),
+                    center = KeyC("a", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("o", size = LARGE),
                 ),
             ),
             listOf(
                 KeyItemC(
-                    center = KeyC("t", size = LARGE),
+                    center = KeyC("s", size = LARGE),
                 ),
-                KeyItemC(
-                    center = KeyC("e", size = LARGE),
-                ),
-                SPACEBAR_SKINNY_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
                 ),
+                SPACEBAR_SKINNY_KEY_ITEM,
                 KeyItemC(
-                    center = KeyC("s", size = LARGE),
+                    center = KeyC("e", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("t", size = LARGE),
                 ),
             ),
         ),
@@ -139,19 +139,19 @@ val KB_EN_WHALE_SHIFTED =
         listOf(
             listOf(
                 KeyItemC(
-                    center = KeyC("B", size = LARGE),
+                    center = KeyC("F", size = LARGE),
                 ),
                 KeyItemC(
-                    center = KeyC("P", size = LARGE),
+                    center = KeyC("W", size = LARGE),
                 ),
                 KeyItemC(
                     center = KeyC("V", size = LARGE),
                 ),
                 KeyItemC(
-                    center = KeyC("W", size = LARGE),
+                    center = KeyC("P", size = LARGE),
                 ),
                 EMOJI_KEY_ITEM.copy(
-                    center = KeyC("F", size = LARGE),
+                    center = KeyC("B", size = LARGE),
                     right =
                         TOGGLE_EMOJI_MODE_TRUE_KEYC.copy(
                             size = SMALL,
@@ -162,10 +162,10 @@ val KB_EN_WHALE_SHIFTED =
             ),
             listOf(
                 KeyItemC(
-                    center = KeyC("Y", size = LARGE),
+                    center = KeyC("M", size = LARGE),
                 ),
                 KeyItemC(
-                    center = KeyC("G", size = LARGE),
+                    center = KeyC("U", size = LARGE),
                 ),
                 KeyItemC(
                     center = KeyC("K", size = LARGE),
@@ -175,10 +175,10 @@ val KB_EN_WHALE_SHIFTED =
                     right = KeyC("X"),
                 ),
                 KeyItemC(
-                    center = KeyC("U", size = LARGE),
+                    center = KeyC("G", size = LARGE),
                 ),
                 NUMERIC_KEY_ITEM.copy(
-                    center = KeyC("M", size = LARGE),
+                    center = KeyC("Y", size = LARGE),
                     right =
                         TOGGLE_NUMERIC_MODE_TRUE_KEYC.copy(
                             size = SMALL,
@@ -189,10 +189,10 @@ val KB_EN_WHALE_SHIFTED =
             ),
             listOf(
                 KeyItemC(
-                    center = KeyC("D", size = LARGE),
+                    center = KeyC("C", size = LARGE),
                 ),
                 KeyItemC(
-                    center = KeyC("I", size = LARGE),
+                    center = KeyC("L", size = LARGE),
                 ),
                 KeyItemC(
                     center = KeyC(".", size = LARGE),
@@ -208,10 +208,10 @@ val KB_EN_WHALE_SHIFTED =
                     backgroundColor = SURFACE_VARIANT,
                 ),
                 KeyItemC(
-                    center = KeyC("L", size = LARGE),
+                    center = KeyC("I", size = LARGE),
                 ),
                 KeyItemC(
-                    center = KeyC("C", size = LARGE),
+                    center = KeyC("D", size = LARGE),
                     bottom =
                         KeyC(
                             display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
@@ -231,32 +231,32 @@ val KB_EN_WHALE_SHIFTED =
             ),
             listOf(
                 KeyItemC(
-                    center = KeyC("O", size = LARGE),
+                    center = KeyC("R", size = LARGE),
                 ),
-                KeyItemC(
-                    center = KeyC("A", size = LARGE),
-                ),
-                BACKSPACE_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("H", size = LARGE),
                 ),
+                BACKSPACE_KEY_ITEM,
                 KeyItemC(
-                    center = KeyC("R", size = LARGE),
+                    center = KeyC("A", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("O", size = LARGE),
                 ),
             ),
             listOf(
                 KeyItemC(
-                    center = KeyC("T", size = LARGE),
+                    center = KeyC("S", size = LARGE),
                 ),
-                KeyItemC(
-                    center = KeyC("E", size = LARGE),
-                ),
-                SPACEBAR_SKINNY_KEY_ITEM,
                 KeyItemC(
                     center = KeyC("N", size = LARGE),
                 ),
+                SPACEBAR_SKINNY_KEY_ITEM,
                 KeyItemC(
-                    center = KeyC("S", size = LARGE),
+                    center = KeyC("E", size = LARGE),
+                ),
+                KeyItemC(
+                    center = KeyC("T", size = LARGE),
                 ),
             ),
         ),

--- a/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
@@ -61,6 +61,7 @@ import com.dessalines.thumbkey.keyboards.KB_EN_MESSAGEASE_SYMBOLS_MODIFIERS
 import com.dessalines.thumbkey.keyboards.KB_EN_MESSAGEASE_SYMBOLS_TWO_HANDS
 import com.dessalines.thumbkey.keyboards.KB_EN_MESSAGEASE_TWO_HANDS
 import com.dessalines.thumbkey.keyboards.KB_EN_MESSAGEASE_WRITER
+import com.dessalines.thumbkey.keyboards.KB_EN_MINNOW
 import com.dessalines.thumbkey.keyboards.KB_EN_MI_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_EN_MI_THUMBKEY_SYMBOLS
 import com.dessalines.thumbkey.keyboards.KB_EN_NL_TYPESPLIT
@@ -468,4 +469,5 @@ enum class KeyboardLayout(
     BNThumbKey(KB_BN_THUMBKEY), // বাংলা thumb-key
     ENWhale(KB_EN_WHALE),
     ENMarlin(KB_EN_MARLIN),
+    ENMinnow(KB_EN_MINNOW)
 }

--- a/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
@@ -469,5 +469,5 @@ enum class KeyboardLayout(
     BNThumbKey(KB_BN_THUMBKEY), // বাংলা thumb-key
     ENWhale(KB_EN_WHALE),
     ENMarlin(KB_EN_MARLIN),
-    ENMinnow(KB_EN_MINNOW)
+    ENMinnow(KB_EN_MINNOW),
 }


### PR DESCRIPTION
Flipping a few of these layouts, and making some changes to whale:

<img height="300" alt="Screenshot_2026-07-11-16-37-01-65_e4424258c8b8649f6e67d283a50a2cbc" src="https://github.com/user-attachments/assets/ac01007e-a830-45e6-9cf4-cbb8799bafde" />

Added a `Minnow` layout (3x3), but I'm not really satisfied with it yet.
