### PR TITLE
Add delete character after cursor action

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ This swaps the 'switch language' and 'toggle emoji' actions on the top-right key
 - `Undo`
 - `Redo`
 - `Delete`
+- `DeleteCharacterAfterCursor`
 - `DeleteWordBeforeCursor`
 - `DeleteWordAfterCursor`
 - `SwitchLanguage`

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/CommonKeys.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/CommonKeys.kt
@@ -255,6 +255,11 @@ val BACKSPACE_TEXT_MANIPULATION_KEYC =
         size = LARGE,
         color = SECONDARY,
     )
+val DELETE_CHARACTER_AFTER_CURSOR_KEYC =
+    KeyC(
+        DeleteCharacterAfterCursor,
+        display = null,
+    )
 val DELETE_WORD_BEFORE_CURSOR_KEYC =
     KeyC(
         DeleteWordBeforeCursor,

--- a/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardModificationService.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardModificationService.kt
@@ -13,6 +13,7 @@ import com.dessalines.thumbkey.keyboards.BACKSPACE_KEYC
 import com.dessalines.thumbkey.keyboards.BACKSPACE_TEXT_MANIPULATION_KEYC
 import com.dessalines.thumbkey.keyboards.COPY_KEYC
 import com.dessalines.thumbkey.keyboards.CUT_KEYC
+import com.dessalines.thumbkey.keyboards.DELETE_CHARACTER_AFTER_CURSOR_KEYC
 import com.dessalines.thumbkey.keyboards.DELETE_WORD_AFTER_CURSOR_KEYC
 import com.dessalines.thumbkey.keyboards.DELETE_WORD_BEFORE_CURSOR_KEYC
 import com.dessalines.thumbkey.keyboards.GOTO_SETTINGS_KEYC
@@ -305,6 +306,7 @@ fun getCommonKeyCFromKeyAction(keyActionSerializable: KeyActionSerializable?): K
         KeyActionSerializable.Undo -> UNDO_KEYC
         KeyActionSerializable.Redo -> REDO_KEYC
         KeyActionSerializable.Delete -> BACKSPACE_KEYC
+        KeyActionSerializable.DeleteCharacterAfterCursor -> DELETE_CHARACTER_AFTER_CURSOR_KEYC
         KeyActionSerializable.DeleteViaTextManipulation -> BACKSPACE_TEXT_MANIPULATION_KEYC
         KeyActionSerializable.DeleteWordBeforeCursor -> DELETE_WORD_BEFORE_CURSOR_KEYC
         KeyActionSerializable.DeleteWordAfterCursor -> DELETE_WORD_AFTER_CURSOR_KEYC
@@ -509,6 +511,7 @@ enum class KeyActionSerializable {
     PreviousWordBeforeCursor,
     NextWordAfterCursor,
     Delete,
+    DeleteCharacterAfterCursor,
     DeleteViaTextManipulation,
     DeleteWordBeforeCursor,
     DeleteWordAfterCursor,

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
@@ -252,6 +252,8 @@ sealed class KeyAction {
 
     data object DeleteKeyAction : KeyAction()
 
+    data object DeleteCharacterAfterCursor : KeyAction()
+
     data object DeleteViaTextManipulation : KeyAction()
 
     data object DeleteWordBeforeCursor : KeyAction()

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Utils.kt
@@ -390,6 +390,12 @@ fun performKeyAction(
                 ?: ime.currentInputConnection.sendKeyEvent(ev)
         }
 
+        is KeyAction.DeleteCharacterAfterCursor -> {
+            val ev = KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_FORWARD_DEL)
+            keyboardSettings.textProcessor?.handleKeyEvent(ime, ev)
+                ?: ime.currentInputConnection.sendKeyEvent(ev)
+        }
+
         // Alternative delete that uses deleteSurroundingText instead of KEYCODE_DEL.
         // Some apps (like Google Chat) ignore key events from soft keyboards but respond
         // to text manipulation. Users can assign this via YAML key modifications.


### PR DESCRIPTION
Closes #1708

Adds a new `DeleteCharacterAfterCursor` key action for deleting one
character to the right of the cursor.

### Changes

- Adds `DeleteCharacterAfterCursor` as a new `KeyAction`.
- Handles it using Android's `KEYCODE_FORWARD_DEL`, mirroring the existing
  delete/backspace action.
- Exposes the action to YAML key modifications.
- Adds the action to the README key action list.
- Leaves all default keyboard layouts unchanged.

### Testing

- Ran `./gradlew formatKotlin`.
- Ran `./gradlew lintKotlin testDebugUnitTest assembleDebug`.
- Tested on a physical device.
- Verified deletion immediately to the right of the cursor.
- Verified that using the action at the end of the text does nothing.
- Verified the action through a YAML key modification.