### PR TITLE
Add English based Romanian hyper and hyper space keyboard layouts

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENROHyper.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENROHyper.kt
@@ -30,7 +30,7 @@ val KB_EN_RO_HYPER_MAIN =
                     bottom = KeyC("!", color = MUTED),
                     top = KeyC("â"),
                     left = KeyC("j"),
-                    right = Keyc("ă"),
+                    right = KeyC("ă"),
                 ),
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
@@ -214,7 +214,7 @@ val KB_EN_RO_HYPER_SHIFTED =
                     center = KeyC("I", size = LARGE),
                     swipeType = FOUR_WAY_CROSS,
                     left = KeyC(":", color = MUTED),
-                    right = ("Î"),
+                    right = KeyC("Î"),
                     top = KeyC("'", color = MUTED),
                 ),
                 KeyItemC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENROHyper.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENROHyper.kt
@@ -1,0 +1,250 @@
+@file:Suppress("ktlint:standard:no-wildcard-imports")
+
+package com.dessalines.thumbkey.keyboards
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowDropDown
+import androidx.compose.material.icons.outlined.ArrowDropUp
+import androidx.compose.material.icons.outlined.Copyright
+import androidx.compose.material.icons.outlined.KeyboardCapslock
+import com.dessalines.thumbkey.utils.*
+import com.dessalines.thumbkey.utils.ColorVariant.*
+import com.dessalines.thumbkey.utils.FontSizeVariant.*
+import com.dessalines.thumbkey.utils.KeyAction.*
+import com.dessalines.thumbkey.utils.SwipeNWay.*
+
+val KB_EN_RO_HYPER_MAIN =
+    KeyboardC(
+        listOf(
+            listOf(
+                RETURN_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("u", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("`", color = MUTED),
+                    bottom = KeyC("x"),
+                ),
+                KeyItemC(
+                    center = KeyC("a", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    bottom = KeyC("!", color = MUTED),
+                    top = KeyC("â"),
+                    left = KeyC("j"),
+                    right = Keyc("ă"),
+                ),
+                KeyItemC(
+                    center = KeyC("n", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("b"),
+                    bottom = KeyC("d"),
+                ),
+                KeyItemC(
+                    center = KeyC("l", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("@", color = MUTED),
+                    bottom = KeyC("y"),
+                ),
+                BACKSPACE_KEY_ITEM,
+            ),
+            listOf(
+                SPACEBAR_SKINNY_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("o", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("k"),
+                    top =
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
+                            action = ToggleShiftMode(true),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(true),
+                            color = MUTED,
+                        ),
+                    bottom =
+                        KeyC(
+                            ToggleShiftMode(false),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(false),
+                        ),
+                ),
+                KeyItemC(
+                    center = KeyC("e", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC(".", color = MUTED),
+                    top = KeyC(",", color = MUTED),
+                    bottom = KeyC("?", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("t", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("ț"),
+                    right = KeyC("p"),
+                    bottom = KeyC("w"),
+                    top = KeyC("m"),
+                ),
+                KeyItemC(
+                    center = KeyC("s", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("c"),
+                    right = KeyC("ș"),
+                    bottom = KeyC("q"),
+                    top = KeyC("-", color = MUTED),
+                ),
+                SPACEBAR_SKINNY_KEY_ITEM,
+            ),
+            listOf(
+                NUMERIC_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("g", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("\"", color = MUTED),
+                    top = KeyC("z"),
+                ),
+                KeyItemC(
+                    center = KeyC("i", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    top = KeyC("'", color = MUTED),
+                    left = KeyC(";", color = MUTED),
+                    right = KeyC("î"),
+                ),
+                KeyItemC(
+                    center = KeyC("h", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("f"),
+                    top = KeyC("v"),
+                ),
+                KeyItemC(
+                    center = KeyC("r", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("#", color = MUTED),
+                    top = KeyC("/", color = MUTED),
+                ),
+                EMOJI_KEY_ITEM,
+            ),
+        ),
+    )
+
+val KB_EN_RO_HYPER_SHIFTED =
+    KeyboardC(
+        listOf(
+            listOf(
+                RETURN_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("U", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("~", color = MUTED),
+                    bottom = KeyC("X"),
+                ),
+                KeyItemC(
+                    center = KeyC("A", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    bottom = KeyC("!", color = MUTED),
+                    top = KeyC("Â"),
+                    left = KeyC("J"),
+                    right = KeyC("Ă"),
+                ),
+                KeyItemC(
+                    center = KeyC("N", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("B"),
+                    bottom = KeyC("D"),
+                ),
+                KeyItemC(
+                    center = KeyC("L", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("@", color = MUTED),
+                    bottom = KeyC("Y"),
+                ),
+                BACKSPACE_KEY_ITEM,
+            ),
+            listOf(
+                SPACEBAR_SKINNY_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("O", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("K"),
+                    top =
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.Outlined.KeyboardCapslock),
+                            capsModeDisplay = KeyDisplay.IconDisplay(Icons.Outlined.Copyright),
+                            action = ToggleCapsLock,
+                            swipeReturnAction = ToggleCurrentWordCapitalization(true),
+                            color = MUTED,
+                        ),
+                    bottom =
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
+                            action = ToggleShiftMode(false),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(false),
+                            color = MUTED,
+                        ),
+                ),
+                KeyItemC(
+                    center = KeyC("E", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC(".", color = MUTED),
+                    top = KeyC(",", color = MUTED),
+                    bottom = KeyC("?", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("T", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("Ț"),
+                    right = KeyC("P"),
+                    top = KeyC("M"),
+                    bottom = KeyC("W"),
+                ),
+                KeyItemC(
+                    center = KeyC("S", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("C"),
+                    right = KeyC("Ș"),
+                    top = KeyC("_", color = MUTED),
+                    bottom = KeyC("Q"),
+                ),
+                SPACEBAR_SKINNY_KEY_ITEM,
+            ),
+            listOf(
+                NUMERIC_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("G", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("\"", color = MUTED),
+                    top = KeyC("Z"),
+                ),
+                KeyItemC(
+                    center = KeyC("I", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC(":", color = MUTED),
+                    right = ("Î"),
+                    top = KeyC("'", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("H", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("F"),
+                    top = KeyC("V"),
+                ),
+                KeyItemC(
+                    center = KeyC("R", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("#", color = MUTED),
+                    top = KeyC("/", color = MUTED),
+                ),
+                EMOJI_KEY_ITEM,
+            ),
+        ),
+    )
+
+val KB_EN_RO_HYPER: KeyboardDefinition =
+    KeyboardDefinition(
+        title = "english română hyper",
+        modes =
+            KeyboardDefinitionModes(
+                main = KB_EN_RO_HYPER_MAIN,
+                shifted = KB_EN_RO_HYPER_SHIFTED,
+                numeric = HYPER_NUMERIC_KEYBOARD,
+            ),
+        settings =
+            KeyboardDefinitionSettings(
+                autoCapitalizers = arrayOf(::autoCapitalizeI, ::autoCapitalizeIApostrophe),
+            ),
+    )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENROHyperSpace.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENROHyperSpace.kt
@@ -30,7 +30,7 @@ val KB_EN_RO_HYPER_SPACE_MAIN =
                     bottom = KeyC("!", color = MUTED),
                     top = KeyC("â"),
                     left = KeyC("j"),
-                    right = Keyc("ă"),
+                    right = KeyC("ă"),
                 ),
                 KeyItemC(
                     center = KeyC("n", size = LARGE),
@@ -219,7 +219,7 @@ val KB_EN_RO_HYPER_SPACE_SHIFTED =
                     center = KeyC("I", size = LARGE),
                     swipeType = FOUR_WAY_CROSS,
                     left = KeyC(":", color = MUTED),
-                    right = ("Î"),
+                    right = KeyC("Î"),
                     top = KeyC("'", color = MUTED),
                 ),
                 KeyItemC(

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENROHyperSpace.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENROHyperSpace.kt
@@ -1,0 +1,250 @@
+@file:Suppress("ktlint:standard:no-wildcard-imports")
+
+package com.dessalines.thumbkey.keyboards
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowDropDown
+import androidx.compose.material.icons.outlined.ArrowDropUp
+import androidx.compose.material.icons.outlined.Copyright
+import androidx.compose.material.icons.outlined.KeyboardCapslock
+import com.dessalines.thumbkey.utils.*
+import com.dessalines.thumbkey.utils.ColorVariant.*
+import com.dessalines.thumbkey.utils.FontSizeVariant.*
+import com.dessalines.thumbkey.utils.KeyAction.*
+import com.dessalines.thumbkey.utils.SwipeNWay.*
+
+val KB_EN_RO_HYPER_SPACE_MAIN =
+    KeyboardC(
+        listOf(
+            listOf(
+                RETURN_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("u", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("`", color = MUTED),
+                    bottom = KeyC("x"),
+                ),
+                KeyItemC(
+                    center = KeyC("a", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    bottom = KeyC("!", color = MUTED),
+                    top = KeyC("â"),
+                    left = KeyC("j"),
+                    right = Keyc("ă"),
+                ),
+                KeyItemC(
+                    center = KeyC("n", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("b"),
+                    bottom = KeyC("d"),
+                ),
+                KeyItemC(
+                    center = KeyC("l", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("@", color = MUTED),
+                    bottom = KeyC("y"),
+                ),
+                BACKSPACE_KEY_ITEM,
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("g", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("\"", color = MUTED),
+                    top = KeyC("z"),
+                ),
+                KeyItemC(
+                    center = KeyC("o", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("k"),
+                    top =
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
+                            action = ToggleShiftMode(true),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(true),
+                            color = MUTED,
+                        ),
+                    bottom =
+                        KeyC(
+                            ToggleShiftMode(false),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(false),
+                        ),
+                ),
+                KeyItemC(
+                    center = KeyC("e", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC(".", color = MUTED),
+                    top = KeyC(",", color = MUTED),
+                    bottom = KeyC("?", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("t", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("ț"),
+                    right = KeyC("p"),
+                    bottom = KeyC("w"),
+                    top = KeyC("m"),
+                ),
+                KeyItemC(
+                    center = KeyC("s", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("c"),
+                    right = KeyC("ș"),
+                    bottom = KeyC("q"),
+                    top = KeyC("-", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("r", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("#", color = MUTED),
+                    top = KeyC("/", color = MUTED),
+                ),
+            ),
+            listOf(
+                NUMERIC_KEY_ITEM,
+                SPACEBAR_SKINNY_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("i", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    top = KeyC("'", color = MUTED),
+                    left = KeyC(";", color = MUTED),
+                    right = KeyC("î"),
+                ),
+                KeyItemC(
+                    center = KeyC("h", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("f"),
+                    top = KeyC("v"),
+                ),
+                SPACEBAR_SKINNY_KEY_ITEM,
+                EMOJI_KEY_ITEM,
+            ),
+        ),
+    )
+
+val KB_EN_RO_HYPER_SPACE_SHIFTED =
+    KeyboardC(
+        listOf(
+            listOf(
+                RETURN_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("U", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("~", color = MUTED),
+                    bottom = KeyC("X"),
+                ),
+                KeyItemC(
+                    center = KeyC("A", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    bottom = KeyC("!", color = MUTED),
+                    top = KeyC("Â"),
+                    left = KeyC("J"),
+                    right = KeyC("Ă"),
+                ),
+                KeyItemC(
+                    center = KeyC("N", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("B"),
+                    bottom = KeyC("D"),
+                ),
+                KeyItemC(
+                    center = KeyC("L", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("@", color = MUTED),
+                    bottom = KeyC("Y"),
+                ),
+                BACKSPACE_KEY_ITEM,
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("G", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("\"", color = MUTED),
+                    top = KeyC("Z"),
+                ),
+                KeyItemC(
+                    center = KeyC("O", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("K"),
+                    top =
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.Outlined.KeyboardCapslock),
+                            capsModeDisplay = KeyDisplay.IconDisplay(Icons.Outlined.Copyright),
+                            action = ToggleCapsLock,
+                            swipeReturnAction = ToggleCurrentWordCapitalization(true),
+                            color = MUTED,
+                        ),
+                    bottom =
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
+                            action = ToggleShiftMode(false),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(false),
+                            color = MUTED,
+                        ),
+                ),
+                KeyItemC(
+                    center = KeyC("E", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC(".", color = MUTED),
+                    top = KeyC(",", color = MUTED),
+                    bottom = KeyC("?", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("T", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("Ț"),
+                    right = KeyC("P"),
+                    top = KeyC("M"),
+                    bottom = KeyC("W"),
+                ),
+                KeyItemC(
+                    center = KeyC("S", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("C"),
+                    right = KeyC("Ș"),
+                    top = KeyC("_", color = MUTED),
+                    bottom = KeyC("Q"),
+                ),
+                KeyItemC(
+                    center = KeyC("R", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("#", color = MUTED),
+                    top = KeyC("/", color = MUTED),
+                ),
+            ),
+            listOf(
+                NUMERIC_KEY_ITEM,
+                SPACEBAR_SKINNY_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("I", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC(":", color = MUTED),
+                    right = ("Î"),
+                    top = KeyC("'", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("H", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("F"),
+                    top = KeyC("V"),
+                ),
+                SPACEBAR_SKINNY_KEY_ITEM,
+                EMOJI_KEY_ITEM,
+            ),
+        ),
+    )
+
+val KB_EN_RO_HYPER_SPACE: KeyboardDefinition =
+    KeyboardDefinition(
+        title = "english română hyper space",
+        modes =
+            KeyboardDefinitionModes(
+                main = KB_EN_RO_HYPER_SPACE_MAIN,
+                shifted = KB_EN_RO_HYPER_SPACE_SHIFTED,
+                numeric = HYPER_NUMERIC_KEYBOARD,
+            ),
+        settings =
+            KeyboardDefinitionSettings(
+                autoCapitalizers = arrayOf(::autoCapitalizeI, ::autoCapitalizeIApostrophe),
+            ),
+    )

--- a/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
@@ -340,8 +340,6 @@ enum class KeyboardLayout(
     EOCyrillicThumbKey(KB_EO_CYRILLIC_THUMBKEY), // esperanto cyrillic thumb-key
     HUTypeSplit(KB_HU_TYPESPLIT), // magyar type-split
     ENROThumbKey(KB_EN_RO_THUMBKEY), // english română thumb-key
-    ENROHyper(KB_EN_RO_HYPER), // english română hyper
-    ENROHyperSpace(KB_EN_RO_HYPER_SPACE), // english română hyper space
     ENLAThumbKey(KB_EN_LA_THUMBKEY), // english latina thumb-key
     NLTypeSplit(KB_NL_TYPESPLIT), // nederlands type-split
     PLMessagEase(KB_PL_MESSAGEASE), // polski messagease
@@ -480,4 +478,6 @@ enum class KeyboardLayout(
     MYWhale(KB_MY_WHALE), // myanmar whale
     ENThumbKeyCompact(KB_EN_THUMBKEY_COMPACT), // english thumb-key compact
     ENThumbKeyWordsShift(KB_EN_THUMBKEY_WORDS_SHIFT), // english thumb-key words shift
+    ENROHyper(KB_EN_RO_HYPER), // english română hyper
+    ENROHyperSpace(KB_EN_RO_HYPER_SPACE), // english română hyper space
 }

--- a/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
@@ -76,8 +76,8 @@ import com.dessalines.thumbkey.keyboards.KB_EN_QWERTEASE
 import com.dessalines.thumbkey.keyboards.KB_EN_QWERTEASE_TWO_HANDS
 import com.dessalines.thumbkey.keyboards.KB_EN_QWERTYFOUR
 import com.dessalines.thumbkey.keyboards.KB_EN_QWERTYFOUR_COMPOSE
-import com.dessalines.thumbkey.keyboards.KB_EN_RO_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_EN_RO_HYPER
+import com.dessalines.thumbkey.keyboards.KB_EN_RO_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_EN_RSINOA
 import com.dessalines.thumbkey.keyboards.KB_EN_SK_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_EN_SV_THUMBKEY_PROGRAMMING
@@ -339,7 +339,7 @@ enum class KeyboardLayout(
     EOCyrillicThumbKey(KB_EO_CYRILLIC_THUMBKEY), // esperanto cyrillic thumb-key
     HUTypeSplit(KB_HU_TYPESPLIT), // magyar type-split
     ENROThumbKey(KB_EN_RO_THUMBKEY), // english română thumb-key
-	ENROHyper(KB_EN_RO_HYPER),
+    ENROHyper(KB_EN_RO_HYPER),
     ENLAThumbKey(KB_EN_LA_THUMBKEY), // english latina thumb-key
     NLTypeSplit(KB_NL_TYPESPLIT), // nederlands type-split
     PLMessagEase(KB_PL_MESSAGEASE), // polski messagease

--- a/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
@@ -77,6 +77,7 @@ import com.dessalines.thumbkey.keyboards.KB_EN_QWERTEASE_TWO_HANDS
 import com.dessalines.thumbkey.keyboards.KB_EN_QWERTYFOUR
 import com.dessalines.thumbkey.keyboards.KB_EN_QWERTYFOUR_COMPOSE
 import com.dessalines.thumbkey.keyboards.KB_EN_RO_THUMBKEY
+import com.dessalines.thumbkey.keyboards.KB_EN_RO_HYPER
 import com.dessalines.thumbkey.keyboards.KB_EN_RSINOA
 import com.dessalines.thumbkey.keyboards.KB_EN_SK_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_EN_SV_THUMBKEY_PROGRAMMING
@@ -338,6 +339,7 @@ enum class KeyboardLayout(
     EOCyrillicThumbKey(KB_EO_CYRILLIC_THUMBKEY), // esperanto cyrillic thumb-key
     HUTypeSplit(KB_HU_TYPESPLIT), // magyar type-split
     ENROThumbKey(KB_EN_RO_THUMBKEY), // english română thumb-key
+	ENROHyper(KB_EN_RO_HYPER),
     ENLAThumbKey(KB_EN_LA_THUMBKEY), // english latina thumb-key
     NLTypeSplit(KB_NL_TYPESPLIT), // nederlands type-split
     PLMessagEase(KB_PL_MESSAGEASE), // polski messagease

--- a/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
@@ -77,6 +77,7 @@ import com.dessalines.thumbkey.keyboards.KB_EN_QWERTEASE_TWO_HANDS
 import com.dessalines.thumbkey.keyboards.KB_EN_QWERTYFOUR
 import com.dessalines.thumbkey.keyboards.KB_EN_QWERTYFOUR_COMPOSE
 import com.dessalines.thumbkey.keyboards.KB_EN_RO_HYPER
+import com.dessalines.thumbkey.keyboards.KB_EN_RO_HYPER_SPACE
 import com.dessalines.thumbkey.keyboards.KB_EN_RO_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_EN_RSINOA
 import com.dessalines.thumbkey.keyboards.KB_EN_SK_THUMBKEY
@@ -339,7 +340,8 @@ enum class KeyboardLayout(
     EOCyrillicThumbKey(KB_EO_CYRILLIC_THUMBKEY), // esperanto cyrillic thumb-key
     HUTypeSplit(KB_HU_TYPESPLIT), // magyar type-split
     ENROThumbKey(KB_EN_RO_THUMBKEY), // english română thumb-key
-    ENROHyper(KB_EN_RO_HYPER),
+    ENROHyper(KB_EN_RO_HYPER), // english română hyper
+    ENROHyperSpace(KB_EN_RO_HYPER_SPACE), // english română hyper space
     ENLAThumbKey(KB_EN_LA_THUMBKEY), // english latina thumb-key
     NLTypeSplit(KB_NL_TYPESPLIT), // nederlands type-split
     PLMessagEase(KB_PL_MESSAGEASE), // polski messagease


### PR DESCRIPTION
Added English based Romanian hyper and hyper space layouts based on the contribution guidelines.

It isn't based on a letter frequency chart since it's meant to be similar to English and because Romanian's letter frequency is more or less similar and mostly uses the same Latin characters.