### PR TITLE
Add Russian hyper space keyboard layout

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/RUHyperSpace.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/RUHyperSpace.kt
@@ -1,0 +1,254 @@
+@file:Suppress("ktlint:standard:no-wildcard-imports")
+
+package com.dessalines.thumbkey.keyboards
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowDropDown
+import androidx.compose.material.icons.outlined.ArrowDropUp
+import androidx.compose.material.icons.outlined.Copyright
+import androidx.compose.material.icons.outlined.KeyboardCapslock
+import com.dessalines.thumbkey.utils.*
+import com.dessalines.thumbkey.utils.ColorVariant.*
+import com.dessalines.thumbkey.utils.FontSizeVariant.*
+import com.dessalines.thumbkey.utils.KeyAction.*
+import com.dessalines.thumbkey.utils.SwipeNWay.*
+
+val KB_RU_HYPER_SPACE_MAIN =
+    KeyboardC(
+        listOf(
+            listOf(
+                RETURN_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("н", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("`", color = MUTED),
+                    bottom = KeyC("ж"),
+                ),
+                KeyItemC(
+                    center = KeyC("с", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    bottom = KeyC("!", color = MUTED),
+                    left = KeyC("э"),
+                    right = KeyC("ы"),
+                ),
+                KeyItemC(
+                    center = KeyC("в", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("у"),
+                    bottom = KeyC("ш"),
+                ),
+                KeyItemC(
+                    center = KeyC("о", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("@", color = MUTED),
+                    bottom = KeyC("й"),
+                    right = KeyC("я"),
+                ),
+                BACKSPACE_KEY_ITEM,
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("р", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("\"", color = MUTED),
+                    top = KeyC("ё"),
+                    left = KeyC("щ"),
+                ),
+                KeyItemC(
+                    center = KeyC("т", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("б"),
+                    top =
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
+                            action = ToggleShiftMode(true),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(true),
+                            color = MUTED,
+                        ),
+                    bottom =
+                        KeyC(
+                            ToggleShiftMode(false),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(false),
+                        ),
+                ),
+                KeyItemC(
+                    center = KeyC("а", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC(".", color = MUTED),
+                    top = KeyC(",", color = MUTED),
+                    bottom = KeyC("?", color = MUTED),
+                    right = KeyC("д"),
+                ),
+                KeyItemC(
+                    center = KeyC("л", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("п"),
+                    bottom = KeyC("х"),
+                    top = KeyC("ф"),
+                ),
+                KeyItemC(
+                    center = KeyC("е", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("ц"),
+                    bottom = KeyC("ю"),
+                    top = KeyC("-", color = MUTED),
+                    right = KeyC("г"),
+                ),
+                KeyItemC(
+                    center = KeyC("м", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("#", color = MUTED),
+                    top = KeyC("/", color = MUTED),
+                    right = KeyC("ь"),
+                ),
+            ),
+            listOf(
+                NUMERIC_KEY_ITEM,
+                SPACEBAR_SKINNY_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("и", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    top = KeyC("'", color = MUTED),
+                    left = KeyC(";", color = MUTED),
+                    right = KeyC("з"),
+                ),
+                KeyItemC(
+                    center = KeyC("к", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("ч"),
+                    top = KeyC("ъ"),
+                ),
+                SPACEBAR_SKINNY_KEY_ITEM,
+                EMOJI_KEY_ITEM,
+            ),
+        ),
+    )
+
+val KB_RU_HYPER_SPACE_SHIFTED =
+    KeyboardC(
+        listOf(
+            listOf(
+                RETURN_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("Н", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("~", color = MUTED),
+                    bottom = KeyC("Ж"),
+                ),
+                KeyItemC(
+                    center = KeyC("С", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    bottom = KeyC("!", color = MUTED),
+                    left = KeyC("Э"),
+                    right = KeyC("Ы"),
+                ),
+                KeyItemC(
+                    center = KeyC("В", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("У"),
+                    bottom = KeyC("Ш"),
+                ),
+                KeyItemC(
+                    center = KeyC("О", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("@", color = MUTED),
+                    bottom = KeyC("Й"),
+                    right = KeyC("Я"),
+                ),
+                BACKSPACE_KEY_ITEM,
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("Р", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("\"", color = MUTED),
+                    top = KeyC("Ё"),
+                    left = KeyC("Щ"),
+                ),
+                KeyItemC(
+                    center = KeyC("Т", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("Б"),
+                    top =
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.Outlined.KeyboardCapslock),
+                            capsModeDisplay = KeyDisplay.IconDisplay(Icons.Outlined.Copyright),
+                            action = ToggleCapsLock,
+                            swipeReturnAction = ToggleCurrentWordCapitalization(true),
+                            color = MUTED,
+                        ),
+                    bottom =
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
+                            action = ToggleShiftMode(false),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(false),
+                            color = MUTED,
+                        ),
+                ),
+                KeyItemC(
+                    center = KeyC("А", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC(".", color = MUTED),
+                    top = KeyC(",", color = MUTED),
+                    bottom = KeyC("?", color = MUTED),
+                    right = KeyC("Д"),
+                ),
+                KeyItemC(
+                    center = KeyC("Л", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("П"),
+                    bottom = KeyC("Х"),
+                    top = KeyC("Ф"),
+                ),
+                KeyItemC(
+                    center = KeyC("Е", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("Ц"),
+                    bottom = KeyC("Ю"),
+                    top = KeyC("_", color = MUTED),
+                    right = KeyC("Г"),
+                ),
+                KeyItemC(
+                    center = KeyC("М", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    left = KeyC("#", color = MUTED),
+                    top = KeyC("/", color = MUTED),
+                    right = KeyC("Ь"),
+                ),
+            ),
+            listOf(
+                NUMERIC_KEY_ITEM,
+                SPACEBAR_SKINNY_KEY_ITEM,
+                KeyItemC(
+                    center = KeyC("И", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    top = KeyC("'", color = MUTED),
+                    left = KeyC(":", color = MUTED),
+                    right = KeyC("З"),
+                ),
+                KeyItemC(
+                    center = KeyC("К", size = LARGE),
+                    swipeType = FOUR_WAY_CROSS,
+                    right = KeyC("Ч"),
+                    top = KeyC("Ъ"),
+                ),
+                SPACEBAR_SKINNY_KEY_ITEM,
+                EMOJI_KEY_ITEM,
+            ),
+        ),
+    )
+
+val KB_RU_HYPER_SPACE: KeyboardDefinition =
+    KeyboardDefinition(
+        title = "русский hyper space",
+        modes =
+            KeyboardDefinitionModes(
+                main = KB_RU_HYPER_SPACE_MAIN,
+                shifted = KB_RU_HYPER_SPACE_SHIFTED,
+                numeric = HYPER_NUMERIC_KEYBOARD,
+            ),
+        settings =
+            KeyboardDefinitionSettings(
+                autoCapitalizers = arrayOf(::autoCapitalizeI, ::autoCapitalizeIApostrophe),
+            ),
+    )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/RUHyperSpace.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/RUHyperSpace.kt
@@ -50,9 +50,9 @@ val KB_RU_HYPER_SPACE_MAIN =
                 KeyItemC(
                     center = KeyC("р", size = LARGE),
                     swipeType = FOUR_WAY_CROSS,
-                    right = KeyC("\"", color = MUTED),
-                    top = KeyC("ё"),
-                    left = KeyC("щ"),
+                    bottom = KeyC("\"", color = MUTED),
+                    right = KeyC("ё"),
+                    top = KeyC("щ"),
                 ),
                 KeyItemC(
                     center = KeyC("т", size = LARGE),
@@ -97,9 +97,9 @@ val KB_RU_HYPER_SPACE_MAIN =
                 KeyItemC(
                     center = KeyC("м", size = LARGE),
                     swipeType = FOUR_WAY_CROSS,
-                    left = KeyC("#", color = MUTED),
-                    top = KeyC("/", color = MUTED),
-                    right = KeyC("ь"),
+                    bottom = KeyC("#", color = MUTED),
+                    left = KeyC("/", color = MUTED),
+                    top = KeyC("ь"),
                 ),
             ),
             listOf(

--- a/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
@@ -447,7 +447,6 @@ enum class KeyboardLayout(
     KRTypeSplit(KB_KR_TYPESPLIT), // 한국어 type-split
     KRThumbKey(KB_KR_THUMBKEY), // 한국어 thumb-key
     RUHyper(KB_RU_HYPER), // русский hyper
-    RUHyperSpace(KB_RU_HYPER_SPACE), // русский hyper space
     MYThumbKey(KB_MY_THUMBKEY), // myanmar thumb-key
     JAKanaStandard(KB_JA_KANA_STANDARD), // japanese standard kana keyboard
     KNThumbKey(KB_KN_THUMBKEY), // ಕನ್ನಡ thumb-key
@@ -478,4 +477,5 @@ enum class KeyboardLayout(
     MYWhale(KB_MY_WHALE), // myanmar whale
     ENThumbKeyCompact(KB_EN_THUMBKEY_COMPACT), // english thumb-key compact
     ENThumbKeyWordsShift(KB_EN_THUMBKEY_WORDS_SHIFT), // english thumb-key words shift
+    RUHyperSpace(KB_RU_HYPER_SPACE), // русский hyper space
 }

--- a/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
@@ -188,6 +188,7 @@ import com.dessalines.thumbkey.keyboards.KB_PT_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_PT_TYPESPLIT
 import com.dessalines.thumbkey.keyboards.KB_RU_ARTI
 import com.dessalines.thumbkey.keyboards.KB_RU_HYPER
+import com.dessalines.thumbkey.keyboards.KB_RU_HYPER_SPACE
 import com.dessalines.thumbkey.keyboards.KB_RU_MESSAGEASE
 import com.dessalines.thumbkey.keyboards.KB_RU_MESSAGEASE_SYMBOLS
 import com.dessalines.thumbkey.keyboards.KB_RU_MESSAGEASE_WRITER
@@ -446,6 +447,7 @@ enum class KeyboardLayout(
     KRTypeSplit(KB_KR_TYPESPLIT), // 한국어 type-split
     KRThumbKey(KB_KR_THUMBKEY), // 한국어 thumb-key
     RUHyper(KB_RU_HYPER), // русский hyper
+    RUHyperSpace(KB_RU_HYPER_SPACE), // русский hyper space
     MYThumbKey(KB_MY_THUMBKEY), // myanmar thumb-key
     JAKanaStandard(KB_JA_KANA_STANDARD), // japanese standard kana keyboard
     KNThumbKey(KB_KN_THUMBKEY), // ಕನ್ನಡ thumb-key


### PR DESCRIPTION
Added Russian hyper space keyboard layout in accordance to the contribution guidelines.

Modification of the hyper layout where the lower outer letter keys are swapped with the space keys.