### PR TITLE
Add the english messagease compose combo layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@
   - [Slide gestures](#slide-gestures)
   - [Drag-and-return](#drag-and-return)
   - [Ghost keys](#ghost-keys)
+  - [Accents and special characters](#accents-and-special-characters)
+    - [Dead keys](#dead-keys)
+    - [Compose combo](#compose-combo)
   - [Coming from MessagEase Keyboard Tips](#coming-from-messagease-keyboard-tips)
   - [Modify keys](#modify-keys)
     - [Example 1](#example-1)
@@ -151,6 +154,84 @@ Enabling `Backspace: Allow normal swipes to work with slide gestures`, in keyboa
 ### Ghost keys
 
 Enabling `Ghost keys` in keyboard settings will enable swiping hidden symbol keys without switching to the numeric layout.
+
+### Accents and special characters
+
+Layouts with `compose` in their name can build characters that have no key of their own. Two independent systems do this — dead keys, and a compose key. They are alternatives rather than replacements, and a layout may offer either or both.
+
+#### Dead keys
+
+A dead key modifies the character you have **just typed**. Type the base letter first, then swipe the dead key:
+
+| Type    | Result |
+| ------- | ------ |
+| `n` `~` | ñ      |
+| `s` `^` | ŝ      |
+| `a` `"` | ä      |
+| `s` `!` | ß      |
+
+Following a dead key with a space types the mark itself.
+
+Ten of them are accents: `"` `'` `` ` `` `^` `~` `°` `˘` `ˇ` `-` and, on Japanese layouts, `゛`. The remaining four produce characters that are not accented letters at all, and are easy to miss because their labels do not look like marks:
+
+| Key     | Produces                          | Examples                                               |
+| ------- | --------------------------------- | ------------------------------------------------------ |
+| `¿¡`    | ligatures and Spanish punctuation | `a`→æ, `o`→œ, `s`→ß, `c`→ç, `l`→ł, `!`→¡, `?`→¿, `<`→« |
+| `$`     | currency                          | `e`→€, `l`→£, `c`→¢, `y`→¥, `w`→₩                      |
+| `?` `*` | Vietnamese tone marks             | `a`→ả, `a`→ạ                                           |
+
+The `¿¡` key is labeled with the two characters it makes from `!` and `?`, and is the closest the original system comes to a general-purpose compose key. Its full contents, and those of every other dead key, are in `Utils.kt`.
+
+Dead keys are quick, but they have two costs. They can only ever combine two characters, so they cannot produce symbols that are not an accented letter. And a dead key makes its own symbol awkward to type: swiping `~` produces nothing on its own, and you have to follow it with a space to get a bare `~`.
+
+That trade is worth it for accents, which are rarely wanted as bare marks, and less so for `~`, `^`, `°` and `"`, which are often typed directly.
+
+Each layout strikes its own balance. `english messagease compose` offers the full set of dead keys. `english messagease compose combo` instead keeps eight dead keys for marks alone — grave, acute, circumflex, diaeresis, tilde, caron, breve and cedilla — grouped along the top edge of `A`, `N` and `I`, and drawn as `` ` `` `´` `ˆ` `¨` `˜` `ˇ` `˘` `¸` so they are visibly not the plain `~` and `^` that sit together on `T`. Everything else there goes through the compose key.
+
+#### Compose combo
+
+The compose key (`♫`) works like the compose key on a desktop Linux system. Press it **first**, then type a short sequence, which is replaced by a single character:
+
+| Type        | Result |
+| ----------- | ------ |
+| `♫` `o` `c` | ©      |
+| `♫` `s` `s` | ß      |
+| `♫` `-` `>` | →      |
+| `♫` `1` `2` | ½      |
+| `♫` `y` `=` | ¥      |
+| `♫` `°` `a` | å      |
+
+`♫` `.` `i` gives the Turkish dotless ı rather than a doubly dotted i, following X11; `♫` `.` `I` gives İ.
+
+Sequences follow the [X11 compose table](https://gitlab.freedesktop.org/xorg/lib/libx11/-/blob/master/nls/en_US.UTF-8/Compose.pre), so habits carry over from desktop Linux. Many characters have more than one spelling, and both orders usually work: © is `o` `c` or `c` `o`. The full list lives in `ComposeComboTable.kt`.
+
+Dashes are the one place Thumb-Key parts company with X11. The em dash is `♫` `-` `-` rather than the three-tap `---`, since it is the one people reach for most:
+
+| Type                       | Result |
+| -------------------------- | ------ |
+| `♫` `-` `-`                | —      |
+| `♫` `-` `m` or `♫` `m` `-` | —      |
+| `♫` `-` `n` or `♫` `n` `-` | –      |
+
+The `m` and `n` spellings are named after the printer's em and en, and give the en dash a spelling that does not depend on counting hyphens. The X11 `---` and `--.` do not work here: once `-` `-` resolves, nothing longer starting with it can be reached.
+
+Mathematical and technical characters are covered too:
+
+| Type        | Result | Type        | Result |
+| ----------- | ------ | ----------- | ------ |
+| `♫` `=` `=` | ≡      | `♫` `~` `~` | ≈      |
+| `♫` `!` `=` | ≠      | `♫` `<` `=` | ≤      |
+| `♫` `+` `-` | ±      | `♫` `>` `=` | ≥      |
+| `♫` `x` `x` | ×      | `♫` `-` `:` | ÷      |
+| `♫` `8` `8` | ∞      | `♫` `{` `}` | ∅      |
+| `♫` `/` `v` | √      | `♫` `m` `u` | µ      |
+| `♫` `.` `.` | …      | `♫` `.` `-` | ·      |
+
+The X11 spellings work too where they differ — `=` `_` for ≡, and `/` `=` or `=` `/` for ≠.
+
+Superscript and subscript digits use `^` and `_`, one sequence per digit, so ¹² is `♫` `^` `1` then `♫` `^` `2`.
+
+If your field needs characters that are not here, adding them is a few lines of data — see [Adding compose sequences](CONTRIBUTING.md#adding-compose-sequences) in the contributing guide.
 
 ### Coming from MessagEase Keyboard Tips
 

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseComposeCombo.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ENMessagEaseComposeCombo.kt
@@ -1,0 +1,470 @@
+@file:Suppress("ktlint:standard:no-wildcard-imports")
+
+package com.dessalines.thumbkey.keyboards
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.*
+import com.dessalines.thumbkey.textprocessors.ComposeComboProcessor
+import com.dessalines.thumbkey.utils.*
+import com.dessalines.thumbkey.utils.ColorVariant.*
+import com.dessalines.thumbkey.utils.FontSizeVariant.*
+import com.dessalines.thumbkey.utils.KeyAction.*
+import com.dessalines.thumbkey.utils.SwipeNWay.*
+
+// "english messagease compose", reworked around the compose key.
+//
+// The dead keys for ~ ^ ° " $ and ¿¡ are gone. Those characters are now plain keys that type
+// themselves, because a dead key makes its own symbol awkward to reach: it only emits the bare
+// character when followed by a space, which is a poor trade for a symbol people type directly.
+//
+// Eight diacritics remain as dead keys, since they are worth the keystroke saved. They are
+// grouped along the top edge of A, N and I so they read as one block rather than as stray keys,
+// with each row reading left to right as corner, top, corner. The cedilla is the exception and
+// sits below A, since a cedilla hangs under its letter. Together they cover German, French,
+// Spanish, Romanian and the caron languages.
+//
+// They are drawn with the spacing-modifier glyphs rather than plain ASCII, so the tilde and
+// circumflex dead keys are visibly not the ordinary ~ and ^ that sit together on T.
+//
+// They use NormalizeLastKey, which appends a combining mark and normalizes, so they work on any
+// letter with a precomposed form rather than only the ones in a hand-written table.
+//
+// E carries the three quote characters " ´ and `, the last of which markdown needs and which
+// the shared numeric layer otherwise hides in digit mode.
+//
+// Everything else goes through the compose key (♫) on the top-left of A: ♫ o c for ©,
+// ♫ ~ ~ for ≈, ♫ = = for ≡.
+
+private val COMPOSE_KEY =
+    KeyC(
+        display = KeyDisplay.TextDisplay("♫"),
+        action = StartComposeCombo,
+        color = MUTED,
+    )
+
+private val GRAVE_KEY =
+    KeyC(
+        display = KeyDisplay.TextDisplay("`"),
+        action = NormalizeLastKey("\u0300"),
+        color = MUTED,
+    )
+
+private val ACUTE_KEY =
+    KeyC(
+        display = KeyDisplay.TextDisplay("´"),
+        action = NormalizeLastKey("\u0301"),
+        color = MUTED,
+    )
+
+private val DIAERESIS_KEY =
+    KeyC(
+        display = KeyDisplay.TextDisplay("¨"),
+        action = NormalizeLastKey("\u0308"),
+        color = MUTED,
+    )
+
+private val CEDILLA_KEY =
+    KeyC(
+        display = KeyDisplay.TextDisplay("¸"),
+        action = NormalizeLastKey("\u0327"),
+        color = MUTED,
+    )
+
+private val TILDE_KEY =
+    KeyC(
+        display = KeyDisplay.TextDisplay("˜"),
+        action = NormalizeLastKey("\u0303"),
+        color = MUTED,
+    )
+
+private val CARON_KEY =
+    KeyC(
+        display = KeyDisplay.TextDisplay("ˇ"),
+        action = NormalizeLastKey("\u030c"),
+        color = MUTED,
+    )
+
+private val CIRCUMFLEX_KEY =
+    KeyC(
+        display = KeyDisplay.TextDisplay("ˆ"),
+        action = NormalizeLastKey("\u0302"),
+        color = MUTED,
+    )
+
+private val BREVE_KEY =
+    KeyC(
+        display = KeyDisplay.TextDisplay("˘"),
+        action = NormalizeLastKey("\u0306"),
+        color = MUTED,
+    )
+
+val KB_EN_MESSAGEASE_COMPOSE_COMBO_MAIN =
+    KeyboardC(
+        listOf(
+            listOf(
+                KeyItemC(
+                    center = KeyC("a", size = LARGE),
+                    topLeft = COMPOSE_KEY,
+                    top = DIAERESIS_KEY,
+                    topRight = TILDE_KEY,
+                    bottom = CEDILLA_KEY,
+                    bottomRight = KeyC("v"),
+                    right = KeyC("-", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("n", size = LARGE),
+                    bottom = KeyC("l"),
+                    topLeft = GRAVE_KEY,
+                    top = CIRCUMFLEX_KEY,
+                    topRight = ACUTE_KEY,
+                    right = KeyC("!", color = MUTED),
+                    bottomRight = KeyC("\\", color = MUTED),
+                    bottomLeft = KeyC("/", color = MUTED),
+                    left = KeyC("+", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("i", size = LARGE),
+                    topLeft = BREVE_KEY,
+                    top = CARON_KEY,
+                    bottomLeft = KeyC("x"),
+                    left = KeyC("?", color = MUTED),
+                    topRight = KeyC("$", color = MUTED),
+                    bottomRight = KeyC("€", color = MUTED),
+                    bottom = KeyC("=", color = MUTED),
+                ),
+                EMOJI_KEY_ITEM,
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("h", size = LARGE),
+                    right = KeyC("k"),
+                    topLeft = KeyC("{", color = MUTED),
+                    topRight = KeyC("%", color = MUTED),
+                    bottomRight = KeyC("_", color = MUTED),
+                    bottomLeft = KeyC("[", color = MUTED),
+                    left = KeyC("(", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("o", size = LARGE),
+                    topLeft = KeyC("q"),
+                    top = KeyC("u"),
+                    topRight = KeyC("p"),
+                    right = KeyC("b"),
+                    bottomRight = KeyC("j"),
+                    bottom = KeyC("d"),
+                    bottomLeft = KeyC("g"),
+                    left = KeyC("c"),
+                ),
+                KeyItemC(
+                    center = KeyC("r", size = LARGE),
+                    left = KeyC("m"),
+                    top =
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
+                            action = ToggleShiftMode(true),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(true),
+                            color = MUTED,
+                        ),
+                    topLeft = KeyC("|", color = MUTED),
+                    topRight = KeyC("}", color = MUTED),
+                    right = KeyC(")", color = MUTED),
+                    bottom =
+                        KeyC(
+                            ToggleShiftMode(false),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(false),
+                        ),
+                    bottomRight = KeyC("]", color = MUTED),
+                    bottomLeft = KeyC("@", color = MUTED),
+                ),
+                NUMERIC_KEY_ITEM,
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("t", size = LARGE),
+                    topRight = KeyC("y"),
+                    topLeft = KeyC("~", color = MUTED),
+                    top = KeyC("^", color = MUTED),
+                    bottomLeft = KeyC("¡", color = MUTED),
+                    bottom = KeyC("¿", color = MUTED),
+                    right = KeyC("*", color = MUTED),
+                    bottomRight = KeyC("\t", displayText = "⇥", color = MUTED),
+                    left = KeyC("<", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("e", size = LARGE),
+                    left = KeyC("`", color = MUTED),
+                    topLeft = KeyC("\"", color = MUTED),
+                    top = KeyC("w"),
+                    topRight = KeyC("'", color = MUTED),
+                    right = KeyC("z"),
+                    bottomRight = KeyC(":", color = MUTED),
+                    bottom = KeyC(".", color = MUTED),
+                    bottomLeft = KeyC(",", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("s", size = LARGE),
+                    topLeft = KeyC("f"),
+                    bottomRight = KeyC("ß"),
+                    top = KeyC("&", color = MUTED),
+                    topRight = KeyC("°", color = MUTED),
+                    right = KeyC(">", color = MUTED),
+                    bottomLeft = KeyC(";", color = MUTED),
+                    left = KeyC("#", color = MUTED),
+                ),
+                BACKSPACE_KEY_ITEM,
+            ),
+            listOf(
+                SPACEBAR_KEY_ITEM,
+                RETURN_KEY_ITEM,
+            ),
+        ),
+    )
+
+val KB_EN_MESSAGEASE_COMPOSE_COMBO_SHIFTED =
+    KeyboardC(
+        listOf(
+            listOf(
+                KeyItemC(
+                    center = KeyC("A", size = LARGE),
+                    topLeft = COMPOSE_KEY,
+                    top = DIAERESIS_KEY,
+                    topRight = TILDE_KEY,
+                    bottom = CEDILLA_KEY,
+                    bottomRight = KeyC("V"),
+                    right = KeyC("-", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("N", size = LARGE),
+                    bottom = KeyC("L"),
+                    topLeft = GRAVE_KEY,
+                    top = CIRCUMFLEX_KEY,
+                    topRight = ACUTE_KEY,
+                    right = KeyC("!", color = MUTED),
+                    bottomRight = KeyC("\\", color = MUTED),
+                    bottomLeft = KeyC("/", color = MUTED),
+                    left = KeyC("+", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("I", size = LARGE),
+                    topLeft = BREVE_KEY,
+                    top = CARON_KEY,
+                    bottomLeft = KeyC("X"),
+                    left = KeyC("?", color = MUTED),
+                    topRight = KeyC("$", color = MUTED),
+                    bottomRight = KeyC("€", color = MUTED),
+                    bottom = KeyC("=", color = MUTED),
+                ),
+                EMOJI_KEY_ITEM,
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("H", size = LARGE),
+                    right = KeyC("K"),
+                    topLeft = KeyC("{", color = MUTED),
+                    topRight = KeyC("%", color = MUTED),
+                    bottomRight = KeyC("_", color = MUTED),
+                    bottomLeft = KeyC("[", color = MUTED),
+                    left = KeyC("(", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("O", size = LARGE),
+                    topLeft = KeyC("Q"),
+                    top = KeyC("U"),
+                    topRight = KeyC("P"),
+                    right = KeyC("B"),
+                    bottomRight = KeyC("J"),
+                    bottom = KeyC("D"),
+                    bottomLeft = KeyC("G"),
+                    left = KeyC("C"),
+                ),
+                KeyItemC(
+                    center = KeyC("R", size = LARGE),
+                    left = KeyC("M"),
+                    bottom =
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
+                            action = ToggleShiftMode(false),
+                            swipeReturnAction = ToggleCurrentWordCapitalization(false),
+                            color = MUTED,
+                        ),
+                    top =
+                        KeyC(
+                            display = KeyDisplay.IconDisplay(Icons.Outlined.KeyboardCapslock),
+                            capsModeDisplay = KeyDisplay.IconDisplay(Icons.Outlined.Copyright),
+                            action = ToggleCapsLock,
+                            swipeReturnAction = ToggleCurrentWordCapitalization(true),
+                            color = MUTED,
+                        ),
+                    topLeft = KeyC("|", color = MUTED),
+                    topRight = KeyC("}", color = MUTED),
+                    right = KeyC(")", color = MUTED),
+                    bottomRight = KeyC("]", color = MUTED),
+                    bottomLeft = KeyC("@", color = MUTED),
+                ),
+                NUMERIC_KEY_ITEM,
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("T", size = LARGE),
+                    topRight = KeyC("Y"),
+                    topLeft = KeyC("~", color = MUTED),
+                    top = KeyC("^", color = MUTED),
+                    bottomLeft = KeyC("¡", color = MUTED),
+                    bottom = KeyC("¿", color = MUTED),
+                    right = KeyC("*", color = MUTED),
+                    left = KeyC("<", color = MUTED),
+                    bottomRight = KeyC("\t", displayText = "⇥", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("E", size = LARGE),
+                    left = KeyC("`", color = MUTED),
+                    topLeft = KeyC("\"", color = MUTED),
+                    top = KeyC("W"),
+                    topRight = KeyC("'", color = MUTED),
+                    right = KeyC("Z"),
+                    bottomRight = KeyC(":", color = MUTED),
+                    bottom = KeyC(".", color = MUTED),
+                    bottomLeft = KeyC(",", color = MUTED),
+                ),
+                KeyItemC(
+                    center = KeyC("S", size = LARGE),
+                    topLeft = KeyC("F"),
+                    bottomRight = KeyC("ẞ"),
+                    top = KeyC("&", color = MUTED),
+                    topRight = KeyC("°", color = MUTED),
+                    right = KeyC(">", color = MUTED),
+                    bottomLeft = KeyC(";", color = MUTED),
+                    left = KeyC("#", color = MUTED),
+                ),
+                BACKSPACE_KEY_ITEM,
+            ),
+            listOf(
+                SPACEBAR_KEY_ITEM,
+                RETURN_KEY_ITEM,
+            ),
+        ),
+    )
+
+// The shared messagease numeric layer has no compose key, which would put the superscripts and
+// subscripts out of reach: they need a digit, and digits only exist here. It is used by 34 other
+// layouts, so this is a copy rather than an edit.
+//
+// Apart from that key it stays close to the shared layer. There are no dead keys here, so the
+// plain ` ^ ´ keep their usual place on 2, which is also where the letter modes put the matching
+// dead keys. The comparison operators join the = on 3.
+val KB_EN_MESSAGEASE_COMPOSE_COMBO_NUMERIC =
+    KeyboardC(
+        listOf(
+            listOf(
+                KeyItemC(
+                    center = KeyC("1", size = LARGE),
+                    topLeft = COMPOSE_KEY,
+                    bottomLeft = KeyC("$"),
+                    right = KeyC("-"),
+                    bottomRight =
+                        getLocalCurrency()?.let {
+                            if (it !in setOf("$", "£", "€")) {
+                                KeyC(it)
+                            } else {
+                                null
+                            }
+                        },
+                ),
+                KeyItemC(
+                    center = KeyC("2", size = LARGE),
+                    topLeft = KeyC("`"),
+                    topRight = KeyC("´"),
+                    right = KeyC("!"),
+                    bottomRight = KeyC("\\"),
+                    bottomLeft = KeyC("/"),
+                    left = KeyC("+"),
+                ),
+                KeyItemC(
+                    center = KeyC("3", size = LARGE),
+                    topLeft = KeyC("≤"),
+                    top = KeyC("≠"),
+                    topRight = KeyC("≥"),
+                    right = KeyC("≈"),
+                    left = KeyC("?"),
+                    bottomRight = KeyC("€"),
+                    bottomLeft = KeyC("£"),
+                    bottom = KeyC("="),
+                ),
+                EMOJI_KEY_ITEM,
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("4", size = LARGE),
+                    topLeft = KeyC("{"),
+                    topRight = KeyC("%"),
+                    bottomRight = KeyC("_"),
+                    bottomLeft = KeyC("["),
+                    left = KeyC("("),
+                ),
+                KeyItemC(
+                    center = KeyC("5", size = LARGE),
+                    top = KeyC("¬"),
+                ),
+                KeyItemC(
+                    center = KeyC("6", size = LARGE),
+                    topLeft = KeyC("|"),
+                    topRight = KeyC("}"),
+                    right = KeyC(")"),
+                    bottomRight = KeyC("]"),
+                    bottomLeft = KeyC("@"),
+                ),
+                ABC_KEY_ITEM,
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("7", size = LARGE),
+                    topLeft = KeyC("~"),
+                    top = KeyC("^"),
+                    left = KeyC("<"),
+                    right = KeyC("*"),
+                    bottomRight = KeyC("\t", displayText = "⇥"),
+                ),
+                KeyItemC(
+                    center = KeyC("8", size = LARGE),
+                    topLeft = KeyC("\""),
+                    topRight = KeyC("'"),
+                    bottomRight = KeyC(":"),
+                    bottom = KeyC("."),
+                    bottomLeft = KeyC(","),
+                ),
+                KeyItemC(
+                    center = KeyC("9", size = LARGE),
+                    top = KeyC("&"),
+                    topRight = KeyC("°"),
+                    right = KeyC(">"),
+                    bottomLeft = KeyC(";"),
+                    left = KeyC("#"),
+                ),
+                BACKSPACE_KEY_ITEM,
+            ),
+            listOf(
+                KeyItemC(
+                    center = KeyC("0", size = LARGE),
+                    widthMultiplier = 2,
+                ),
+                SPACEBAR_SKINNY_KEY_ITEM,
+                RETURN_KEY_ITEM,
+            ),
+        ),
+    )
+
+val KB_EN_MESSAGEASE_COMPOSE_COMBO: KeyboardDefinition =
+    KeyboardDefinition(
+        title = "english messagease compose combo",
+        modes =
+            KeyboardDefinitionModes(
+                main = KB_EN_MESSAGEASE_COMPOSE_COMBO_MAIN,
+                shifted = KB_EN_MESSAGEASE_COMPOSE_COMBO_SHIFTED,
+                numeric = KB_EN_MESSAGEASE_COMPOSE_COMBO_NUMERIC,
+            ),
+        settings =
+            KeyboardDefinitionSettings(
+                autoCapitalizers = arrayOf(::autoCapitalizeI, ::autoCapitalizeIApostrophe),
+                textProcessor = ComposeComboProcessor(),
+            ),
+    )

--- a/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
@@ -54,6 +54,7 @@ import com.dessalines.thumbkey.keyboards.KB_EN_LA_THUMBKEY
 import com.dessalines.thumbkey.keyboards.KB_EN_MARLIN
 import com.dessalines.thumbkey.keyboards.KB_EN_MESSAGEASE
 import com.dessalines.thumbkey.keyboards.KB_EN_MESSAGEASE_COMPOSE
+import com.dessalines.thumbkey.keyboards.KB_EN_MESSAGEASE_COMPOSE_COMBO
 import com.dessalines.thumbkey.keyboards.KB_EN_MESSAGEASE_COMPOSE_LEFT_FLIPPED_NUMPAD
 import com.dessalines.thumbkey.keyboards.KB_EN_MESSAGEASE_LEFT
 import com.dessalines.thumbkey.keyboards.KB_EN_MESSAGEASE_LEFT_SYMBOLS
@@ -488,4 +489,5 @@ enum class KeyboardLayout(
     ENThumbKeyShift(KB_EN_THUMBKEY_SHIFT), // english thumb-key shift
     TOKThumbKeyLettersShift(KB_TOK_THUMBKEY_LETTERS_SHIFT), // toki pona thumb-key letters shift
     CZTypeSplit(KB_CZ_TYPESPLIT_FULL), // čeština type-split
+    ENMessagEaseComposeCombo(KB_EN_MESSAGEASE_COMPOSE_COMBO), // english messagease compose combo
 }


### PR DESCRIPTION
Adds `english messagease compose combo`, the opt-in layout that uses the compose key merged in #1998. This is the second half of #1800; the mechanism landed, this is the layout that exercises it.

Nothing existing changes. The layout is a new file plus one enum entry appended at the end of `KeyboardLayout`, so no other layout's ordinal moves.

### What it looks like

The compose key (`♫`) sits on the top-left of `A`. Press it first, then type a short sequence: `♫` `o` `c` for ©, `♫` `~` `~` for ≈, `♫` `=` `=` for ≡, `♫` `1` `2` for ½.

Since the compose key reaches everything a dead key can, the layout drops the dead keys for `~ ^ ° " $` and `¿¡` and lets those characters type themselves. A dead key only emits its own symbol when followed by a space, which is a poor trade for characters people type directly.

Eight dead keys stay, for marks that are never wanted bare — grave, acute, circumflex, diaeresis, tilde, caron, breve and cedilla. They are grouped along the top edge of `A`, `N` and `I`, and drawn with the spacing-modifier glyphs `` ` `` `´` `ˆ` `¨` `˜` `ˇ` `˘` `¸` so they read as marks and are visibly not the plain `~` and `^` that sit together on `T`. They use `NormalizeLastKey`, so they work on any letter with a precomposed form rather than only the ones in a hand-written table.

`E` carries the three quote characters `"` `´` and `` ` ``, the last of which markdown needs and which the shared numeric layer otherwise hides in digit mode.

### README

Adds an "Accents and special characters" section covering both systems and the difference between them — dead keys modify the character just typed, the compose key opens a sequence. It documents the four dead keys whose labels do not look like marks (`¿¡`, `$`, `?`, `*`) and is explicit that the two systems are alternatives rather than one replacing the other, since `english messagease compose` keeps the full dead-key set and this layout does not.

It also notes where the table departs from X11, so nobody has to discover the dash spellings by trial: `♫` `-` `-` is the em dash rather than the three-tap `---`, with `-m`/`-n` as spellings that do not depend on counting hyphens.

### Note on the earlier branch

The `compose-combo` branch linked from #1800 still carries the pre-merge state (mechanism + layout on an older main). This PR is that branch's layout commit rebased onto current main, on `compose-combo-layout`.

Formatted with `formatKotlin`, passes `lintKotlin`, `lint`, `assembleDebug` and the prettier markdown check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014JQCNJEG5fAdWfq4UQzRWb
